### PR TITLE
Allow antivirus checks and other background jobs to work inline in RSpec suite

### DIFF
--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -93,12 +93,9 @@ jobs:
         PGHOST: localhost
         PGUSER: postgres
         RAILS_ENV: test
-        ANTIVIRUS_URL: ${{ secrets.AntivirusUrl }}
-        ANTIVIRUS_USERNAME: ${{ secrets.AntivirusUsername }}
-        ANTIVIRUS_PASSWORD: ${{ secrets.AntivirusPassword }}
       run: |
         cd psd-web
-        bin/rails db:setup
+        bin/rails db:create db:schema:load
     - name: Run Tests
       env:
         ELASTICSEARCH_URL: localhost

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -93,6 +93,9 @@ jobs:
         PGHOST: localhost
         PGUSER: postgres
         RAILS_ENV: test
+        ANTIVIRUS_URL: ${{ secrets.AntivirusUrl }}
+        ANTIVIRUS_USERNAME: ${{ secrets.AntivirusUsername }}
+        ANTIVIRUS_PASSWORD: ${{ secrets.AntivirusPassword }}
       run: |
         cd psd-web
         bin/rails db:setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
     ports:
       - 5432:5432
 
+  antivirus:
+    image: beisopss/antivirus:master
+    env_file:
+      - ./docker/env.antivirus
+    environment:
+      - PORT=3006
+    ports:
+      - "3006:3006"
+
   keycloak:
     image: beisopss/keycloak:master
     env_file:

--- a/docker/env.antivirus
+++ b/docker/env.antivirus
@@ -1,0 +1,5 @@
+# Note: These are DEVELOPMENT values only - not used in production
+
+# Antivirus API details
+ANTIVIRUS_USERNAME=av
+ANTIVIRUS_PASSWORD=password

--- a/psd-web/.env.development.example
+++ b/psd-web/.env.development.example
@@ -13,4 +13,6 @@ ELASTICSEARCH_URL=http://localhost:9200
 
 EMAIL_WHITELIST_ENABLED=false
 
-ANTIVIRUS_URL=http://antivirus
+ANTIVIRUS_URL=http://localhost:3006/safe
+ANTIVIRUS_USERNAME=av
+ANTIVIRUS_PASSWORD=password

--- a/psd-web/.env.development.example
+++ b/psd-web/.env.development.example
@@ -12,3 +12,5 @@ REDIS_URL=redis://localhost:6379
 ELASTICSEARCH_URL=http://localhost:9200
 
 EMAIL_WHITELIST_ENABLED=false
+
+ANTIVIRUS_URL=http://antivirus

--- a/psd-web/.env.test.example
+++ b/psd-web/.env.test.example
@@ -12,4 +12,6 @@ REDIS_HOST=localhost
 
 ELASTICSEARCH_URL=http://localhost:9200
 
-ANTIVIRUS_URL=http://antivirus
+ANTIVIRUS_URL=http://localhost:3006/safe
+ANTIVIRUS_USERNAME=av
+ANTIVIRUS_PASSWORD=password

--- a/psd-web/.env.test.example
+++ b/psd-web/.env.test.example
@@ -11,3 +11,5 @@ REDIS_URL=redis://localhost:6379
 REDIS_HOST=localhost
 
 ELASTICSEARCH_URL=http://localhost:9200
+
+ANTIVIRUS_URL=http://antivirus

--- a/psd-web/app/analyzers/anti_virus_analyzer.rb
+++ b/psd-web/app/analyzers/anti_virus_analyzer.rb
@@ -5,7 +5,7 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
 
   def metadata
     download_blob_to_tempfile do |file|
-      response = RestClient::Request.execute method: :post, url: ENV["ANTIVIRUS_URL"], user: ENV["ANTIVIRUS_USERNAME"], password: ENV["ANTIVIRUS_PASSWORD"], payload: { file: file }
+      response = RestClient::Request.execute method: :post, url: ENV.fetch("ANTIVIRUS_URL", "http://antivirus"), user: ENV["ANTIVIRUS_USERNAME"], password: ENV["ANTIVIRUS_PASSWORD"], payload: { file: file }
       body = JSON.parse(response.body)
       { safe: body["safe"] }
     end

--- a/psd-web/app/analyzers/anti_virus_analyzer.rb
+++ b/psd-web/app/analyzers/anti_virus_analyzer.rb
@@ -5,7 +5,7 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
 
   def metadata
     download_blob_to_tempfile do |file|
