### PR TITLE
Fix flaky RSpec spec

### DIFF
--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
 
     it "has the expected fields" do
       expect(product_summary_list).to summarise("Product details", text: "2 products added")
-      expect(product_summary_list).to summarise("Category", text: investigation.products.first.category)
+
+      investigation.products.each { |product| expect(product_summary_list).to summarise("Category", text: product.category) }
+
       expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_type}/)
       expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_description}/)
       expect(product_summary_list).to summarise("Compliance", text: /#{investigation.non_compliant_reason}/)

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
     it "has the expected fields" do
       expect(product_summary_list).to summarise("Product details", text: "2 products added")
 
-      investigation.products.each { |product| expect(product_summary_list).to summarise("Category", text: product.category) }
+      investigation.products.each { |product| expect(product_summary_list).to summarise("Category", text: /#{Regexp.escape(product.category)}/i) }
 
-      expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_type}/)
-      expect(product_summary_list).to summarise("Hazards", text: /#{investigation.hazard_description}/)
-      expect(product_summary_list).to summarise("Compliance", text: /#{investigation.non_compliant_reason}/)
+      expect(product_summary_list).to summarise("Hazards", text: /#{Regexp.escape(investigation.hazard_type)}/)
+      expect(product_summary_list).to summarise("Hazards", text: /#{Regexp.escape(investigation.hazard_description)}/)
+      expect(product_summary_list).to summarise("Compliance", text: /#{Regexp.escape(investigation.non_compliant_reason)}/)
     end
 
     context "with two products of the same category" do
@@ -94,8 +94,8 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
 
     it "has the expected fields" do
       expect(investigation_summary_list).to summarise("Status", text: investigation.status)
-      expect(investigation_summary_list).to summarise("Created by", text: /#{investigation.source.user.name}/)
-      expect(investigation_summary_list).to summarise("Created by", text: /#{investigation.source.user.organisation.name}/)
+      expect(investigation_summary_list).to summarise("Created by", text: /#{Regexp.escape(investigation.source.user.name)}/)
+      expect(investigation_summary_list).to summarise("Created by", text: /#{Regexp.escape(investigation.source.user.organisation.name)}/)
       expect(investigation_summary_list).to summarise("Assigned to", text: /Unassigned/)
       expect(investigation_summary_list).
         to summarise("Date created", text: investigation.created_at.to_s(:govuk))
@@ -143,10 +143,10 @@ RSpec.describe InvestigationDecorator, with_stubbed_elasticsearch: true do
       expect(source_details_summary_list).to summarise("Received date",   text: investigation.date_received.strftime("%e %B %Y"))
       expect(source_details_summary_list).to summarise("Received by",     text: investigation.received_type.upcase_first)
       expect(source_details_summary_list).to summarise("Source type",     text: investigation.complainant.complainant_type)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.name}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.phone_number}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.email_address}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{investigation.complainant.other_details}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.name)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.phone_number)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.email_address)}/)
+      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.other_details)}/)
     end
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This addresses a flaky RSpec spec which could fail, depending on the order in which the two associated products were returned. The existing test only matched against the first returned product, but in some cases where the other product was returned first the matcher would fail because it was being compared case-sensitively. The [decorator modifies the case of the text](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/decorators/investigation_decorator.rb#L127) on the page from the raw database value.

This change simply modifies the test to compare case insensitively, and also adds some regex escaping to guard against potential failures in future where the data might contain special characters, which might not be spotted or provide false positives.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
