### PR TITLE
Format free text field

### DIFF
--- a/psd-web/app/controllers/concerns/corrective_actions_concern.rb
+++ b/psd-web/app/controllers/concerns/corrective_actions_concern.rb
@@ -8,8 +8,9 @@ module CorrectiveActionsConcern
   end
 
   def set_corrective_action
-    @corrective_action = @investigation.corrective_actions.build(corrective_action_params).decorate
-    @corrective_action.set_dates_from_params(params[:corrective_action])
+    corrective_action = @investigation.corrective_actions.build(corrective_action_params)
+    corrective_action.set_dates_from_params(params[:corrective_action])
+    @corrective_action = corrective_action.decorate
   end
 
   def corrective_action_params

--- a/psd-web/app/controllers/concerns/corrective_actions_concern.rb
+++ b/psd-web/app/controllers/concerns/corrective_actions_concern.rb
@@ -8,7 +8,7 @@ module CorrectiveActionsConcern
   end
 
   def set_corrective_action
-    @corrective_action = @investigation.corrective_actions.build(corrective_action_params)
+    @corrective_action = @investigation.corrective_actions.build(corrective_action_params).decorate
     @corrective_action.set_dates_from_params(params[:corrective_action])
   end
 

--- a/psd-web/app/controllers/products_controller.rb
+++ b/psd-web/app/controllers/products_controller.rb
@@ -12,7 +12,7 @@ class ProductsController < ApplicationController
   # GET /products
   # GET /products.json
   def index
-    @products = search_for_products(20)
+    @products = search_for_products(20).decorate
   end
 
   # GET /products/1

--- a/psd-web/app/decorators/active_storage/attachment_decorator.rb
+++ b/psd-web/app/decorators/active_storage/attachment_decorator.rb
@@ -1,10 +1,9 @@
 module ActiveStorage
   class AttachmentDecorator < ApplicationDecorator
-    decorates_association :blob
     delegate_all
 
     def description
-      h.simple_format(object.metadata[:description])
+      h.simple_format(object.description)
     end
   end
 end

--- a/psd-web/app/decorators/active_storage/attachment_decorator.rb
+++ b/psd-web/app/decorators/active_storage/attachment_decorator.rb
@@ -1,0 +1,10 @@
+module ActiveStorage
+  class AttachmentDecorator < ApplicationDecorator
+    decorates_association :blob
+    delegate_all
+
+    def description
+      h.simple_format(object.metadata[:description])
+    end
+  end
+end

--- a/psd-web/app/decorators/corrective_action_decorator.rb
+++ b/psd-web/app/decorators/corrective_action_decorator.rb
@@ -1,5 +1,5 @@
 class CorrectiveActionDecorator < ApplicationDecorator
-
+  delegate_all
   def details
     h.simple_format(object.details)
   end

--- a/psd-web/app/decorators/corrective_action_decorator.rb
+++ b/psd-web/app/decorators/corrective_action_decorator.rb
@@ -3,5 +3,4 @@ class CorrectiveActionDecorator < ApplicationDecorator
   def details
     h.simple_format(object.details)
   end
-
 end

--- a/psd-web/app/decorators/corrective_action_decorator.rb
+++ b/psd-web/app/decorators/corrective_action_decorator.rb
@@ -1,0 +1,7 @@
+class CorrectiveActionDecorator < ApplicationDecorator
+
+  def details
+    h.simple_format(object.details)
+  end
+
+end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -24,7 +24,7 @@ class InvestigationDecorator < ApplicationDecorator
 
   def product_summary_list
     products_details = [products.count, "product".pluralize(products.count), "added"].join(" ")
-    hazards = h.simple_format([hazard_type, hazard_description].join("\n\n"))
+    hazards = h.simple_format([hazard_type, object.hazard_description].join("\n\n"))
     rows = [
       category.present? ? { key: { text: "Category" }, value: { text: category }, actions: [] } : nil,
       {
@@ -32,8 +32,8 @@ class InvestigationDecorator < ApplicationDecorator
         value: { text: products_details },
         actions: [href: h.investigation_products_path(object), visually_hidden_text: "product details", text: "View"]
       },
-      hazard_type.present? ? { key: { text: "Hazards" }, value: { text: hazards }, actions: [] } : nil,
-      object.non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: h.simple_format(non_compliant_reason) }, actions: [] } : nil,
+      object.hazard_type.present? ? { key: { text: "Hazards" }, value: { text: hazards }, actions: [] } : nil,
+      object.non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: non_compliant_reason }, actions: [] } : nil,
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -5,6 +5,10 @@ class InvestigationDecorator < ApplicationDecorator
     user_title
   end
 
+  def hazard_description
+    h.simple_format(object.hazard_description)
+  end
+
   def display_product_summary_list?
     products.any?
   end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -9,6 +9,10 @@ class InvestigationDecorator < ApplicationDecorator
     h.simple_format(object.hazard_description)
   end
 
