### PR TITLE
Use log level info so we don't log sql queries

### DIFF
--- a/psd-web/config/environments/production.rb
+++ b/psd-web/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Currently we are extending logit quota, and we don't really need to log sql queries.