-      response = RestClient::Request.execute method: :post, url: ENV.fetch("ANTIVIRUS_URL", "http://antivirus"), user: ENV["ANTIVIRUS_USERNAME"], password: ENV["ANTIVIRUS_PASSWORD"], payload: { file: file }
+      response = RestClient::Request.execute method: :post, url: Rails.application.config.antivirus_url, user: ENV["ANTIVIRUS_USERNAME"], password: ENV["ANTIVIRUS_PASSWORD"], payload: { file: file }
       body = JSON.parse(response.body)
       { safe: body["safe"] }
     end

--- a/psd-web/config/application.rb
+++ b/psd-web/config/application.rb
@@ -37,6 +37,6 @@ module ProductSafetyDatabase
 
     config.email_whitelist_enabled = ENV.fetch("EMAIL_WHITELIST_ENABLED", "true") == "true"
 
-    config.antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://antivirus")
+    config.antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://localhost:3006/safe")
   end
 end

--- a/psd-web/config/application.rb
+++ b/psd-web/config/application.rb
@@ -36,5 +36,7 @@ module ProductSafetyDatabase
     config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
 
     config.email_whitelist_enabled = ENV.fetch("EMAIL_WHITELIST_ENABLED", "true") == "true"
+
+    config.antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://antivirus")
   end
 end

--- a/psd-web/config/environments/test.rb
+++ b/psd-web/config/environments/test.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   }
 
   config.action_mailer.default_url_options = { host: "test" }
+
+  config.active_job.queue_adapter = :inline
 end

--- a/psd-web/config/environments/test.rb
+++ b/psd-web/config/environments/test.rb
@@ -49,4 +49,6 @@ Rails.application.configure do
     host: ENV["HTTP_HOST"] || "localhost",
     port: ENV["HTTP_PORT"] || 3001
   }
+
+  config.action_mailer.default_url_options = { host: "test" }
 end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keycloak_config do
+RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keycloak_config, :with_stubbed_mailer do
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::TextHelper
   let(:organisation) { create :organisation }

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Adding a correcting action to a case", :with_keycloak_config, :with_elasticsearch do
+RSpec.feature "Adding a correcting action to a case", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus do
   let(:user) { create(:user, :activated) }
   let(:investigation) { create(:allegation, products: [create(:product_washing_machine)], assignee: user) }
 

--- a/psd-web/spec/features/assign_investigation_spec.rb
+++ b/psd-web/spec/features/assign_investigation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Assigning an investigation", type: :feature, with_keycloak_config: true, with_stubbed_elasticsearch: true do
+RSpec.feature "Assigning an investigation", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_mailer do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team]) }
   let(:investigation) { create(:allegation, assignee: user) }

--- a/psd-web/spec/features/filter_investigations_spec.rb
+++ b/psd-web/spec/features/filter_investigations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Case filtering", type: :feature, with_keycloak_config: true, with_elasticsearch: true do
+RSpec.feature "Case filtering", :with_keycloak_config, :with_elasticsearch, :with_stubbed_mailer do
   let(:organisation) { create(:organisation) }
   let(:team) { create(:team, organisation: organisation) }
   let(:other_team) { create(:team, organisation: organisation, name: "other team") }

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Reporting a product", :with_keycloak_config, :with_elasticsearch do
+RSpec.feature "Reporting a product", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   before { sign_in as_user: create(:user, :activated, :opss_user, has_viewed_introduction: true) }
 
   let(:reference_number) { Faker::Number.number(digits: 10) }

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Sending a product safety alert", type: :feature, with_keycloak_config: true, with_stubbed_elasticsearch: true do
+RSpec.feature "Sending a product safety alert", :with_keycloak_config, :with_stubbed_elasticsearch do
   let(:user) { create(:user, :activated, :opss_user) }
   let(:investigation) { create(:allegation) }
 

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Your team page", type: :feature, with_keycloak_config: true do
+RSpec.feature "Your team page", :with_keycloak_config do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team]) }
 

--- a/psd-web/spec/rails_helper.rb
+++ b/psd-web/spec/rails_helper.rb
@@ -62,4 +62,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  ActiveJob::Base.queue_adapter = :inline
 end

--- a/psd-web/spec/rails_helper.rb
+++ b/psd-web/spec/rails_helper.rb
@@ -62,6 +62,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-
-  ActiveJob::Base.queue_adapter = :inline
 end

