### PR TITLE
Resend account invite govuk visually hidden

### DIFF
--- a/psd-web/app/views/teams/show.html.slim
+++ b/psd-web/app/views/teams/show.html.slim
@@ -14,7 +14,8 @@
             - html = capture do
               | Resend invitation
               span.govuk-visually-hidden
-                |  Resend invitation to #{user.email}
+                '
+                | to #{user.email}
             = link_to html, resend_invitation_team_path(email_address: user.email),
             method: :put, class: "text-align: right"
           h3.teams--user-contact

--- a/psd-web/app/views/teams/show.html.slim
+++ b/psd-web/app/views/teams/show.html.slim
@@ -11,8 +11,12 @@
         - user_signed_up = user.name.present?
         li.teams--user class="govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0"
           - if !user_signed_up && current_user_is_team_admin
-            = link_to "Resend invitation", resend_invitation_team_path(email_address: user.email),
-            method: :put, class: "text-align: right", aria: { label: "Resend invitation to #{user.email}" }
+            - html = capture do
+              | Resend invitation
+              span.govuk-visually-hidden
+                |  Resend invitation to #{user.email}
+            = link_to html, resend_invitation_team_path(email_address: user.email),
+            method: :put, class: "text-align: right"
           h3.teams--user-contact
             - if user_signed_up
               span.govuk-heading-s.teams--user-name = user.name

--- a/psd-web/manifest.prod.yml
+++ b/psd-web/manifest.prod.yml
@@ -15,6 +15,7 @@ web_defaults: &web_defaults
     - psd-auth-env
     - psd-database
     - psd-elasticsearch
+    - psd-email-whitelist-env
     - psd-health-env
     - psd-keycloak-env
     - psd-notify-env

--- a/psd-web/manifest.prod.yml
+++ b/psd-web/manifest.prod.yml
@@ -15,7 +15,6 @@ web_defaults: &web_defaults
     - psd-auth-env
     - psd-database
     - psd-elasticsearch
-    - psd-email-whitelist-env
     - psd-health-env
     - psd-keycloak-env
     - psd-notify-env


### PR DESCRIPTION
For accessibility, I was previously applying aria-label to the link_to

Now it has a span in the link_to text, so that screen readers read out "Resend invitation to #{user.email}"

Before it could miss the aria-label, as well as reading out "Resend invitation, Resend invitation to #{user.email}"