### PR TITLE
Improve styling of placeholder graphic

### DIFF
--- a/psd-web/app/assets/application/stylesheets/documents.scss
+++ b/psd-web/app/assets/application/stylesheets/documents.scss
@@ -18,12 +18,14 @@
 }
 
 .document-processing-placeholder {
-  background-color: govuk-colour("grey-1");
-  color: govuk-colour("white");
-  font-weight: bold;
-  font-size: 2.5em;
+  border: 3px dashed govuk-colour("grey-1");
+  @include govuk-font($size: 24);
   text-align: center;
-  vertical-align: top;
+  color: govuk-colour("grey-1");
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(6, "bottom");
+  // For mobile display
+  @include govuk-responsive-margin(6, "bottom");
 }
 
 .document-list {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Our current 'Processing image' placeholder doesn't specify a font and is too distracting on the page.

Changes:
* Explicitly set font and size
* Change to dashed border
* Give it padding and margin

## Before:
### Desktop:
![Screenshot 2019-11-26 at 17 46 37](https://user-images.githubusercontent.com/2204224/69660924-43a20400-1079-11ea-96d4-4dcaac1ed2fa.png)
### Mobile:
![Screenshot 2019-11-26 at 18 22 18](https://user-images.githubusercontent.com/2204224/69661140-c3c86980-1079-11ea-866d-2ceb27d94b34.png)

## After:
### Desktop:
![Screenshot 2019-11-26 at 18 14 17](https://user-images.githubusercontent.com/2204224/69660946-4e5c9900-1079-11ea-9f10-bdad060eadd9.png)
![Screenshot 2019-11-26 at 18 14 21](https://user-images.githubusercontent.com/2204224/69660953-51f02000-1079-11ea-86cd-47da1d51700a.png)
### Mobile:
![Screenshot 2019-11-26 at 18 20 43](https://user-images.githubusercontent.com/2204224/69661038-87950900-1079-11ea-9c28-fdce77ba93d2.png)
