### PR TITLE
Add missing database indexes

### DIFF
--- a/psd-web/db/migrate/20200103185949_add_missing_indexes.rb
+++ b/psd-web/db/migrate/20200103185949_add_missing_indexes.rb
@@ -1,0 +1,8 @@
+class AddMissingIndexes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :sources, %i[sourceable_id sourceable_type], algorithm: :concurrently
+    add_index :investigations, :updated_at, algorithm: :concurrently
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_162619) do
+ActiveRecord::Schema.define(version: 2020_01_03_185949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_162619) do
     t.string "user_title"
     t.index ["assignable_type", "assignable_id"], name: "index_investigations_on_assignable_type_and_assignable_id"
     t.index ["pretty_id"], name: "index_investigations_on_pretty_id"
+    t.index ["updated_at"], name: "index_investigations_on_updated_at"
   end
 
   create_table "locations", id: :serial, force: :cascade do |t|
@@ -222,6 +223,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_162619) do
     t.string "type"
     t.datetime "updated_at", null: false
     t.uuid "user_id"
+    t.index ["sourceable_id", "sourceable_type"], name: "index_sources_on_sourceable_id_and_sourceable_type"
     t.index ["user_id"], name: "index_sources_on_user_id"
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
While investigating the broken export functionality, I reviewed the generated SQL statement and identified two missing indexes which would benefit the query. There are multiple joins on the polymorphic `sources` table, and the entire result set is ordered by `updated_at`.

I'm not sure if this will entirely fix the problem; we might have to increase the statement timeout, but hopefully not.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