+  def non_compliant_reason
+    h.simple_format(object.non_compliant_reason)
+  end
+
   def display_product_summary_list?
     products.any?
   end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -1,5 +1,6 @@
 class InvestigationDecorator < ApplicationDecorator
   delegate_all
+  decorates_associations :documents_attachments
 
   def title
     user_title

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -13,6 +13,10 @@ class InvestigationDecorator < ApplicationDecorator
     h.simple_format(object.non_compliant_reason)
   end
 
+  def description
+    h.simple_format(object.description)
+  end
+
   def display_product_summary_list?
     products.any?
   end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -33,7 +33,7 @@ class InvestigationDecorator < ApplicationDecorator
         actions: [href: h.investigation_products_path(object), visually_hidden_text: "product details", text: "View"]
       },
       hazard_type.present? ? { key: { text: "Hazards" }, value: { text: hazards }, actions: [] } : nil,
-      non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: h.simple_format(non_compliant_reason) }, actions: [] } : nil,
+      object.non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: h.simple_format(non_compliant_reason) }, actions: [] } : nil,
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"

--- a/psd-web/app/decorators/product_decorator.rb
+++ b/psd-web/app/decorators/product_decorator.rb
@@ -4,12 +4,12 @@ class ProductDecorator < ApplicationDecorator
 
   def summary_list(include_batch_number: false)
     rows = [
-      { key: { text: "Product name" }, value: { text: product.name } },
+      { key: { text: "Product name" }, value: { text: object.name } },
       { key: { text: "Barcode / serial number" }, value: { text: product_code } },
       { key: { text: "Type" }, value: { text: product_type } },
       include_batch_number ? { key: { text: "Batch number" }, value: { text: batch_number } } : nil,
       { key: { text: "Category" }, value: { text: category } },
-      { key: { text: "Webpage" }, value: { text: product.webpage } },
+      { key: { text: "Webpage" }, value: { text: object.webpage } },
       { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
       { key: { text: "Description" }, value: { text: description } }
     ]

--- a/psd-web/app/decorators/product_decorator.rb
+++ b/psd-web/app/decorators/product_decorator.rb
@@ -1,16 +1,17 @@
 class ProductDecorator < ApplicationDecorator
   delegate_all
   decorates_association :investigations
+
   def summary_list(include_batch_number: false)
     rows = [
       { key: { text: "Product name" }, value: { text: product.name } },
-      { key: { text: "Barcode / serial number" }, value: { text: product.product_code } },
-      { key: { text: "Type" }, value: { text: product.product_type } },
-      include_batch_number ? { key: { text: "Batch number" }, value: { text: product.batch_number } } : nil,
+      { key: { text: "Barcode / serial number" }, value: { text: product_code } },
+      { key: { text: "Type" }, value: { text: product_type } },
+      include_batch_number ? { key: { text: "Batch number" }, value: { text: batch_number } } : nil,
       { key: { text: "Category" }, value: { text: category } },
       { key: { text: "Webpage" }, value: { text: product.webpage } },
-      { key: { text: "Country of origin" }, value: { text: country_from_code(product.country_of_origin) } },
-      { key: { text: "Description" }, value: { text: product.description } }
+      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
+      { key: { text: "Description" }, value: { text: description } }
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows

--- a/psd-web/app/decorators/product_decorator.rb
+++ b/psd-web/app/decorators/product_decorator.rb
@@ -19,5 +19,4 @@ class ProductDecorator < ApplicationDecorator
   def description
     h.simple_format(object.description)
   end
-
 end

--- a/psd-web/app/decorators/product_decorator.rb
+++ b/psd-web/app/decorators/product_decorator.rb
@@ -15,4 +15,9 @@ class ProductDecorator < ApplicationDecorator
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows
   end
+
+  def description
+    h.simple_format(object.description)
+  end
+
 end

--- a/psd-web/app/decorators/products_decorator.rb
+++ b/psd-web/app/decorators/products_decorator.rb
@@ -1,2 +1,3 @@
 class ProductsDecorator < Draper::CollectionDecorator
+  delegate :current_page, :total_pages, :limit_value
 end

--- a/psd-web/app/helpers/complainant_helper.rb
+++ b/psd-web/app/helpers/complainant_helper.rb
@@ -1,12 +1,5 @@
 module ComplainantHelper
   def complainant_types
-    {
-      "Consumer": "A consumer",
-      "Business": "A business",
-      "Local authority (Trading Standards)": "Local authority (Trading Standards)",
-      "Other government department": "Other government department",
-      "Emergency service": "Emergency service",
-      "Internal": "Internal"
-    }
+    Complainant::TYPES
   end
 end

--- a/psd-web/app/helpers/products_helper.rb
+++ b/psd-web/app/helpers/products_helper.rb
@@ -12,8 +12,8 @@ module ProductsHelper
 
   def search_for_products(page_size)
     Product.full_search(search_query)
-      .paginate(page: params[:page], per_page: page_size)
       .records
+      .paginate(page: params[:page], per_page: page_size)
   end
 
   def sort_column

--- a/psd-web/app/helpers/url_helper.rb
+++ b/psd-web/app/helpers/url_helper.rb
@@ -32,7 +32,7 @@ module UrlHelper
     {
       is_simple_link: true,
       text: "Back to #{investigation.pretty_description}",
-      href: investigation
+      href: investigation_path(investigation)
     }
   end
 end

--- a/psd-web/app/models/complainant.rb
+++ b/psd-web/app/models/complainant.rb
@@ -24,7 +24,7 @@ class Complainant < ApplicationRecord
     can_be_seen_by_current_user? || investigation.child_should_be_displayed?
   end
 
-  private
+private
 
   def can_be_seen_by_current_user?
     return true if investigation.source&.user_has_gdpr_access?

--- a/psd-web/app/models/complainant.rb
+++ b/psd-web/app/models/complainant.rb
@@ -1,5 +1,15 @@
 class Complainant < ApplicationRecord
   include SanitizationHelper
+
+  TYPES = {
+    "Consumer": "A consumer",
+    "Business": "A business",
+    "Local authority (Trading Standards)": "Local authority (Trading Standards)",
+    "Other government department": "Other government department",
+    "Emergency service": "Emergency service",
+    "Internal": "Internal"
+  }.freeze
+
   belongs_to :investigation, optional: true
 
   before_validation { trim_line_endings(:name, :other_details) }
@@ -14,7 +24,7 @@ class Complainant < ApplicationRecord
     can_be_seen_by_current_user? || investigation.child_should_be_displayed?
   end
 
-private
+  private
 
   def can_be_seen_by_current_user?
     return true if investigation.source&.user_has_gdpr_access?

--- a/psd-web/app/views/documents/_document_card.html.slim
+++ b/psd-web/app/views/documents/_document_card.html.slim
@@ -2,6 +2,7 @@ ruby:
   restricted = !can_be_displayed?(document, parent)
   title = restricted ? document_restricted_title : document.metadata[:title]
   safe = document.metadata["safe"]
+  document = document.decorate
 
 .govuk-grid-row[class="govuk-!-padding-bottom-6"]
   .govuk-grid-column-one-third
@@ -13,7 +14,7 @@ ruby:
       p = render "components/hmcts_badge", text: "Restricted access", classes: "hmcts-badge--grey"
       p = document_restricted_body
     - else
-      p = document.metadata[:description]
+      p = document.description
       p
         - if safe
           = link_to "View #{pretty_type_description(document)}",

--- a/psd-web/app/views/investigations/corrective_actions/details.html.slim
+++ b/psd-web/app/views/investigations/corrective_actions/details.html.slim
@@ -3,7 +3,7 @@
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
 
-= form_with model: @corrective_action, local: true, url: wizard_path, method: :put do |form|
+= form_with model: @corrective_action.object, local: true, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form

--- a/psd-web/app/views/investigations/edit_summary.html.slim
+++ b/psd-web/app/views/investigations/edit_summary.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title, "Update summary"
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
-= form_with(scope: :investigation, model: @investigation, \
+= form_with(scope: :investigation, model: @investigation.object, \
   url: edit_summary_investigation_path(@investigation)) do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop

--- a/psd-web/app/views/investigations/project/new.html.slim
+++ b/psd-web/app/views/investigations/project/new.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title, "New project"
 - content_for :after_header do
   = link_to "Back to Cases", investigations_path(previous_search_params), class: "govuk-back-link"
-= form_with(model: @investigation, scope: :investigation, url: project_index_path, method: :post) do |form|
+= form_with(model: @investigation.object, scope: :investigation, url: project_index_path, method: :post) do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form

--- a/psd-web/app/views/investigations/tabs/_overview.html.slim
+++ b/psd-web/app/views/investigations/tabs/_overview.html.slim
@@ -8,7 +8,7 @@
     p.govuk-body-l = @investigation.title
 
     h2.govuk-heading-m Summary
-    p[class="govuk-body"] = simple_format(@investigation.description)
+    p[class="govuk-body"] = @investigation.description
     p.govuk-body = link_to "Change summary", edit_summary_investigation_path(@investigation), \
       class: "govuk-link"
 

--- a/psd-web/app/views/products/edit.html.slim
+++ b/psd-web/app/views/products/edit.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title, "Edit product"
 - content_for :after_header do
   = link_to "Back to product", @product, class: "govuk-back-link"
-= form_with model: @product, local: true do |form|
+= form_with model: @product.object, local: true do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form

--- a/psd-web/app/views/products/index.html.slim
+++ b/psd-web/app/views/products/index.html.slim
@@ -19,5 +19,5 @@
                   label: { text: "Keywords", classes: "govuk-label--s" }
           = form.submit "Search", name: nil, class: "search-box--submit"
   .govuk-grid-column-three-quarters
-    = render "table", products: @products.decorate
+    = render "table", products: @products
     = will_paginate @products

--- a/psd-web/app/views/products/tabs/_details.html.slim
+++ b/psd-web/app/views/products/tabs/_details.html.slim
@@ -8,4 +8,4 @@
 
 .govuk-grid-row[class="govuk-!-padding-bottom-6"]
   .govuk-grid-column-full
-    = @product.decorate.summary_list(include_batch_number: true)
+    = @product.summary_list(include_batch_number: true)

--- a/psd-web/spec/decorators/active_storage/attachment_decorator_spec.rb
+++ b/psd-web/spec/decorators/active_storage/attachment_decorator_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ActiveStorage::AttachmentDecorator do
+  include ActionView::Helpers::TextHelper
+
+  let(:attachment) { ActiveStorage::Attachment.new.tap {|a| a.build_blob } }
+
+  subject { attachment.decorate }
+
+  describe "#description" do
+    let(:description) { "something\nwith\nnew lines" }
+    before do
+      attachment.metadata[:description] = description
+    end
+
+    it 'formats the metadata description' do
+      expect(subject.description).to eq(simple_format(description))
+    end
+  end
+
+end

--- a/psd-web/spec/decorators/active_storage/attachment_decorator_spec.rb
+++ b/psd-web/spec/decorators/active_storage/attachment_decorator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ActiveStorage::AttachmentDecorator do
   include ActionView::Helpers::TextHelper
 
-  let(:attachment) { ActiveStorage::Attachment.new.tap {|a| a.build_blob } }
+  let(:attachment) { ActiveStorage::Attachment.new.tap(&:build_blob) }
 
   subject { attachment.decorate }
 
@@ -13,9 +13,8 @@ RSpec.describe ActiveStorage::AttachmentDecorator do
       attachment.metadata[:description] = description
     end
 
-    it 'formats the metadata description' do
+    it "formats the metadata description" do
       expect(subject.description).to eq(simple_format(description))
     end
   end
-
 end

--- a/psd-web/spec/decorators/corrective_action_decorator_spec.rb
+++ b/psd-web/spec/decorators/corrective_action_decorator_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe CorrectiveActionDecorator do
+  let(:corrective_action) { CorrectiveAction.new }
+
+  subject { corrective_action.decorate }
+
+  describe "#description" do
+    include_examples "a formated text", :corrective_action, :details
+  end
+end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keycloak_config do
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::TextHelper
-
-  let!(:user)         { create(:user) }
-  let(:user_source)   { build(:user_source) }
+  let(:organisation) { create :organisation }
+  let(:user)         { create(:user, organisation: organisation) }
+  let(:creator)      { create(:user, organisation: organisation) }
+  let(:user_source)   { build(:user_source, user: creator) }
   let(:products)      { [] }
   let(:investigation) { create(:allegation, products: products, assignee: user, source: user_source) }
   let!(:complainant) { create(:complainant, investigation: investigation) }
@@ -266,16 +267,18 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keyclo
   describe "#source_details_summary_list" do
     let(:source_details_summary_list) { subject.source_details_summary_list }
 
-    before { allow(User).to receive(:current).and_return(user) }
+    before do
+      allow(User).to receive(:current).and_return(user)
+    end
 
     it "has the expected fields" do
       expect(source_details_summary_list).to summarise("Received date",   text: investigation.date_received.to_s(:govuk))
       expect(source_details_summary_list).to summarise("Received by",     text: investigation.received_type.upcase_first)
       expect(source_details_summary_list).to summarise("Source type",     text: investigation.complainant.complainant_type)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.name}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.phone_number}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.email_address}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.other_details}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.name)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.phone_number)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.email_address)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.other_details)}/)
     end
   end
 

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -163,8 +163,140 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
     include_examples "a formated text", :investigation, :hazard_description
   end
 