--- a/psd-web/spec/support/antivirus.rb
+++ b/psd-web/spec/support/antivirus.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
+  before do
+    antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://antivirus")
+    stubbed_response = JSON.generate(safe: true)
+    stub_request(:any, /#{Regexp.quote(antivirus_url)}/).to_return(body: stubbed_response, status: 200)
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context "with stubbed Antivirus API", with_stubbed_antivirus: true
+end

--- a/psd-web/spec/support/antivirus.rb
+++ b/psd-web/spec/support/antivirus.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
   before do
-    antivirus_url = ENV.fetch("ANTIVIRUS_URL", "http://antivirus")
+    antivirus_url = Rails.application.config.antivirus_url
     stubbed_response = JSON.generate(safe: true)
     stub_request(:any, /#{Regexp.quote(antivirus_url)}/).to_return(body: stubbed_response, status: 200)
   end

--- a/psd-web/spec/support/mailer.rb
+++ b/psd-web/spec/support/mailer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with stubbed mailer", shared_context: :metadata do
+  before { allow_any_instance_of(NotifyMailer).to receive(:mail) { true } }
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context "with stubbed mailer", with_stubbed_mailer: true
+end

--- a/psd-web/test/controllers/investigations/tests_controller_test.rb
+++ b/psd-web/test/controllers/investigations/tests_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TestsControllerTest < ActionDispatch::IntegrationTest
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @product = products(:one)
   end

--- a/psd-web/test/controllers/products_controller_test.rb
+++ b/psd-web/test/controllers/products_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ProductsControllerTest < ActionDispatch::IntegrationTest
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @product_one = products(:one)
     @product_one.source = sources(:product_one)
     @product_iphone = products(:iphone)

--- a/psd-web/test/models/test_test.rb
+++ b/psd-web/test/models/test_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TestTest < ActiveSupport::TestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @product = products(:one)
   end

--- a/psd-web/test/system/activity_entry_test.rb
+++ b/psd-web/test/system/activity_entry_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class ActivityEntryTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     visit investigation_path(@investigation)
     click_on "Add activity"

--- a/psd-web/test/system/alert_test.rb
+++ b/psd-web/test/system/alert_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class AlertTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one).decorate
     @alert = alerts :one
     go_to_new_activity_for_investigation @investigation

--- a/psd-web/test/system/breadcrumb_test.rb
+++ b/psd-web/test/system/breadcrumb_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class BreadcrumbTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation_products = load_case(:search_related_products).decorate
     @product = @investigation_products.products.first
     @investigation_businesses = load_case(:search_related_businesses).decorate

--- a/psd-web/test/system/create_allegation_test.rb
+++ b/psd-web/test/system/create_allegation_test.rb
@@ -16,6 +16,7 @@ class CreateAllegationTest < ApplicationSystemTestCase
     )
 
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     visit new_allegation_path
   end
 

--- a/psd-web/test/system/create_enquiry_test.rb
+++ b/psd-web/test/system/create_enquiry_test.rb
@@ -17,6 +17,7 @@ class CreateEnquiryTest < ApplicationSystemTestCase
     ).decorate
 
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     visit new_enquiry_path
   end
 

--- a/psd-web/test/system/create_new_record_test.rb
+++ b/psd-web/test/system/create_new_record_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class CreateNewRecordTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     visit new_investigation_path
 
     assert_css "h1", text: "Create new"

--- a/psd-web/test/system/create_project_test.rb
+++ b/psd-web/test/system/create_project_test.rb
@@ -4,6 +4,7 @@ class CreateProjectTest < ApplicationSystemTestCase
   setup do
     @project = Investigation::Project.new(description: "new project description", user_title: "project title")
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     visit new_project_path
   end
 

--- a/psd-web/test/system/document_test.rb
+++ b/psd-web/test/system/document_test.rb
@@ -4,6 +4,7 @@ class DocumentTest < ApplicationSystemTestCase
   include UrlHelper
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
 
     visit new_investigation_new_path(load_case(:no_products))
   end

--- a/psd-web/test/system/introduction_test.rb
+++ b/psd-web/test/system/introduction_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class IntroductionTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     mock_user_as_non_opss User.current
 
     visit "/"

--- a/psd-web/test/system/investigation_assignee_test.rb
+++ b/psd-web/test/system/investigation_assignee_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationAssigneeTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @user = User.current
     @team = @user.teams.first
     visit new_investigation_assign_path(load_case(:one))

--- a/psd-web/test/system/investigation_business_test.rb
+++ b/psd-web/test/system/investigation_business_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationBusinessTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @business = businesses(:three)
     @business.source = sources(:business_three)

