### PR TITLE
Fix e-mail not being sent when creating a case

### DIFF
--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -47,6 +47,7 @@ class Investigation < ApplicationRecord
   has_one :source, as: :sourceable, dependent: :destroy
   has_one :complainant, dependent: :destroy
 
+  # TODO: Refactor to remove this callback hell
   before_create :set_source_to_current_user, :assign_to_current_user, :add_pretty_id
   after_create :create_audit_activity_for_case, :send_confirmation_email
 
@@ -213,13 +214,14 @@ private
     self.assignee = User.current if assignee.blank? && User.current
   end
 
+  # TODO: Refactor to remove dependency on User.current
   def send_confirmation_email
     if User.current
       NotifyMailer.investigation_created(
         pretty_id,
         User.current.name,
         User.current.email,
-        title,
+        self.decorate.title,
         case_type
       ).deliver_later
     end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -1,6 +1,19 @@
 FactoryBot.define do
   factory :allegation, class: Investigation::Allegation do
-    description { "test" }
+    description { "test allegation" }
+    user_title { "test allegation title" }
+    is_closed { false }
+  end
+
+  factory :enquiry, class: Investigation::Enquiry do
+    description { "test enquiry" }
+    user_title { "test enquiry title" }
+    is_closed { false }
+  end
+
+  factory :project, class: Investigation::Project do
+    description { "test project" }
+    user_title { "test project title" }
     is_closed { false }
   end
 end

--- a/psd-web/spec/models/investigation_spec.rb
+++ b/psd-web/spec/models/investigation_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+# TODO: Refactor Investigation model to remove callback hell and dependency on User.current
+RSpec.shared_examples "an Investigation" do
+  describe "record creation", with_stubbed_elasticsearch: true, with_keycloak_config: true do
+    let(:user) { create(:user) }
+    let(:investigation) { build(factory) }
+
+    before do
+      User.current = user
+      NotifyMailer.stub(:investigation_created) { double("mailer", deliver_later: true) }
+      investigation.save # Need to trigger save after stubbing the mailer due to callback hell
+    end
+
+    after do
+      User.current = nil # :puke:
+    end
+
+    it "sends a notification email" do
+      expect(NotifyMailer).to have_received(:investigation_created).with(investigation.pretty_id, user.name, user.email, investigation.decorate.title, investigation.case_type)
+    end
+  end
+end
+
+RSpec.describe Investigation::Allegation do
+  let(:factory) { :allegation }
+  it_behaves_like "an Investigation"
+end
+
+RSpec.describe Investigation::Enquiry do
+  let(:factory) { :enquiry }
+  it_behaves_like "an Investigation"
+end
+
+RSpec.describe Investigation::Project do
+  let(:factory) { :project }
+  it_behaves_like "an Investigation"
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes a regression [introduced recently](https://github.com/UKGovernmentBEIS/beis-opss-psd/commit/c78dd635bff891bb8a4834221326b492d74ca9ee#diff-c573245a97e3475b3a065cd10502cd47L14) which prevented e-mails from being sent on case creation. It also adds a new test to prevent future regressions.

I have not attempted to improve the implementation which is pretty nasty with callbacks and dependency on `User.current`, the purpose of this is to fix the regression only and prevent it happening again.

It does also provide a starting point to build up test coverage of the `Investigation` model and subclasses.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