+  describe "#product_summary_list" do
+    let(:product_summary_list) { subject.product_summary_list }
+
+    it "has the expected fields" do
+      expect(product_summary_list).to summarise("Product details", text: "2 products added")
+      expect(product_summary_list).to summarise("Category", text: investigation.products.first.category)
+      expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_type}/)
+      expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_description}/)
+      expect(product_summary_list).to summarise("Compliance", text: /#{investigation.non_compliant_reason}/)
+    end
+
+    context "with two products of the same category" do
+      fixtures(:products)
+      let(:iphone_3g)     { products(:iphone_3g) }
+      let(:iphone)        { products(:iphone)  }
+      let(:samsung)       { products(:samsung) }
+      let(:products_list) { [iphone_3g, samsung] }
+
+      before do
+        investigation.assign_attributes(
+          product_category: iphone_3g.category,
+          products: products_list
+        )
+      end
+
+      it "displays the only category present a paragraphe" do
+        random_product_category = investigation.products.sample.category
+        expect(product_summary_list)
+          .to have_css("dd.govuk-summary-list__value p.govuk-body", text: random_product_category.upcase_first)
+      end
+
+      context "with two products on different categories" do
+        let(:products_list) { [iphone, iphone_3g] }
+
+        it "displays a categories as a list" do
+          expect(product_summary_list)
+            .to have_css("dd.govuk-summary-list__value ul.govuk-list li", text: iphone_3g.category.upcase_first)
+          expect(product_summary_list)
+            .to have_css("dd.govuk-summary-list__value ul.govuk-list li", text: iphone.category.upcase_first)
+        end
+      end
+    end
+
+    context "whithout hazard_type" do
+      let(:product_summary_list) { Capybara.string(subject.product_summary_list) }
+
+      before do
+        investigation.hazard_type = nil
+        investigation.hazard_description = nil
+      end
+
+      it { expect(product_summary_list).not_to have_css("dt.govuk-summary-list__key", text: "Hazards") }
+    end
+
+    context "whithout non_compliant_reason" do
+      let(:product_summary_list) { Capybara.string(subject.product_summary_list) }
+
+      before { investigation.non_compliant_reason = nil }
+
+      it { expect(product_summary_list).not_to have_css("dt.govuk-summary-list__key", text: "Compliance") }
+    end
+  end
+
+  describe "#investigation_summary_list" do
+    fixtures(:sources)
+    let(:investigation_summary_list) { subject.investigation_summary_list }
+
+    it "has the expected fields" do
+      expect(investigation_summary_list).to summarise("Status", text: investigation.status)
+      expect(investigation_summary_list).to summarise("Created by", text: /#{investigation.source.user.name}/)
+      expect(investigation_summary_list).to summarise("Created by", text: /#{investigation.source.user.organisation.name}/)
+      expect(investigation_summary_list).to summarise("Assigned to", text: /Unassigned/)
+      expect(investigation_summary_list).
+        to summarise("Date created", text: investigation.created_at.to_s(:govuk))
+      expect(investigation_summary_list).to summarise("Last updated", text: time_ago_in_words(investigation.updated_at))
+      expect(investigation_summary_list).to summarise("Trading Standards reference", text: investigation.complainant_reference)
+    end
+
+    context "when investigation has no source" do
+      before { investigation.source = nil }
+
+      it "renders nothing as the Created by" do
+        expect(investigation_summary_list).to summarise("Created by", text: "")
+      end
+    end
+
+    context "when the investigation's source no user" do
+      before { investigation.source.user = nil }
+
+      it "renders nothing as the Created by" do
+        expect(investigation_summary_list).to summarise("Created by", text: "")
+      end
+    end
+
+    context "without complainant reference" do
+      let(:investigation_summary_list) { Capybara.string(subject.investigation_summary_list) }
+
+      before { investigation.complainant_reference = nil }
+
+      it { expect(investigation_summary_list).not_to have_css("dt.govuk-summary-list__key", text: "Trading Standards reference") }
+    end
+  end
+
+  describe "#source_details_summary_list" do
+    fixtures(:complainants, :sources, :organisations, :users)
+    let(:investigation) { investigations(:enquiry) }
+    let(:source_details_summary_list) { subject.source_details_summary_list }
+
+    before do
+      User.current = users(:opss)
+      investigation.source = sources(:investigation_one)
+      investigation.complainant = complainants(:one)
+    end
+
+    it "has the expected fields" do
+      expect(source_details_summary_list).to summarise("Received date",   text: investigation.date_received.strftime("%e %B %Y"))
+      expect(source_details_summary_list).to summarise("Received by",     text: investigation.received_type.upcase_first)
+      expect(source_details_summary_list).to summarise("Source type",     text: investigation.complainant.complainant_type)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.name}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.phone_number}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.email_address}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.other_details}/)
+    end
+  end
+
   describe "#non_compliant_reason" do
     include_examples "a formated text", :investigation, :non_compliant_reason
