### PR TITLE
Eager load user organisation and teams for assignee filter list to eliminate n+1 database queries

### DIFF
--- a/psd-web/app/helpers/investigations/user_filters_helper.rb
+++ b/psd-web/app/helpers/investigations/user_filters_helper.rb
@@ -1,6 +1,6 @@
 module Investigations::UserFiltersHelper
   def entities
-    User.get_assignees(except: User.current) + Team.get_assignees
+    User.get_assignees(except: User.current) + Team.all_with_organisation
   end
 
   def assigned_to(form)

--- a/psd-web/app/helpers/investigations/user_filters_helper.rb
+++ b/psd-web/app/helpers/investigations/user_filters_helper.rb
@@ -1,6 +1,6 @@
 module Investigations::UserFiltersHelper
   def entities
-    User.get_assignees(except: User.current) + Team.all
+    User.get_assignees(except: User.current) + Team.get_assignees
   end
 
   def assigned_to(form)

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -38,7 +38,7 @@ class Team < ApplicationRecord
     self.ensure_names_up_to_date
   end
 
-  def self.get_assignees
+  def self.all_with_organisation
     all.includes(:organisation)
   end
 

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -38,8 +38,12 @@ class Team < ApplicationRecord
     self.ensure_names_up_to_date
   end
 
+  def self.get_assignees
+    all.includes(:organisation)
+  end
+
   def display_name(ignore_visibility_restrictions: false, current_user: User.current)
-    return name if (current_user && (current_user.organisation == organisation)) || ignore_visibility_restrictions
+    return name if (current_user && (current_user.organisation_id == organisation_id)) || ignore_visibility_restrictions
 
     organisation.name
   end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
 
   def self.get_assignees(except: [])
     user_ids_to_exclude = Array(except).collect(&:id)
-    self.activated.where.not(id: user_ids_to_exclude).preload(:organisation, :teams)
+    self.activated.where.not(id: user_ids_to_exclude).eager_load(:organisation, :teams)
   end
 
   def self.get_team_members(user:)

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
 
   def self.get_assignees(except: [])
     users_to_exclude = Array(except)
-    self.activated - users_to_exclude
+    self.activated.includes(:organisation, :teams) - users_to_exclude
   end
 
   def self.get_team_members(user:)

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -128,8 +128,8 @@ class User < ApplicationRecord
   end
 
   def self.get_assignees(except: [])
-    users_to_exclude = Array(except)
-    self.activated.includes(:organisation, :teams) - users_to_exclude
+    user_ids_to_exclude = Array(except).collect(&:id)
+    self.activated.where.not(id: user_ids_to_exclude).preload(:organisation, :teams)
   end
 
   def self.get_team_members(user:)

--- a/psd-web/spec/models/team_spec.rb
+++ b/psd-web/spec/models/team_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Team do
+  describe ".get_assignees" do
+    before { 3.times { create(:team) } }
+
+    it "includes associations needed for display_name" do
+      assignees = described_class.get_assignees
+
+      expect(assignees.length).to eq(3)
+      expect(-> {
+        assignees.map(&:display_name)
+      }).to not_talk_to_db
+    end
+  end
+
   describe ".get_visible_teams" do
     before do
       allow(Rails.application.config).to receive(:team_names).and_return(

--- a/psd-web/spec/models/team_spec.rb
+++ b/psd-web/spec/models/team_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Team do
-  describe ".get_assignees" do
+  describe ".all_with_organisation" do
     before { 3.times { create(:team) } }
 
     it "includes associations needed for display_name" do
-      assignees = described_class.get_assignees
+      assignees = described_class.all_with_organisation
 
       expect(assignees.length).to eq(3)
       expect(-> {

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe User, with_keycloak_config: true do
       expect(described_class.get_assignees).not_to include(inactive_user)
     end
 
+    it "includes associations needed for display_name" do
+      assignees = described_class.get_assignees
+      expect(-> {
+        assignees.map(&:display_name)
+      }).to not_talk_to_db
+    end
+
     context "when a user to except is supplied" do
       it "does not return the excepted user" do
         expect(described_class.get_assignees(except: active_user)).to be_empty

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe User, with_keycloak_config: true do
     end
 
     it "includes associations needed for display_name" do
-      assignees = described_class.get_assignees
+      assignees = described_class.get_assignees.to_a # to_a forces the query execution and load immediately
       expect(-> {
         assignees.map(&:display_name)
       }).to not_talk_to_db

--- a/psd-web/spec/support/not_talk_to_db_matcher.rb
+++ b/psd-web/spec/support/not_talk_to_db_matcher.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :not_talk_to_db do |_expected|
+  match do |block_to_test|
+    %w(exec_delete exec_insert exec_query exec_update).each do |meth|
+      expect(ActiveRecord::Base.connection).not_to receive(meth)
+    end
+    block_to_test.call
+  end
+  supports_block_expectations
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
In Scout we are seeing ([example here](https://scoutapm.com/apps/156303/endpoints/Q29udHJvbGxlci9pbnZlc3RpZ2F0aW9ucy9pbmRleA==/trace/1704969432)) over 1,300 database queries taking over 450ms, on the case overview page. The Scout backtrace shows this is coming from rendering the list of users in the 'assigned to' filter list. There are a lot of n+1 database queries created by calling the `display_name` method on the lists of users and teams to render these forms.

The number of database queries is similar to the number of users +teams in the database, so the problem is getting worse as we add more users:

```
irb(main):001:0> User.count
=> 1084
irb(main):002:0> Team.count
=> 217
```

This change uses eager loading to eliminate most of those extra database queries and hopefully significantly improve page load time.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
