### PR TITLE
Fix back links on case attachment pages

### DIFF
--- a/psd-web/app/helpers/url_helper.rb
+++ b/psd-web/app/helpers/url_helper.rb
@@ -1,19 +1,44 @@
 module UrlHelper
+  # Due to STI on the Investigation subclasses and renaming of the named routes
+  # polymorphic_path resolves to the wrong controller when given an instance of
+  # an Investigation subclass. This is a sticky plaster on a crazy design.
+  #
+  def path_for_model(object, *slug)
+    slug = Array(slug)
+
+    if object.is_a?(Investigation)
+      model = :investigation
+      param_key = slug.any? ? :investigation_pretty_id : :pretty_id
+      params = { param_key => object.pretty_id }
+    else
+      model = object
+      params = {}
+    end
+
+    polymorphic_path([model] + slug, params)
+  end
+
   # DOCUMENTS
+
+  # Unlike Business and Product, Investigation does not implement a /documents
+  # collection route, this is instead implemented as /attachments. But member
+  # routes are under /documents. But the model name is Attachments. Fun!
+  #
   def associated_documents_path(parent)
-    polymorphic_path([parent, :documents])
+    slug = parent.is_a?(Investigation) ? :attachments : :documents
+    path_for_model(parent, slug)
   end
 
   def associated_document_path(parent, document)
-    associated_documents_path(parent) + "/" + document.id.to_s
+    path_for_model(parent, :documents) + "/" + document.id.to_s
   end
 
   def new_associated_document_path(parent)
-    associated_documents_path(parent) + "/new"
+    path_for_model(parent, :documents) + "/new"
   end
 
   def new_document_flow_path(parent)
-    associated_documents_path(parent) + "/new/new"
+    path_for_model(parent, :documents) + "/new/new"
   end
 
   def edit_associated_document_path(parent, document)

--- a/psd-web/app/views/documents/edit.html.slim
+++ b/psd-web/app/views/documents/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title, "Edit document"
 - content_for :after_header do
-  = link_to "Back", polymorphic_path(@parent), class: "govuk-back-link"
+  = link_to "Back", path_for_model(@parent), class: "govuk-back-link"
 
 = render "metadata_form", document: @file, edit: true, target_url: associated_document_path(@parent, @file) do
   = render "page_heading", title: "Edit document details"

--- a/psd-web/app/views/documents/remove.html.slim
+++ b/psd-web/app/views/documents/remove.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title, "Remove attachment"
 - content_for :after_header do
-  = link_to "Back", polymorphic_path(@parent), class: "govuk-back-link"
+  = link_to "Back", path_for_model(@parent), class: "govuk-back-link"
 
 = render "page_heading", title: "Remove attachment"
 

--- a/psd-web/app/views/documents_flow/metadata.html.slim
+++ b/psd-web/app/views/documents_flow/metadata.html.slim
@@ -1,7 +1,7 @@
 - @parent = @parent.decorate
 - content_for :page_title, "New document"
 - content_for :after_header do
-  = link_to "Back to #{@parent.pretty_description}", @parent, class: "govuk-back-link"
+  = link_to "Back to #{@parent.pretty_description}", path_for_model(@parent), class: "govuk-back-link"
 
 = render "documents/metadata_form", document: @file_blob, edit: false, target_url: wizard_path do
   .govuk-grid-row

--- a/psd-web/app/views/documents_flow/upload.html.slim
+++ b/psd-web/app/views/documents_flow/upload.html.slim
@@ -1,7 +1,7 @@
 - @parent = @parent.decorate
 - content_for :page_title, "Add attachment"
 - content_for :after_header do
-  = link_to "Back to #{@parent.pretty_description}", @parent, class: "govuk-back-link"
+  = link_to "Back to #{@parent.pretty_description}", path_for_model(@parent), class: "govuk-back-link"
 
 = form_with scope: :document, url: wizard_path, method: :put, local: true do |form|
   .govuk-grid-row