+  end
+
+  describe "#pretty_description" do
+    it {
+      expect(subject.pretty_description)
+        .to eq("#{investigation.case_type.titleize}: #{investigation.pretty_id}")
+    }
   end
 
   describe "#description" do

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keyclo
   let(:user_source)   { build(:user_source) }
   let(:products)      { [] }
   let(:investigation) { create(:allegation, products: products, assignee: user, source: user_source) }
-  let!(:complainant)   { create(:complainant, investigation: investigation) }
+  let!(:complainant) { create(:complainant, investigation: investigation) }
 
   subject { investigation.decorate }
 

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -165,4 +165,13 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
       expect(subject.hazard_description).to eq(simple_format(hazard_description))
     end
   end
+
+  describe '#non_compliant_reason' do
+    let(:non_compliant_reason) { "this is\n\nmulti line\n\nformated" }
+    before { investigation.non_compliant_reason = non_compliant_reason }
+
+    it 'keeps the line breaks' do
+      expect(subject.non_compliant_reason).to eq(simple_format(non_compliant_reason))
+    end
+  end
 end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keyclo
     end
 
     context "with two products of the same category" do
-      let(:iphone_3g)     { build(:iphone_3g) }
-      let(:iphone)        { build(:iphone)  }
-      let(:samsung)       { build(:samsung) }
+      let(:iphone_3g)     { build(:product_iphone_3g) }
+      let(:iphone)        { build(:product_iphone)  }
+      let(:samsung)       { build(:product_samsung) }
       let(:products_list) { [iphone_3g, samsung] }
 
       before do

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -158,11 +158,12 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
     }
   end
 
