### PR TITLE
Allow Sidekiq queue name to be specified - especially to segregate review apps

### DIFF
--- a/psd-web/app/jobs/application_job.rb
+++ b/psd-web/app/jobs/application_job.rb
@@ -1,3 +1,3 @@
 class ApplicationJob < ActiveJob::Base
-  queue_as :psd
+  queue_as ENV["SIDEKIQ_QUEUE"] || "psd"
 end

--- a/psd-web/config/application.rb
+++ b/psd-web/config/application.rb
@@ -23,7 +23,7 @@ module ProductSafetyDatabase
     config.eager_load_paths << Rails.root.join("presenters")
 
     config.active_job.queue_adapter = :sidekiq
-    config.action_mailer.deliver_later_queue_name = "psd-mailers"
+    config.action_mailer.deliver_later_queue_name = "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}-mailers"
 
     # This changes Rails timezone, but keeps ActiveRecord in UTC
     config.time_zone = "Europe/London"

--- a/psd-web/config/initializers/sidekiq.rb
+++ b/psd-web/config/initializers/sidekiq.rb
@@ -1,8 +1,9 @@
 def remove_files_without_attachments_job
   remove_files_without_attachments_job = Sidekiq::Cron::Job.new(
-    name: "remove files not attached to anything, midnight every sunday",
+    name: "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}: remove files not attached to anything, midnight every sunday",
     cron: "0 0 * * 0",
-    class: "RemoveFilesWithoutAttachmentsJob"
+    class: "RemoveFilesWithoutAttachmentsJob",
+    queue: ENV["SIDEKIQ_QUEUE"] || "psd"
   )
   unless remove_files_without_attachments_job.save
     Rails.logger.error "***** WARNING - Removing files without attachments was not saved! *****"
@@ -12,17 +13,16 @@ end
 
 def create_log_db_metrics_job
   log_db_metrics_job = Sidekiq::Cron::Job.new(
-    name: "log db metrics, every day at 1am",
+    name: "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}: log db metrics, every day at 1am",
     cron: "0 1 * * *",
     class: "LogDbMetricsJob",
-    queue: "psd"
+    queue: ENV["SIDEKIQ_QUEUE"] || "psd"
   )
   unless log_db_metrics_job.save
     Rails.logger.error "***** WARNING - Log DB metrics job was not saved! *****"
     Rails.logger.error log_db_metrics_job.errors.join("; ")
   end
 end
-
 
 Sidekiq.configure_server do |config|
   config.redis = Rails.application.config_for(:redis_store)

--- a/psd-web/config/initializers/storage.rb
+++ b/psd-web/config/initializers/storage.rb
@@ -5,4 +5,4 @@ Rails.application.config.document_analyzers = Rails.application.config.active_st
 Rails.application.config.document_analyzers.append AntiVirusAnalyzer
 # MasterAnalyzer is the only one that we pass to active_storage
 Rails.application.config.active_storage.analyzers = [MasterAnalyzer]
-Rails.application.config.active_storage.queue = :psd
+Rails.application.config.active_storage.queue = ENV["SIDEKIQ_QUEUE"] || "psd"

--- a/psd-web/config/sidekiq.yml
+++ b/psd-web/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
 :concurrency: 10
 :queues:
-  - psd
-  - psd-mailers
+  - <%= ENV['SIDEKIQ_QUEUE'] || "psd" %>
+  - <%= ENV['SIDEKIQ_QUEUE'] || "psd" %>-mailers

--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -32,6 +32,9 @@ cf push -f $MANIFEST_FILE $WORKER -d $DOMAIN --no-start --var psd-instance-name=
 
 cf set-env $WEB PSD_HOST "$WEB.$DOMAIN"
 
+cf set-env $WEB SIDEKIQ_QUEUE "$INSTANCE_NAME"
+cf set-env $WORKER SIDEKIQ_QUEUE "$INSTANCE_NAME"
+
 rm -fR ${PWD-.}/psd-web/env/
 
 cf start $WEB


### PR DESCRIPTION
Currently all review app workers are sharing the same queue, so it is not possible to segregate them.

An immediately obvious example would be if you create a new scheduled job another review app worker can pick it up, but immediately fail because it doesn't have that job class available.

Other problems could occur when app logic is modified and it will not be possible to tell which review app processed the job.

This change separates the queues based on the review instance name, e.g. `pr-XX`.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