--- a/psd-web/spec/factories/documents.rb
+++ b/psd-web/spec/factories/documents.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  trait :with_document do
+    transient do
+      document_file { Rails.root + "test/fixtures/files/test_result.txt" }
+      document_title { Faker::Lorem.sentence }
+      document_description { Faker::Lorem.paragraph }
+    end
+
+    after :create do |model, evaluator|
+      file = ActiveStorage::Blob.create_after_upload!(io: File.open(evaluator.document_file), filename: File.basename(evaluator.document_file), content_type: "text/plain", metadata: {
+        title: evaluator.document_title,
+        description: evaluator.document_description,
+        updated: Time.now.iso8601
+      })
+
+      model.documents.attach(file)
+    end
+  end
+end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -26,24 +26,6 @@ FactoryBot.define do
       user_title { "test project title" }
     end
 
-    trait :with_document do
-      transient do
-        document_file { Rails.root + "test/fixtures/files/test_result.txt" }
-        document_title { Faker::Lorem.sentence }
-        document_description { Faker::Lorem.paragraph }
-      end
-
-      after :create do |investigation, evaluator|
-        file = ActiveStorage::Blob.create_after_upload!(io: File.open(evaluator.document_file), filename: File.basename(evaluator.document_file), content_type: "text/plain", metadata: {
-          title: evaluator.document_title,
-          description: evaluator.document_description,
-          updated: Time.now.iso8601
-        })
-
-        investigation.documents.attach(file)
-      end
-    end
-
     trait :with_business do
       transient do
         business_to_add { create(:business) }

--- a/psd-web/spec/features/add_attachment_spec.rb
+++ b/psd-web/spec/features/add_attachment_spec.rb
@@ -69,13 +69,13 @@ RSpec.feature "Adding an attachment to a case", :with_stubbed_elasticsearch, :wi
   def expect_to_be_on_add_attachment_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/upload")
     expect(page).to have_selector("h1", text: "Add attachment")
-    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
+    expect(page).to have_link("Back", href: investigation_path(investigation))
   end
 
   def expect_to_be_on_enter_attachment_details_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
     expect(page).to have_selector("h3", text: "Document details")
-    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
+    expect(page).to have_link("Back", href: investigation_path(investigation))
   end
 
   def expect_to_be_on_case_overview_page

--- a/psd-web/spec/features/add_attachment_spec.rb
+++ b/psd-web/spec/features/add_attachment_spec.rb
@@ -69,11 +69,13 @@ RSpec.feature "Adding an attachment to a case", :with_keycloak_config, :with_stu
   def expect_to_be_on_add_attachment_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/upload")
     expect(page).to have_selector("h1", text: "Add attachment")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
   end
 
   def expect_to_be_on_enter_attachment_details_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
     expect(page).to have_selector("h3", text: "Document details")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
   end
 
   def expect_to_be_on_case_overview_page

--- a/psd-web/spec/features/delete_attachment_spec.rb
+++ b/psd-web/spec/features/delete_attachment_spec.rb
@@ -38,8 +38,9 @@ RSpec.feature "Deleting an attachment from a case", :with_keycloak_config, :with
   end
 
   def expect_to_be_on_remove_attachment_confirmation_page
-    expect(page).to have_current_path("/investigation/allegation/#{investigation.pretty_id}/documents/#{document.id}/remove")
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.id}/remove")
     expect(page).to have_selector("h2", text: "Remove attachment")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
   end
 
   def expect_to_be_on_case_overview_page

--- a/psd-web/spec/features/edit_attachment_spec.rb
+++ b/psd-web/spec/features/edit_attachment_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Editing an attachment on a case", :with_keycloak_config, :with_st
   def expect_to_be_on_edit_attachment_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.to_param}/edit")
     expect(page).to have_selector("h2", text: "Edit document details")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
   end
 
   def expect_case_attachments_page_to_show_entered_information

