### PR TITLE
Fix Sentry and Sidekiq env vars on review apps

### DIFF
--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -11,6 +11,7 @@ applications:
   env:
     PSD_HOST: ((psd-host))
     SIDEKIQ_QUEUE: ((sidekiq-queue))
+    SENTRY_CURRENT_ENV: ((sentry-current-env))
   command: export $(./env/get-env-from-vcap.sh) && ES_NAMESPACE=((psd-instance-name)) STATEMENT_TIMEOUT=60s SAFETY_ASSURED=1 bin/rake cf:on_first_instance db:migrate db:seed keycloak:sync && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   stack: cflinuxfs3
   services:
@@ -34,6 +35,10 @@ applications:
     - ruby_buildpack
   instances: 1
   path: .
+  env:
+    PSD_HOST: ((psd-host))
+    SIDEKIQ_QUEUE: ((sidekiq-queue))
+    SENTRY_CURRENT_ENV: ((sentry-current-env))
   command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
   no-route: true
   health-check-type: process


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
These changes were lost [when migrating to rolling deployments](https://github.com/UKGovernmentBEIS/beis-opss-psd/commit/d38420f9b3d153c9d4b3a194b835e7a29eac9345#diff-ab23bd9f27daaf8761d83809ecc38f46). This meant that background jobs (antivirus scans and emails) were not being processed, and exceptions were being tagged with the `production` environment.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
