### PR TITLE
Set font on thumbnail text

### DIFF
--- a/psd-web/app/assets/stylesheets/documents.scss
+++ b/psd-web/app/assets/stylesheets/documents.scss
@@ -11,7 +11,7 @@
     width: 75px;
     height: 30px;
     color: govuk-colour("white");
-    @include govuk-font(19, $weight: bold, $line-height:30px);
+    @include govuk-font(19, $weight: bold, $line-height: 30px);
     text-align: center;
   }
 }

--- a/psd-web/app/assets/stylesheets/documents.scss
+++ b/psd-web/app/assets/stylesheets/documents.scss
@@ -11,8 +11,7 @@
     width: 75px;
     height: 30px;
     color: govuk-colour("white");
-    line-height: 30px;
-    font-weight: bold;
+    @include govuk-font(19, $weight: bold, $line-height:30px);
     text-align: center;
   }
 }


### PR DESCRIPTION
There's no font set on the text content of the document thumbnail - so it renders with whatever the system font is.

Before:
![Screenshot 2019-11-26 at 18 47 07](https://user-images.githubusercontent.com/2204224/69663094-79e18280-107d-11ea-9b2c-cd381eaf749c.png)

After:
![Screenshot 2019-11-26 at 18 46 05](https://user-images.githubusercontent.com/2204224/69663115-81089080-107d-11ea-95cb-aa3c5f556716.png)