--- a/psd-web/spec/helpers/url_helper_spec.rb
+++ b/psd-web/spec/helpers/url_helper_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe UrlHelper do
+  describe "#path_for_model", :with_stubbed_elasticsearch do
+    let(:slug) { nil }
+
+    subject { helper.path_for_model(object, slug) }
+
+    context "with an instance of Investigation" do
+      let(:object) { create(:allegation, assignee: nil) }
+
+      context "with no slug" do
+        it "returns /cases/:pretty_id" do
+          expect(subject).to eq("/cases/#{object.pretty_id}")
+        end
+      end
+
+      context "with slug" do
+        let(:slug) { "attachments" }
+
+        it "returns /cases/:pretty_id/:slug" do
+          expect(subject).to eq("/cases/#{object.pretty_id}/attachments")
+        end
+      end
+    end
+
+    context "with an instance of Business" do
+      let(:object) { create(:business) }
+
+      context "with no slug" do
+        it "returns /businesses/:id" do
+          expect(subject).to eq("/businesses/#{object.id}")
+        end
+      end
+
+      context "with slug" do
+        let(:slug) { "documents" }
+
+        it "returns /businesses/:id/:slug" do
+          expect(subject).to eq("/businesses/#{object.id}/documents")
+        end
+      end
+    end
+  end
+
+  describe "#associated_documents_path", :with_stubbed_elasticsearch do
+    subject { helper.associated_documents_path(object) }
+
+    context "with an instance of Investigation" do
+      let(:object) { create(:allegation, assignee: nil) }
+
+      it "returns /cases/:pretty_id/attachments" do
+        expect(subject).to eq("/cases/#{object.pretty_id}/attachments")
+      end
+    end
+
+    context "with an instance of Business" do
+      let(:object) { create(:business) }
+
+      it "returns /businesses/:id/documents" do
+        expect(subject).to eq("/businesses/#{object.id}/documents")
+      end
+    end
+  end
+
+  describe "#associated_document_path", :with_stubbed_elasticsearch, :with_stubbed_antivirus do
+    let(:document) { object.documents.first }
+
+    subject { helper.associated_document_path(object, document) }
+
+    context "with an instance of Investigation" do
+      let(:object) { create(:allegation, :with_document, assignee: nil) }
+
+      it "returns /cases/:pretty_id/documents/:id" do
+        expect(subject).to eq("/cases/#{object.pretty_id}/documents/#{document.id}")
+      end
+    end
+
+    context "with an instance of Business" do
+      let(:object) { create(:business, :with_document) }
+
+      it "returns /businesses/:id/documents/:id" do
+        expect(subject).to eq("/businesses/#{object.id}/documents/#{document.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This is just a crude sticky plaster solution to fix the back links on the add/edit/remove attachment pages for a case, so that users don't see error messages. It should also resolve some exceptions we're seeing in Sentry due to the links routing to the wrong controller (which is part of the creation flow).

The changed page templates are shared for investigations/businesses/products, but there are big differences in how these three view template groups and routes work.

Businesses/products do not implement proper routes i.e. /products/:id/attachments, instead they implement a Javascript tab only, so the back links go to the overview page instead. It would be possible to add a further sticky plaster for investigations to go to `/attachments`, but I think if we want to go further we should just fix the crazy routing design.

The design really is crazy: the model association name for attachments is `documents`, but the model name for a document is resolved to `attachment` by the polymorphic route helpers. The route name is `documents`, so it is not resolved correctly, meaning it has to be overridden using [custom helpers](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/helpers/url_helper.rb).

Except the route name for *cases* is `attachments` on the `index` action only; member actions are called documents.  But the index action name on products/businesses is `documents`.

All of this means we have some crude URL helpers to maintain, which I've modified here.

There's plenty of other WTF in the attachments routing and behaviour, so to improve further we should consider rewriting this. The scope of this change is just to get the links working for users.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
