### PR TITLE
Fix factories which populate date_attribute properties

### DIFF
--- a/psd-web/spec/factories/corrective_actions.rb
+++ b/psd-web/spec/factories/corrective_actions.rb
@@ -3,15 +3,19 @@ FactoryBot.define do
     investigation
     product
     summary { Faker::Lorem.sentence }
-    date_decided_day { Faker::Date.backward(days: 14).day }
-    date_decided_month { Faker::Date.backward(days: 14).month }
-    date_decided_year { Faker::Date.backward(days: 14).year }
+    date_decided_day { date_decided.day }
+    date_decided_month { date_decided.month }
+    date_decided_year { date_decided.year }
     legislation { Rails.application.config.legislation_constants["legislation"].sample }
     measure_type { CorrectiveAction::MEASURE_TYPES.sample }
     duration { CorrectiveAction::DURATION_TYPES.sample }
     geographic_scope { Rails.application.config.corrective_action_constants["geographic_scope"].sample }
     details { Faker::Lorem.sentence }
     related_file { "No" }
+
+    transient do
+      date_decided { Faker::Date.backward(days: 14) }
+    end
 
     trait :with_file do
       related_file { "Yes" }

--- a/psd-web/spec/factories/correspondences.rb
+++ b/psd-web/spec/factories/correspondences.rb
@@ -7,9 +7,13 @@ FactoryBot.define do
     email_subject { Faker::Lorem.sentence }
     email_direction { "from" }
     phone_number { Faker::PhoneNumber.phone_number }
-    correspondence_date_day { Faker::Date.backward(days: 14).day }
-    correspondence_date_month { Faker::Date.backward(days: 14).month }
-    correspondence_date_year { Faker::Date.backward(days: 14).year }
+    correspondence_date_day { correspondence_date.day }
+    correspondence_date_month { correspondence_date.month }
+    correspondence_date_year { correspondence_date.year }
     contact_method { %w[phone email].sample }
+
+    transient do
+      correspondence_date { Faker::Date.backward(days: 14) }
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes factories which populate a `date_attribute` property. When the date is at the threshold of a year, sometimes the dates produced could be in the future because the day/month/year were generated independently.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
