### PR TITLE
Better logging around creating correspondence

### DIFF
--- a/psd-web/app/controllers/investigations/correspondence_controller.rb
+++ b/psd-web/app/controllers/investigations/correspondence_controller.rb
@@ -23,6 +23,7 @@ class Investigations::CorrespondenceController < ApplicationController
       audit_class.from(@correspondence, @investigation)
       redirect_to investigation_path @investigation, flash: { success: 'Correspondence was successfully recorded' }
     else
+      Rails.logger.error "Cannot create correspondence because investigation has errors: #{@investigation.errors.full_messages}" unless @investigation.valid?
       redirect_to investigation_path(@investigation), flash: { warning: "Correspondence could not be saved." }
     end
   end

--- a/psd-web/app/controllers/investigations/emails_controller.rb
+++ b/psd-web/app/controllers/investigations/emails_controller.rb
@@ -61,6 +61,7 @@ private
     @correspondence.validate_email_file_and_content(@email_file_blob) if step == :content
     validate_blob_size(@email_file_blob, @correspondence.errors, "email file")
     validate_blob_size(@email_attachment_blob, @correspondence.errors, "email attachment")
+    Rails.logger.error "#{__method__}: correspondence has errors: #{@correspondence.errors.full_messages}" if @correspondence.errors.any?
     @correspondence.errors.empty?
   end
 


### PR DESCRIPTION
Copied from https://github.com/UKGovernmentBEIS/beis-opss/pull/1319.

Ticket: https://trello.com/c/XQGnlDyl

## Description
This problem was caused by the `date_received` being blank in old Enquiries (it's now mandatory). But it was difficult to diagnose. Better log messages have been put in so that this kind of problem will be easier to diagnose in the future.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
