### PR TITLE
Fix Keycloak client test isolation

### DIFF
--- a/psd-web/spec/clients/keycloak_client_spec.rb
+++ b/psd-web/spec/clients/keycloak_client_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe KeycloakClient, :with_stubbed_keycloak_config do
+  subject { described_class.instance }
+
+  describe "#instance" do
+    it "does not retrieve Keycloak config on instantiation" do
+      expect(RestClient).not_to receive(:get)
+      subject
+    end
+  end
+
+  describe "#client" do
+    it "retrieves Keycloak config lazily" do
+      expect(subject.instance_variable_get(:@client)).to be_nil
+      expect(RestClient).to receive(:get).with("#{ENV.fetch('KEYCLOAK_AUTH_URL')}/realms/opss/.well-known/openid-configuration")
+      subject.client
+      expect(subject.instance_variable_get(:@client)).to be(Keycloak::Client)
+    end
+  end
+
+  describe "#admin" do
+    it "sets instance variable lazily" do
+      expect(subject.instance_variable_get(:@admin)).to be_nil
+      subject.admin
+      expect(subject.instance_variable_get(:@admin)).to be(Keycloak::Admin)
+    end
+  end
+
+  describe "#internal" do
+    it "sets instance variable lazily" do
+      expect(subject.instance_variable_get(:@internal)).to be_nil
+      subject.internal
+      expect(subject.instance_variable_get(:@internal)).to be(Keycloak::Internal)
+    end
+  end
+
+  describe "#reset" do
+    subject { described_class.instance }
+
+    it "resets instance variables" do
+      described_class.instance.client
+      described_class.instance.internal
+      described_class.instance.admin
+      described_class.instance.reset
+      expect(subject.instance_variable_get(:@client)).to be_nil
+      expect(subject.instance_variable_get(:@internal)).to be_nil
+      expect(subject.instance_variable_get(:@admin)).to be_nil
+    end
+  end
+end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_keycloak_config, :with_stubbed_mailer do
+RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbed_mailer do
   include ActionView::Helpers::DateHelper
   include ActionView::Helpers::TextHelper
   let(:organisation) { create :organisation }

--- a/psd-web/spec/features/add_attachment_spec.rb
+++ b/psd-web/spec/features/add_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Adding an attachment to a case", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Adding an attachment to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create(:user, :activated) }
   let(:investigation) { create(:allegation, assignee: user) }
   let(:file) { Rails.root + "test/fixtures/files/test_result.txt" }

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Adding a correcting action to a case", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create(:user, :activated) }
   let(:investigation) { create(:allegation, products: [create(:product_washing_machine)], assignee: user) }
 

--- a/psd-web/spec/features/assign_investigation_spec.rb
+++ b/psd-web/spec/features/assign_investigation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Assigning an investigation", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+RSpec.feature "Assigning an investigation", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team]) }
   let(:investigation) { create(:allegation, assignee: user) }

--- a/psd-web/spec/features/delete_attachment_spec.rb
+++ b/psd-web/spec/features/delete_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Deleting an attachment from a case", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Deleting an attachment from a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create(:user, :activated) }
   let(:investigation) { create(:allegation, :with_document, assignee: user) }
   let(:document) { investigation.documents.first }

--- a/psd-web/spec/features/edit_attachment_spec.rb
+++ b/psd-web/spec/features/edit_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Editing an attachment on a case", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Editing an attachment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create(:user, :activated) }
   let(:investigation) { create(:allegation, :with_document, assignee: user) }
   let(:document) { investigation.documents.first }

--- a/psd-web/spec/features/filter_investigations_spec.rb
+++ b/psd-web/spec/features/filter_investigations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Case filtering", :with_keycloak_config, :with_elasticsearch, :with_stubbed_mailer do
+RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:organisation) { create(:organisation) }
   let(:team) { create(:team, organisation: organisation) }
   let(:other_team) { create(:team, organisation: organisation, name: "other team") }