-  describe '#hazard_descrition' do
+
+  describe "#hazard_descrition" do
     include_examples "a formated text", :investigation, :hazard_description
   end
 
-  describe '#non_compliant_reason' do
+  describe "#non_compliant_reason" do
     include_examples "a formated text", :investigation, :non_compliant_reason
   end
 

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -156,4 +156,13 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
         .to eq("#{investigation.case_type.titleize}: #{investigation.pretty_id}")
     }
   end
+
+  describe '#hazard_descrition' do
+    let(:hazard_description) { "this is\n\nmulti line\n\nformated" }
+    before { investigation.hazard_description = hazard_description }
+
+    it 'keeps the line breaks' do
+      expect(subject.hazard_description).to eq(simple_format(hazard_description))
+    end
+  end
 end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -1,5 +1,14 @@
 require "rails_helper"
 
+RSpec.shared_examples "a formated text" do |text_attribute|
+  let(:text) { "this is\n\nmulti line\n\nformated" }
+  before { investigation.public_send(:"#{text_attribute}=", text) }
+
+  it 'keeps the line breaks' do
+    expect(subject.public_send(text_attribute)).to eq(simple_format(text))
+  end
+end
+
 RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::TextHelper
@@ -158,20 +167,14 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
   end
 
   describe '#hazard_descrition' do
