### PR TITLE
Fix dodgy test

### DIFF
--- a/psd-web/test/controllers/teams_controller_test.rb
+++ b/psd-web/test/controllers/teams_controller_test.rb
@@ -76,10 +76,11 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
   test "Inviting new user creates the account and adds them to the team" do
     kc = KeycloakClient.instance
 
+    expect(kc).to receive(:send_required_actions_welcome_email)
+
     assert_difference "@my_team.users.count" => 1, "User.all(include_incomplete: true).size" => 1 do
       put invite_to_team_url(@my_team), params: { new_user: { email_address: "new_user@northamptonshire.gov.uk" } }
       assert_response :see_other
-      expect(kc).to have_received(:send_required_actions_welcome_email)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes a dodgy test which either provides a potential false positive, or fails depending on the test run order because the expectation match count is carried over from previous tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