--- a/psd-web/spec/features/forbidden_spec.rb
+++ b/psd-web/spec/features/forbidden_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Access forbidden", :with_keycloak_config do
+RSpec.feature "Access forbidden", :with_stubbed_keycloak_config do
   scenario "Logging in when user does not yet exist and has no groups" do
     sign_in(as_user: build(:user, organisation: nil))
     visit "/cases"

--- a/psd-web/spec/features/help_pages_spec.rb
+++ b/psd-web/spec/features/help_pages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Help pages", :with_keycloak_config do
+RSpec.feature "Help pages", :with_stubbed_keycloak_config do
   scenario "User signed out" do
     sign_out
 

--- a/psd-web/spec/features/home_page_spec.rb
+++ b/psd-web/spec/features/home_page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Home page", :with_keycloak_config, :with_elasticsearch do
+RSpec.feature "Home page", :with_elasticsearch, :with_stubbed_keycloak_config do
   context "User signed out" do
     scenario "shows the home page" do
       sign_out

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Reporting a product", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
+RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   before { sign_in as_user: create(:user, :activated, :opss_user, has_viewed_introduction: true) }
 
   let(:reference_number) { Faker::Number.number(digits: 10) }

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Sending a product safety alert", :with_keycloak_config, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create(:user, :activated, :opss_user) }
   let(:investigation) { create(:allegation) }
 

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Your team page", :with_keycloak_config do
+RSpec.feature "Your team page", :with_stubbed_keycloak_config do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team]) }
 

--- a/psd-web/spec/models/alert_spec.rb
+++ b/psd-web/spec/models/alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Alert, with_keycloak_config: true do
+RSpec.describe Alert do
   describe "#send_alert_email" do
     subject(:alert) { described_class.new(summary: "test", description: "test") }
 

--- a/psd-web/spec/models/investigation_spec.rb
+++ b/psd-web/spec/models/investigation_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 # TODO: Refactor Investigation model to remove callback hell and dependency on User.current
 RSpec.shared_examples "an Investigation" do
-  describe "record creation", :with_stubbed_elasticsearch, :with_keycloak_config do
+  describe "record creation", :with_stubbed_elasticsearch do
     let(:user) { create(:user) }
     let(:investigation) { build(factory) }
 
@@ -28,7 +28,7 @@ RSpec.shared_examples "an Investigation" do
   # needed to improve the relevance of the results. We should then add
   # assertions that irrelevant records are *not* returned here.
   #
-  describe ".full_search", :with_elasticsearch, :with_keycloak_config, :with_stubbed_mailer do
+  describe ".full_search", :with_elasticsearch, :with_stubbed_mailer do
     let(:product) { create(:product_iphone) }
     let(:correspondence) { create(:correspondence) }
     let(:business) { create(:business) }

--- a/psd-web/spec/models/team_spec.rb
+++ b/psd-web/spec/models/team_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Team do
     end
   end
 
-  describe "#display_name", with_keycloak_config: true do
+  describe "#display_name" do
     subject(:team) { create(:team, organisation: organisation) }
 
     let(:organisation) { create(:organisation) }

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe User, with_keycloak_config: true do
+RSpec.describe User do
   describe ".activated" do
     it "returns only users with activated accounts" do
       create(:user, :inactive)
@@ -59,7 +59,7 @@ RSpec.describe User, with_keycloak_config: true do
     end
   end
 
-  describe "#roles", with_keycloak_config: true do
+  describe "#roles" do
     subject(:user) { build(:user) }
 
     before do

--- a/psd-web/spec/requests/home_page_spec.rb
+++ b/psd-web/spec/requests/home_page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "HomePage", :with_keycloak_config, :with_elasticsearch do
+RSpec.describe "HomePage", :with_elasticsearch do
   context "when not signed in" do
     before do
       allow(KeycloakClient.instance).to receive(:user_signed_in?).and_return(false)