-    let(:hazard_description) { "this is\n\nmulti line\n\nformated" }
-    before { investigation.hazard_description = hazard_description }
-
-    it 'keeps the line breaks' do
-      expect(subject.hazard_description).to eq(simple_format(hazard_description))
-    end
+    include_examples "a formated text", :hazard_description
   end
 
   describe '#non_compliant_reason' do
-    let(:non_compliant_reason) { "this is\n\nmulti line\n\nformated" }
-    before { investigation.non_compliant_reason = non_compliant_reason }
+    include_examples "a formated text", :non_compliant_reason
+  end
 
-    it 'keeps the line breaks' do
-      expect(subject.non_compliant_reason).to eq(simple_format(non_compliant_reason))
-    end
+  describe "#description" do
+    include_examples "a formated text", :description
   end
 end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -1,13 +1,5 @@
 require "rails_helper"
 
-RSpec.shared_examples "a formated text" do |text_attribute|
-  let(:text) { "this is\n\nmulti line\n\nformated" }
-  before { investigation.public_send(:"#{text_attribute}=", text) }
-
-  it 'keeps the line breaks' do
-    expect(subject.public_send(text_attribute)).to eq(simple_format(text))
-  end
-end
 
 RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
   include ActionView::Helpers::DateHelper
@@ -167,14 +159,14 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
   end
 
   describe '#hazard_descrition' do
-    include_examples "a formated text", :hazard_description
+    include_examples "a formated text", :investigation, :hazard_description
   end
 
   describe '#non_compliant_reason' do
-    include_examples "a formated text", :non_compliant_reason
+    include_examples "a formated text", :investigation, :non_compliant_reason
   end
 
   describe "#description" do
-    include_examples "a formated text", :description
+    include_examples "a formated text", :investigation, :description
   end
 end

--- a/psd-web/spec/decorators/product_decorator_spec.rb
+++ b/psd-web/spec/decorators/product_decorator_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe ProductDecorator do
       end
     end
   end
+
+  describe "#description" do
+    include_examples "a formated text", :product, :description
+  end
 end

--- a/psd-web/spec/factories/complainants.rb
+++ b/psd-web/spec/factories/complainants.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :complainant do
+    email_address { "test@example.com" }
+    name { "complainant name" }
+    other_details { "some details" }
+    phone_number { "1234567890" }
+    complainant_type { Complainant::TYPES.keys.sample }
+  end
+
+  Complainant::TYPES.keys.each do |type|
+    factory :"complainant_#{type}", parent: :complainant do
+      complainant_type { type }
+    end
+  end
+end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-
   factory :investigation do
     user_title { "investigation title" }
     hazard_type { "hazard type" }
@@ -25,5 +24,4 @@ FactoryBot.define do
       user_title { "test project title" }
     end
   end
-
 end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -1,19 +1,29 @@
 FactoryBot.define do
-  factory :allegation, class: Investigation::Allegation do
-    description { "test allegation" }
-    user_title { "test allegation title" }
+
+  factory :investigation do
+    user_title { "investigation title" }
+    hazard_type { "hazard type" }
+    hazard_description { "hazard description" }
+    non_compliant_reason { "non compliant reason" }
+    complainant_reference { "complainant reference" }
+    date_received { 1.day.ago }
+    received_type { %w(email phone other).sample }
     is_closed { false }
