### PR TITLE
Small tweaks to title algorithm

### DIFF
--- a/psd-web/app/decorators/investigation/allegation_decorator.rb
+++ b/psd-web/app/decorators/investigation/allegation_decorator.rb
@@ -1,8 +1,8 @@
 class Investigation < ApplicationRecord
   class AllegationDecorator < InvestigationDecorator
     def title
-      title = build_title_from_products || ""
-      title << " – #{object.hazard_type}" if object.hazard_type.present?
+      title = build_title_from_products || "Allegation"
+      title << " – #{object.hazard_type.downcase} hazard" if object.hazard_type.present?
       title << " (no product specified)" if object.products.empty?
       title.presence || "Untitled case"
     end
@@ -17,7 +17,7 @@ class Investigation < ApplicationRecord
       return object.product_category.dup if object.products.empty?
 
       title_components = []
-      title_components << "#{object.products.length} Products" if object.products.length > 1
+      title_components << "#{object.products.length} products" if object.products.length > 1
       title_components << get_product_property_value_if_shared(:name)
       title_components << get_product_property_value_if_shared(:product_type)
       title_components.reject(&:blank?).join(", ")

--- a/psd-web/spec/decorators/investigation/allegation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation/allegation_decorator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Investigation::AllegationDecorator do
           expect(allegation.decorate.title).to eq("iPhone XS MAX, phone – asphyxiation hazard")
         end
       end
-      context "with two produtcs" do
+      context "with two products" do
         context "with two common values" do
           let!(:allegation) { investigations :two_products_with_common_values }
 
@@ -40,7 +40,7 @@ RSpec.describe Investigation::AllegationDecorator do
     context "when no products are present on the case" do
       let(:allegation) { investigations :no_products_case_title }
 
-      it "has the corect title" do
+      it "has the correct title" do
         expect(subject.title).to eq("Alarms – asphyxiation hazard (no product specified)")
       end
     end

--- a/psd-web/spec/decorators/investigation/allegation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation/allegation_decorator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Investigation::AllegationDecorator do
     context "when products are present" do
       context "with one product" do
         it "produces the correct title" do
-          expect(allegation.decorate.title).to eq("iPhone XS MAX, phone – Asphyxiation")
+          expect(allegation.decorate.title).to eq("iPhone XS MAX, phone – asphyxiation hazard")
         end
       end
       context "with two produtcs" do
@@ -23,7 +23,7 @@ RSpec.describe Investigation::AllegationDecorator do
           let!(:allegation) { investigations :two_products_with_common_values }
 
           it "produces the correct title" do
-            expect(allegation.decorate.title).to eq("2 Products, phone – Asphyxiation")
+            expect(allegation.decorate.title).to eq("2 products, phone – asphyxiation hazard")
           end
         end
 
@@ -31,7 +31,7 @@ RSpec.describe Investigation::AllegationDecorator do
           let!(:allegation) { investigations :two_products_with_no_common_values }
 
           it "produces the correct title" do
-            expect(allegation.decorate.title).to eq("2 Products – Asphyxiation")
+            expect(allegation.decorate.title).to eq("2 products – asphyxiation hazard")
           end
         end
       end
@@ -41,7 +41,7 @@ RSpec.describe Investigation::AllegationDecorator do
       let(:allegation) { investigations :no_products_case_title }
 
       it "has the corect title" do
-        expect(subject.title).to eq("Alarms – Asphyxiation (no product specified)")
+        expect(subject.title).to eq("Alarms – asphyxiation hazard (no product specified)")
       end
     end
   end

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -244,13 +244,13 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     expect(page).to have_selector("h1", text: "Case created")
     expect_no_error_messages
     expect(page).to have_text(/Case ID: ([\d-]+)/)
-    expect(page).to have_text("#{product_details[:name]}, #{product_details[:type]} – #{hazard_type} has now been assigned to you")
+    expect(page).to have_text("#{product_details[:name]}, #{product_details[:type]} – #{hazard_type.downcase} hazard has now been assigned to you")
   end
 
   def expect_case_details_page_to_show_entered_information
     expect(page).to have_selector("h1", text: "Overview")
 
-    expect(page).to have_text("#{product_details[:name]}, #{product_details[:type]} – #{hazard_type}")
+    expect(page).to have_text("#{product_details[:name]}, #{product_details[:type]} – #{hazard_type.downcase} hazard")
     expect(page).to have_text("Product reported because it is unsafe and non-compliant.")
 
     expect(page.find("dt", text: "Trading Standards reference")).to have_sibling("dd", text: reference_number)


### PR DESCRIPTION
Some small tweaks to the allegation title algorithm:

* Use sentence case rather than title case
* append 'hazard' to hazard type
* Include name 'Allegation' for edge case where a case has no products and no product category.


## Examples:

### Before:
**Electrical appliances and equipment – Fire (no product specified)**
### After:
**Electrical appliances and equipment – fire hazard (no product specified)**
### Before:
**Electric 546 Shaver, Shaver – Other**
### After:
**Electric 546 Shaver, Shaver – other hazard**