### PR TITLE
Dropdown autocomplete bug

### DIFF
--- a/psd-web/app/assets/application/javascripts/autocomplete.js
+++ b/psd-web/app/assets/application/javascripts/autocomplete.js
@@ -41,7 +41,6 @@ function simpleAccessibleAutocomplete(id, autocompleteOptions) {
     if (removeButton) {
       const removeValue = () => {
         $enhancedElement.val('');
-        $enhancedElement.click().focus().blur();
         $(element).parent().find('select').val('');
       };
       removeButton.addEventListener('keypress', (e) => {

--- a/psd-web/app/views/investigations/assign.html.slim
+++ b/psd-web/app/views/investigations/assign.html.slim
@@ -24,5 +24,6 @@
         br
         | Contact
         strong = " #{@investigation.assignee.display_name} "
+        '
         | to change assignment.
       = link_to "Return to case", @investigation, class: "govuk-button"

--- a/psd-web/app/views/investigations/assign/choose.html.slim
+++ b/psd-web/app/views/investigations/assign/choose.html.slim
@@ -24,5 +24,6 @@
         br
         ' Contact
         strong = @investigation.assignee.display_name
+        '
         | to change assignment.
       = link_to "Return to case", @investigation, class: "govuk-button"


### PR DESCRIPTION
https://trello.com/c/Dw7hYef1/151-dropdown-fields-clear-x-is-not-working-as-expected

Remove .focus().blur() as it sets dropdown input to first entry 

There are still some weird quirks going on with it, but this is a small fix to actually help clear the autocomplete.

We need to update the autocomplete, and in future dig deeper into why setting the value to '', opens the autocomplete.

ALSO ++

https://trello.com/c/gCjcxrW9/145-missing-space-on-error-message

Adding missing space