+
+    factory :allegation, class: Investigation::Allegation do
+      description { "test allegation" }
+      user_title { "test allegation title" }
+    end
+
+    factory :enquiry, class: Investigation::Enquiry do
+      description { "test enquiry" }
+      user_title { "test enquiry title" }
+    end
+
+    factory :project, class: Investigation::Project do
+      description { "test project" }
+      user_title { "test project title" }
+    end
   end
 
-  factory :enquiry, class: Investigation::Enquiry do
-    description { "test enquiry" }
-    user_title { "test enquiry title" }
-    is_closed { false }
-  end
-
-  factory :project, class: Investigation::Project do
-    description { "test project" }
-    user_title { "test project title" }
-    is_closed { false }
-  end
 end

--- a/psd-web/spec/factories/products.rb
+++ b/psd-web/spec/factories/products.rb
@@ -1,35 +1,35 @@
 FactoryBot.define do
   factory :product do
-    name { "product name"}
+    name { "product name" }
     description { "product description" }
     category { Rails.application.config.product_constants["product_category"].sample }
     product_type { "product_type" }
   end
 
-  factory :iphone, parent: :product  do
-    product_code { 234}
+  factory :iphone, parent: :product do
+    product_code { 234 }
     name { "iPhone XS MAX" }
-    webpage  { "https://www.iphone.webpage" }
+    webpage { "https://www.iphone.webpage" }
     product_type { "phone" }
-    category  {"phone category"}
-    description {"iphone description"}
-    country_of_origin  {"United States"}
+    category { "phone category" }
+    description { "iphone description" }
+    country_of_origin { "United States" }
     batch_number { "1234" }
   end
 
   factory :iphone_3g, parent: :product do
-    product_code  { 345}
-    name {"iPhone"}
+    product_code { 345 }
+    name { "iPhone" }
     product_type { "phone" }
     category { "phone" }
   end
 
   factory :samsung, parent: :product do
-    product_code  {  4524}
-    name {"galaxy"}
-    product_type { "phone"}
-    category {"phone"}
-    description {"a phone by samsung"}
-    country_of_origin {"Republic of Korea"}
+    product_code { 4524 }
+    name { "galaxy" }
+    product_type { "phone" }
+    category { "phone" }
+    description { "a phone by samsung" }
+    country_of_origin { "Republic of Korea" }
   end
 end

--- a/psd-web/spec/factories/products.rb
+++ b/psd-web/spec/factories/products.rb
@@ -4,32 +4,32 @@ FactoryBot.define do
     description { "product description" }
     category { Rails.application.config.product_constants["product_category"].sample }
     product_type { "product_type" }
-  end
 
-  factory :iphone, parent: :product do
-    product_code { 234 }
-    name { "iPhone XS MAX" }
-    webpage { "https://www.iphone.webpage" }
-    product_type { "phone" }
-    category { "phone category" }
-    description { "iphone description" }
-    country_of_origin { "United States" }
-    batch_number { "1234" }
-  end
+    factory :product_iphone do
+      product_code { 234 }
+      name { "iPhone XS MAX" }
+      webpage { "https://www.iphone.webpage" }
+      product_type { "phone" }
+      category { "phone category" }
+      description { "iphone description" }
+      country_of_origin { "United States" }
+      batch_number { "1234" }
+    end
 
-  factory :iphone_3g, parent: :product do
-    product_code { 345 }
-    name { "iPhone" }
-    product_type { "phone" }
-    category { "phone" }
-  end
+    factory :product_iphone_3g do
+      product_code { 345 }
+      name { "iPhone" }
+      product_type { "phone" }
+      category { "phone" }
+    end
 
-  factory :samsung, parent: :product do
-    product_code { 4524 }
-    name { "galaxy" }
-    product_type { "phone" }
-    category { "phone" }
-    description { "a phone by samsung" }
-    country_of_origin { "Republic of Korea" }
+    factory :product_samsung do
+      product_code { 4524 }
+      name { "galaxy" }
+      product_type { "phone" }
+      category { "phone" }
+      description { "a phone by samsung" }
+      country_of_origin { "Republic of Korea" }
+    end
   end
 end

--- a/psd-web/spec/factories/products.rb
+++ b/psd-web/spec/factories/products.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :product do
+    name { "product name"}
+    description { "product description" }
+    category { Rails.application.config.product_constants["product_category"].sample }
+    product_type { "product_type" }
+  end
+
+  factory :iphone, parent: :product  do
+    product_code { 234}
+    name { "iPhone XS MAX" }
+    webpage  { "https://www.iphone.webpage" }
+    product_type { "phone" }
+    category  {"phone category"}
+    description {"iphone description"}
+    country_of_origin  {"United States"}
+    batch_number { "1234" }
+  end
+
+  factory :iphone_3g, parent: :product do
+    product_code  { 345}
+    name {"iPhone"}
+    product_type { "phone" }
+    category { "phone" }
+  end
+
+  factory :samsung, parent: :product do
+    product_code  {  4524}
+    name {"galaxy"}
+    product_type { "phone"}
+    category {"phone"}
+    description {"a phone by samsung"}
+    country_of_origin {"Republic of Korea"}
+  end
+end

