### PR TITLE
Show case status on search results cards

### DIFF
--- a/psd-web/app/views/investigations/_highlight_card.html.slim
+++ b/psd-web/app/views/investigations/_highlight_card.html.slim
@@ -5,6 +5,7 @@
     span.govuk-caption-m[class="govuk-!-font-size-16"]
       = investigation.pretty_description
     span = link_to investigation.title, investigation_path(investigation), class: "govuk-!-font-weight-bold"
+    = render "investigations/case_card_status_area", investigation: investigation
   .govuk-grid-column-one-half
     - displayable_highlights.each do |highlight|
       span.govuk-caption-m[class="govuk-!-font-size-16"] = highlight[:label]


### PR DESCRIPTION
In #88 I missed that search results use a different template. This adds the status tags to the search results.

![Screenshot 2019-12-05 at 16 33 15](https://user-images.githubusercontent.com/2204224/70254439-f7dc1280-177c-11ea-8a94-33a8621af73d.png)