--- a/psd-web/test/system/investigation_default_opss_team_assignee_test.rb
+++ b/psd-web/test/system/investigation_default_opss_team_assignee_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationAssigneeTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify(name: "Ts_user") # non-OPSS
+    stub_antivirus_api
     @user = User.current
     @team = @user.teams.first
     Rails.application.config.team_names = {

--- a/psd-web/test/system/investigation_test_request_test.rb
+++ b/psd-web/test/system/investigation_test_request_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationTestRequestTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
 
     @investigation = load_case(:one)
     @test = tests(:one)

--- a/psd-web/test/system/investigation_test_result_test.rb
+++ b/psd-web/test/system/investigation_test_result_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationTestResultTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
 
     @investigation = load_case(:one)
     @test = tests(:one)

--- a/psd-web/test/system/products_test.rb
+++ b/psd-web/test/system/products_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class InvestigationSubNavigation < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
   end
 

--- a/psd-web/test/system/record_email_correspondence_test.rb
+++ b/psd-web/test/system/record_email_correspondence_test.rb
@@ -6,6 +6,7 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
 
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @investigation.source = sources(:investigation_one)
     set_investigation_source! @investigation, User.current

--- a/psd-web/test/system/record_meeting_correspondence_test.rb
+++ b/psd-web/test/system/record_meeting_correspondence_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class RecordMeetingCorrespondenceTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @investigation.source = sources(:investigation_one)
     @correspondence = correspondences(:meeting)

--- a/psd-web/test/system/record_phonecall_correspondence_test.rb
+++ b/psd-web/test/system/record_phonecall_correspondence_test.rb
@@ -7,6 +7,7 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
 
   setup do
     mock_out_keycloak_and_notify
+    stub_antivirus_api
     @investigation = load_case(:one)
     @investigation.source = sources(:investigation_one)
     set_investigation_source! @investigation, User.current

--- a/psd-web/test/system/update_product_test.rb
+++ b/psd-web/test/system/update_product_test.rb
@@ -4,6 +4,7 @@ class UpdateProductTest < ApplicationSystemTestCase
   setup do
     @product = products(:one)
     mock_out_keycloak_and_notify
+    stub_antivirus_api
   end
 
   teardown do

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -14,6 +14,10 @@ end
 require "rails/test_help"
 require "rspec/mocks/standalone"
 
+# Added Webmock only to allow use of stub_request - Minitest suite is deprecated
+require 'webmock/minitest'
+WebMock.allow_net_connect!
+
 class ActiveSupport::TestCase
   include ::RSpec::Mocks::ExampleMethods
 
@@ -39,6 +43,10 @@ class ActiveSupport::TestCase
 
   def setup
     self.class.import_into_elasticsearch
+  end
+
+  def teardown
+    WebMock.reset!
   end
 
   # On top of mocking out external services, this method also sets the user to an initial,
@@ -69,6 +77,12 @@ class ActiveSupport::TestCase
     User.load_from_keycloak
     sign_in_as User.find_by(name: "Test #{name}")
     stub_notify_mailer
+  end
+
+  def stub_antivirus_api
+    antivirus_url = Rails.application.config.antivirus_url
+    stubbed_response = JSON.generate(safe: true)
+    stub_request(:any, /#{Regexp.quote(antivirus_url)}/).to_return(body: stubbed_response, status: 200)
   end
 
   def sign_in_as(user)

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -15,7 +15,7 @@ require "rails/test_help"
 require "rspec/mocks/standalone"
 
 # Added Webmock only to allow use of stub_request - Minitest suite is deprecated
-require 'webmock/minitest'
+require "webmock/minitest"
 WebMock.allow_net_connect!
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This ensures that background jobs (including antivirus checks) run inline during RSpec specs.

It introduces a new requirement for `ANTIVIRUS_URL` environment variable to be set, otherwise an exception will be thrown. I've updated the example .env files to reflect this. Please copy the `ANTIVIRUS_*` env vars from the example to your `.env.development` file.

It doesn't mean the API always has to be run in development mode as it will normally fail silently in the background job if it can't connect. Running it will allow you to add attachments to cases, however.

I've added the `antivirus` service to the `docker-compose.yml` file to allow Antivirus to be run locally:

```bash
$ docker-compose up antivirus
```

This change also addresses minor issues with email notification in the test environment and adds helpers to stub mail sending and antivirus scanning.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