--- a/psd-web/spec/factories/sources.rb
+++ b/psd-web/spec/factories/sources.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :source do
     name { "source name" }
   end
-  factory :user_source, class: 'UserSource' do
-    user { create(:user, :psd_user)}
+  factory :user_source, class: "UserSource" do
+    user { create(:user, :psd_user) }
   end
 end

--- a/psd-web/spec/factories/sources.rb
+++ b/psd-web/spec/factories/sources.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :source do
+    name { "source name" }
+  end
+  factory :user_source, class: 'UserSource' do
+    user { create(:user, :psd_user)}
+  end
+end

--- a/psd-web/spec/models/investigation_spec.rb
+++ b/psd-web/spec/models/investigation_spec.rb
@@ -8,7 +8,9 @@ RSpec.shared_examples "an Investigation" do
 
     before do
       User.current = user
-      NotifyMailer.stub(:investigation_created) { double("mailer", deliver_later: true) }
+      allow(NotifyMailer)
+        .to receive(:investigation_created)
+        .and_return(double("mailer", deliver_later: true))
       investigation.save # Need to trigger save after stubbing the mailer due to callback hell
     end
 

--- a/psd-web/spec/support/simple_format_examples.rb
+++ b/psd-web/spec/support/simple_format_examples.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples "a formated text" do |instance, text_attribute|
   let(:text) { "this is\n\nmulti line\n\nformated" }
   before { public_send(instance).public_send(:"#{text_attribute}=", text) }
 
-  it 'keeps the line breaks' do
+  it "keeps the line breaks" do
     expect(subject.public_send(text_attribute)).to eq(simple_format(text))
   end
 end

--- a/psd-web/spec/support/simple_format_examples.rb
+++ b/psd-web/spec/support/simple_format_examples.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples "a formated text" do |instance, text_attribute|
+  include ActionView::Helpers::TextHelper
+  let(:text) { "this is\n\nmulti line\n\nformated" }
+  before { public_send(instance).public_send(:"#{text_attribute}=", text) }
+
+  it 'keeps the line breaks' do
+    expect(subject.public_send(text_attribute)).to eq(simple_format(text))
+  end
+end

--- a/psd-web/test/models/investigation_test.rb
+++ b/psd-web/test/models/investigation_test.rb
@@ -145,6 +145,7 @@ class InvestigationTest < ActiveSupport::TestCase
   end
 
   test "elasticsearch should find complainant email address" do
+    @investigation_with_complainant.__elasticsearch__.index_document
     query = ElasticsearchQuery.new(@complainant.email_address, {}, {})
     assert_includes(Investigation.full_search(query).records.map(&:id), @investigation_with_complainant.id)
   end

--- a/psd-web/test/system/create_enquiry_test.rb
+++ b/psd-web/test/system/create_enquiry_test.rb
@@ -133,7 +133,7 @@ class CreateEnquiryTest < ApplicationSystemTestCase
     assert_current_path(/cases\/\d+/)
     click_on "Activity"
     assert_text "Enquiry logged: #{@enquiry.title}"
-    assert_text @enquiry.description
+    assert_text @enquiry.object.description
 
     assert_text "Name: #{@complainant.name}"
     assert_text "Type: #{@complainant.complainant_type}"
@@ -209,7 +209,7 @@ class CreateEnquiryTest < ApplicationSystemTestCase
 
   def fill_enquiry_details_and_continue
     fill_in "enquiry[user_title]", with: @enquiry.user_title
-    fill_in "enquiry[description]", with: @enquiry.description
+    fill_in "enquiry[description]", with: @enquiry.object.description
     click_on "Create enquiry"
   end
 end

--- a/psd-web/test/system/keycloak_test.rb
+++ b/psd-web/test/system/keycloak_test.rb
@@ -12,12 +12,14 @@ class KeycloakTest < ApplicationSystemTestCase
 
   test "can login" do
     visit root_url
+    sign_out_if_signed_in
     sign_in email: "user@example.com", password: ENV.fetch("KEYCLOAK_USER_PASSWORD", "password")
     assert_text "Sign out"
   end
 
   test "can logout" do
     visit root_url
+    sign_out_if_signed_in
     sign_in email: "user@example.com", password: ENV.fetch("KEYCLOAK_USER_PASSWORD", "password")
     click_on "Sign out"
     assert_css "h1", text: "Sign in to the Product safety database"


### PR DESCRIPTION
## Description

1. Add `simple_format` in the relevant decorators.
2. move away from fixtures in favour of FactoryBot in investigation_decorator_spec.rb

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
