### PR TITLE
Remove unnecessary class

### DIFF
--- a/psd-web/app/views/products/_product_card.html.slim
+++ b/psd-web/app/views/products/_product_card.html.slim
@@ -1,4 +1,4 @@
-.govuk-grid-row.psd-product-card.govuk-body
+.govuk-grid-row.psd-product-card
   .govuk-grid-column-one-half
     span.govuk-caption-m[class="govuk-!-font-size-16"] Product
     span = link_to product.name, product


### PR DESCRIPTION
Removes the `govuk-body` class from the product list view.

This class:
* Is unnecessary as `.psd-product-card` already defines the font and size
* Is not appropriate as the contents aren't body.
* Conflicts with #71 which sets a max width on `govuk-body`