### PR TITLE
Fix intermittently failing test on update assignee notifications

### DIFF
--- a/psd-web/test/models/notification_test.rb
+++ b/psd-web/test/models/notification_test.rb
@@ -76,10 +76,16 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test "should notify previous assignee team if case is assigned to someone by someone outside" do
-    @investigation.update(assignee: @user_one)
-    @investigation.update(assignee: @user_three.teams[0])
-    mock_investigation_updated(who_will_be_notified: [@user_three, @user_one].map(&:email))
-    @investigation.update(assignee: @user_one)
+    @investigation.update!(assignee: @user_one)
+
+    team_with_recipient_email = Team.find_by(name: "Team 4")
+
+    @investigation.update!(assignee: team_with_recipient_email)
+
+    expected_recipients = [@user_three.email, @user_one.email, team_with_recipient_email.team_recipient_email]
+
+    mock_investigation_updated(who_will_be_notified: expected_recipients)
+    @investigation.update!(assignee: @user_one)
     assert_equal @number_of_notifications, 2
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes another intermittent test failure caused by the order in which associated records are returned sometimes being different to that assumed.

In this case, the second record would have a `team_recipient_email` property which altered the behaviour of the tested functionality, adding an extra email recipient to the list who should receive the notification of the assignment change.

This change fixes the team and I also ensured it was the one with the recipient email in order to test that it was included in the list of recipients.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
