### PR TITLE
WIP: Fix ElasticSearch indices not being created in tests

### DIFF
--- a/psd-web/app/models/concerns/indexable.rb
+++ b/psd-web/app/models/concerns/indexable.rb
@@ -2,6 +2,6 @@ module Indexable
   extend ActiveSupport::Concern
 
   included do
-    [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, self.class.to_s.gsub('::', '').downcase].join("_")
+    index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, self.to_s.gsub('::', '').downcase].join("_")
   end
 end

--- a/psd-web/app/models/concerns/indexable.rb
+++ b/psd-web/app/models/concerns/indexable.rb
@@ -2,6 +2,30 @@ module Indexable
   extend ActiveSupport::Concern
 
   included do
-    index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, self.to_s.gsub('::', '').downcase].join("_")
+
+
+
+    # index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, (model.superclass.respond_to?(:__elasticsearch__) ? self.superclass : self).to_s.gsub('::', '').downcase].join("_")
+
+    class_eval do
+      after_commit -> { insert_search_index }, on: :create
+      after_commit -> { update_search_index }, on: :update
+      after_commit -> { delete_search_index }, on: :destroy
+    end
+  end
+
+  def insert_search_index
+    __elasticsearch__.index_document
+    self.class.__elasticsearch__.refresh_index! if Rails.env.test?
+  end
+
+  def update_search_index
+    __elasticsearch__.update_document
+    self.class.__elasticsearch__.refresh_index! if Rails.env.test?
+  end
+
+  def delete_search_index
+    __elasticsearch__.delete_document
+    self.class.__elasticsearch__.refresh_index! if Rails.env.test?
   end
 end

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -24,22 +24,6 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  # Import all relevant models into Elasticsearch
-  def self.import_into_elasticsearch
-    unless @models_imported
-      ActiveRecord::Base.descendants.each do |model|
-        if model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
-          model.import force: true, refresh: true
-        end
-      end
-      @models_imported = true
-    end
-  end
-
-  def setup
-    self.class.import_into_elasticsearch
-  end
-
   # On top of mocking out external services, this method also sets the user to an initial,
   # sensible value, but it should only be run once per test.
   # To change currently logged in user afterwards call `sign_in_as(...)`
@@ -139,7 +123,8 @@ class ActiveSupport::TestCase
   end
 
   def load_case(key)
-    Investigation.import force: true, refresh: true
+    Investigation.__elasticsearch__.refresh_index!
+
     investigation = investigations(key)
     investigation.assignee = User.current
     investigation.save

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -24,6 +24,12 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
+  ActiveRecord::Base.descendants.each do |model|
+    if model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
+      model.__elasticsearch__.refresh_index!
+    end
+  end
+
   # On top of mocking out external services, this method also sets the user to an initial,
   # sensible value, but it should only be run once per test.
   # To change currently logged in user afterwards call `sign_in_as(...)`


### PR DESCRIPTION
This fixes ElasticSearch indices not being created before tests run, at the expense of longer startup time for the test suite.

Here's an example of failing tests: https://travis-ci.org/UKGovernmentBEIS/beis-opss-psd/jobs/598170140