### PR TITLE
Remove hack hijacking investigation subclasses model name

### DIFF
--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -42,7 +42,7 @@ class InvestigationsController < ApplicationController
 
   # GET /cases/new
   def new
-    return redirect_to new_ts_investigation_path unless User.current.is_opss?
+    return redirect_to new_investigation_ts_investigation_path unless User.current.is_opss?
 
     case params[:type]
     when "allegation"
@@ -84,7 +84,7 @@ private
     respond_to do |format|
       if @investigation.update(update_params)
         format.html {
-          redirect_to @investigation, flash: {
+          redirect_to investigation_path(@investigation), flash: {
             success: "#{@investigation.case_type.titleize} was successfully updated."
           }
         }

--- a/psd-web/app/models/investigation/allegation.rb
+++ b/psd-web/app/models/investigation/allegation.rb
@@ -5,12 +5,6 @@ class Investigation::Allegation < Investigation
 
   index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "investigations"].join("_")
 
-  # Elasticsearch index name must be declared in children and parent
-
-  def self.model_name
-    self.superclass.model_name
-  end
-
   def title
     case_title
   end

--- a/psd-web/app/models/investigation/enquiry.rb
+++ b/psd-web/app/models/investigation/enquiry.rb
@@ -8,10 +8,6 @@ class Investigation::Enquiry < Investigation
 
   date_attribute :date_received, required: false
 
-  def self.model_name
-    self.superclass.model_name
-  end
-
   def title
     user_title
   end

--- a/psd-web/app/models/investigation/project.rb
+++ b/psd-web/app/models/investigation/project.rb
@@ -3,10 +3,6 @@ class Investigation::Project < Investigation
 
   index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "investigations"].join("_")
 
-  def self.model_name
-    self.superclass.model_name
-  end
-
   def title
     user_title
   end

--- a/psd-web/app/views/homepage/non_opss.html.slim
+++ b/psd-web/app/views/homepage/non_opss.html.slim
@@ -11,7 +11,7 @@
       |  Product safety database
     p.govuk-body-l
       |  Report, track and share product safety information.
-    = link_to new_ts_investigation_path,
+    = link_to new_investigation_ts_investigation_path,
             class: "govuk-button govuk-button--start", role: "button", draggable: "false"
       | Open a new case
 

--- a/psd-web/app/views/investigations/index.html.slim
+++ b/psd-web/app/views/investigations/index.html.slim
@@ -10,7 +10,7 @@
       - else
         | Cases
   .govuk-grid-column-one-third[style="text-align:right"]
-    = link_to "Create new", User.current.is_opss? ? new_investigation_path : new_ts_investigation_path,
+    = link_to "Create new", User.current.is_opss? ? new_investigation_path : new_investigation_ts_investigation_path,
             class: "govuk-button govuk-!-margin-bottom-3", role: "button"
 
 .govuk-grid-row

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -26,10 +26,13 @@ Rails.application.routes.draw do
     get :skip
   end
 
-  resources :enquiry, controller: "investigations/enquiry", only: %i[show new create update]
-  resources :allegation, controller: "investigations/allegation", only: %i[show new create update]
-  resources :project, controller: "investigations/project", only: %i[new create]
-  resources :ts_investigation, controller: "investigations/ts_investigations", only: %i[show new create update]
+  namespace :investigation, path: "" do
+    resources :enquiry,          controller: "investigations/enquiries", only: %i[show new create update], concerns: %i[document_attachable]
+    resources :allegation,       controller: "investigations/allegations", only: %i[show new create update], concerns: %i[document_attachable]
+    resources :project,          controller: "investigations/projects", only: %i[new show create], concerns: %i[document_attachable]
+    resources :ts_investigation, controller: "investigations/ts_investigations", only: %i[show new create update], concerns: %i[document_attachable]
+  end
+
 
   resources :investigations, path: "cases", only: %i[index show new], param: :pretty_id,
             concerns: %i[document_attachable] do

--- a/psd-web/test/controllers/investigations_controller_test.rb
+++ b/psd-web/test/controllers/investigations_controller_test.rb
@@ -67,7 +67,7 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
           }
       }
     end
-    assert_redirected_to investigation_url(investigation)
+    assert_redirected_to investigation_path(investigation)
   end
 
   test "should set description" do
@@ -82,7 +82,7 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to investigation_url(investigation)
+    assert_redirected_to investigation_path(investigation)
   end
 
   test "should require description to not be empty" do

--- a/psd-web/test/system/create_ts_investigation_test.rb
+++ b/psd-web/test/system/create_ts_investigation_test.rb
@@ -17,7 +17,7 @@ class CreateTsInvestigationTest < ApplicationSystemTestCase
     @corrective_action_two = corrective_actions :two
     @test = tests :two
 
-    visit new_ts_investigation_path
+    visit new_investigation_ts_investigation_path
   end
 
   teardown do


### PR DESCRIPTION
now elasitcseaerch indices are manually provided which remove the need for this
hack.
This is inconveniant because this modifies routes/form generation.
I need this to be merge for the reformat overview page and make each tabs a
seperate action.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
