### PR TITLE
Fix incorrect test, caused by factories having common names

### DIFF
--- a/psd-web/spec/factories/organisations.rb
+++ b/psd-web/spec/factories/organisations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :organisation do
     id { SecureRandom.uuid }
-    name { "test" }
+    name { "test organisation" }
     path { "/test/test" }
   end
 end

--- a/psd-web/spec/factories/teams.rb
+++ b/psd-web/spec/factories/teams.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :team do
     id { SecureRandom.uuid }
-    name { "test" }
+    name { "test team" }
     team_recipient_email { "test@example.com" }
     organisation
     path { "/test/test" }

--- a/psd-web/spec/factories/users.rb
+++ b/psd-web/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     id { SecureRandom.uuid }
-    name { "test" }
+    name { "test user" }
     email { "test@example.com" }
     organisation
     has_accepted_declaration { false }

--- a/psd-web/spec/models/team_spec.rb
+++ b/psd-web/spec/models/team_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Team do
     end
 
     context "with user of another organisation" do
-      let(:viewing_user) { user_same_org }
+      let(:viewing_user) { user_other_org }
 
       context "with ignore_visibility_restrictions: true" do
         let(:ignore_visibility_restrictions) { true }
@@ -67,7 +67,7 @@ RSpec.describe Team do
 
       context "with ignore_visibility_restrictions: false" do
         it "returns the organisation name" do
-          expect(result).to eq(team.name)
+          expect(result).to eq(organisation.name)
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
The previous implementation of this spec was incorrect and giving false positives because the factories of different classes had the same `name` value. This fixes the test and also ensures factories have unique names.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
