### PR TITLE
Fix page layout on error pages not being rendered

### DIFF
--- a/psd-web/app/controllers/application_controller.rb
+++ b/psd-web/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   end
 
   def nav_items
-    return nil if hide_nav? # On some pages we don't want to show the main navigation
+    return nil if hide_nav? || !User.current # On some pages we don't want to show the main navigation
 
     items = []
     unless User.current.is_opss?

--- a/psd-web/app/controllers/errors_controller.rb
+++ b/psd-web/app/controllers/errors_controller.rb
@@ -1,5 +1,4 @@
 class ErrorsController < ApplicationController
-
   layout "application"
 
   skip_before_action :authenticate_user!, :authorize_user, :has_accepted_declaration

--- a/psd-web/app/controllers/errors_controller.rb
+++ b/psd-web/app/controllers/errors_controller.rb
@@ -1,4 +1,9 @@
-class ErrorsController < ActionController::Base
+class ErrorsController < ApplicationController
+
+  layout "application"
+
+  skip_before_action :authenticate_user!, :authorize_user, :has_accepted_declaration
+
   def not_found
     render status: :not_found, formats: [:html]
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes the page layout not being rendered on error pages.

Before:

![Screenshot 2019-11-18 at 14 53 34](https://user-images.githubusercontent.com/408371/69062718-40709d80-0a13-11ea-9b48-7168cf009bb8.png)

After (logged out):

![Screenshot 2019-11-18 at 14 51 37](https://user-images.githubusercontent.com/408371/69062742-48304200-0a13-11ea-952d-4f4fc5315d41.png)

After (logged in)

![Screenshot 2019-11-18 at 14 51 24](https://user-images.githubusercontent.com/408371/69062768-4ebeb980-0a13-11ea-922d-ebd564e3a861.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