--- a/psd-web/spec/requests/sign_in_spec.rb
+++ b/psd-web/spec/requests/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "sign in callback route", :with_keycloak_config do
+RSpec.describe "sign in callback route" do
   let(:auth_code) { "test" }
   let(:request_path) { "" }
 
@@ -8,7 +8,7 @@ RSpec.describe "sign in callback route", :with_keycloak_config do
 
   subject { get(signin_session_path, params: { code: auth_code, request_path: request_path }) }
 
-  context "when an error occurs exchanging the authorization code for a token with Keycloak" do
+  context "when an error occurs exchanging the authorization code for a token with Keycloak", :with_stubbed_keycloak_config do
     let(:redirect_uri) { keycloak_login_url(redirect_uri: signin_session_url(params: { request_path: request_path })) }
 
     before { allow(KeycloakClient.instance).to receive(:exchange_code_for_token).with(auth_code, kind_of(String)).and_raise(exception) }

--- a/psd-web/spec/requests/user_declaration_spec.rb
+++ b/psd-web/spec/requests/user_declaration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User accepting declaration", type: :request, with_keycloak_config: true do
+RSpec.describe "User accepting declaration", type: :request, with_stubbed_keycloak_config: true do
   let(:user) { create(:user) }
 
   before { sign_in(as_user: user) }

--- a/psd-web/spec/services/user_declaration_spec.rb
+++ b/psd-web/spec/services/user_declaration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe UserDeclarationService, with_keycloak_config: true do
+describe UserDeclarationService do
   describe ".accept_declaration" do
     let(:user) { create(:user, has_accepted_declaration: false, account_activated: false) }
     let(:mailer) { double("mailer", deliver_later: true) }

--- a/psd-web/spec/support/keycloak.rb
+++ b/psd-web/spec/support/keycloak.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.shared_context "with Keycloak configuration", shared_context: :metadata do
+RSpec.shared_context "with stubbed Keycloak configuration", shared_context: :metadata do
   let(:openid_config) { file_fixture("keycloak_openid_config.json").read.gsub("http://keycloak:8080/auth", ENV.fetch("KEYCLOAK_AUTH_URL")) }
   let(:response_double) { double("OpenID response", code: 200, body: openid_config) }
   before { allow(RestClient).to receive(:get).with("#{ENV.fetch('KEYCLOAK_AUTH_URL')}/realms/opss/.well-known/openid-configuration") { response_double } }
+  after { KeycloakClient.instance.reset }
 end
 
 RSpec.configure do |rspec|
-  rspec.include_context "with Keycloak configuration", with_keycloak_config: true
+  rspec.include_context "with stubbed Keycloak configuration", with_stubbed_keycloak_config: true
 end

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -106,6 +106,8 @@ class ActiveSupport::TestCase
     allow(NotifyMailer).to receive(:investigation_updated).and_call_original
     allow(NotifyMailer).to receive(:investigation_created).and_call_original
     allow(NotifyMailer).to receive(:user_added_to_team).and_call_original
+
+    @keycloak_client_instance.reset
   end
 
   def stub_notify_mailer


### PR DESCRIPTION
## Description
The `KeycloakClient` singleton class was designed in such a way as state was persisted between tests, and it would also make a request to the OpenID configuration endpoint immediately upon instantiation, which wasn't always necessary.

This manifested in [errors](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/123/checks?check_run_id=369212250) depending on the spec suite run order if the Keycloak config wasn't stubbed correctly. Sometimes it would give a false positive if a previous test had already stubbed it. There were two model tests which were not stubbing the Keycloak config correctly.

It also meant that you had to stub the endpoint just to create a user with a factory, even if `KeycloakClient` was never called again.

This change ensures that the `KeycloakClient` state can be reset after each test, and lazily calls the configuration endpoint. This meant I could remove some unnecessary stubbing in some tests and it also yielded a small performance improvement of about 4 seconds on my machine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
