### PR TITLE
Improve focus styling to match govuk-frontend

### DIFF
--- a/psd-web/app/assets/stylesheets/autocomplete.scss
+++ b/psd-web/app/assets/stylesheets/autocomplete.scss
@@ -33,11 +33,6 @@
   padding: 5px;
 }
 
-.autocomplete__input--focused {
-  outline-offset: 0;
-  outline: 3px solid $govuk-focus-colour;
-}
-
 .autocomplete__input--show-all-values {
   padding: 5px 35px 5px 5px;
   cursor: pointer;
@@ -114,8 +109,8 @@
 
 .autocomplete__option--focused,
 .autocomplete__option:hover {
-  background-color: $govuk-link-colour;
-  border-color: $govuk-link-colour;
+  background-color: govuk-colour("blue");
+  border-color: govuk-colour("blue");
   color: govuk-colour("white");
   outline: none;
 }
@@ -141,7 +136,7 @@
 }
 
 .autocomplete-select-with-clear {
-  width: calc(100% - 48px);
+  width: calc(100% - 44px);
   display: inline-block;
 }
 
@@ -150,14 +145,12 @@
   border-color: transparent;
   cursor: pointer;
   width: 44px;
-  margin: 0 2px;
   display: inline-block;
   vertical-align: top;
 }
 
 .autocomplete__clear-button:focus {
-  outline: 3px solid $govuk-focus-colour;
-  outline-offset: 0;
+  @include govuk-focused-text;
 }
 
 .autocomplete__clear-viewbox {
@@ -188,5 +181,24 @@
   .autocomplete__wrapper input,
   .autocomplete__wrapper li {
     font-size: 19px;
+  }
+}
+
+// Focus styles can possibly be removed if we update to latest accessible autocomplete
+// Copied from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/input/_input.scss#L30
+.autocomplete__input--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  // Ensure outline appears outside of the element
+  outline-offset: 0;
+  // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
+  // components such as textarea where we avoid changing `border-width` as
+  // it will change the element size. Also, `outline` cannot be utilised
+  // here as it is already used for the yellow focus state.
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+
+  @include govuk-if-ie8 {
+    // IE8 doesn't support `box-shadow` so double the border with
+    // `border-width`.
+    border-width: $govuk-border-width-form-element * 2;
   }
 }

--- a/psd-web/app/assets/stylesheets/search-box.scss
+++ b/psd-web/app/assets/stylesheets/search-box.scss
@@ -1,25 +1,28 @@
 .search-box {
-
   position: relative;
   @include govuk-responsive-margin(2, "bottom");
-
-  &--submit {
-    position:   absolute;
-    right:      0;
-    bottom:     0;
-
-    width: 40px;
-    height: 40px;
-    font-size: 0;
-
-    background-size: 40px 40px;
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") $govuk-link-colour no-repeat top left;
-
-    border: 0;
-    cursor: pointer;
-  }
 
   .govuk-input {
     padding-right: 40px;
   }
+}
+
+.search-box--submit {
+  position:   absolute;
+  right:      0;
+  bottom:     0;
+
+  width: 40px;
+  height: 40px;
+  font-size: 0;
+
+  background-size: 40px 40px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") $govuk-link-colour no-repeat top left;
+
+  border: 0;
+  cursor: pointer;
+}
+
+.search-box--submit:focus {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
 }


### PR DESCRIPTION
Improves the focus styling of our autocompletes to match govuk-frontend.

Before:
<img width="590" alt="Screenshot 2019-12-27 at 14 18 51" src="https://user-images.githubusercontent.com/2204224/71520406-d968c300-28b3-11ea-970a-765c0415a24a.png">
<img width="602" alt="Screenshot 2019-12-27 at 14 18 55" src="https://user-images.githubusercontent.com/2204224/71520412-e1c0fe00-28b3-11ea-8966-fe150f424983.png">
<img width="355" alt="Screenshot 2019-12-27 at 14 18 39" src="https://user-images.githubusercontent.com/2204224/71520418-e5ed1b80-28b3-11ea-83fb-664a3af05281.png">

After:
<img width="748" alt="Screenshot 2019-12-27 at 14 03 24" src="https://user-images.githubusercontent.com/2204224/71520368-9dcdf900-28b3-11ea-9ad0-0520b96a9bfc.png">
<img width="597" alt="Screenshot 2019-12-27 at 14 03 29" src="https://user-images.githubusercontent.com/2204224/71520373-a6263400-28b3-11ea-94be-ea3d8b7c8121.png">
<img width="325" alt="Screenshot 2019-12-27 at 14 17 58" src="https://user-images.githubusercontent.com/2204224/71520380-b63e1380-28b3-11ea-9bf5-f2a9428fd6ac.png">
