### PR TITLE
Fix export

### DIFF
--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -19,13 +19,14 @@ class InvestigationsController < ApplicationController
       format.xlsx do
         @answer = search_for_investigations
         @investigations = Investigation.eager_load(:complainant,
-                                                   :source,
-                                                   { products: :source },
-                                                   { activities: :source },
-                                                   { businesses: %i[locations source] },
-                                                   :corrective_actions,
-                                                   :correspondences,
-                                                   :tests).where(id: @answer.results.map(&:_id))
+                                                   :source).where(id: @answer.results.map(&:_id))
+
+        @activity_counts = Activity.group(:investigation_id).count
+        @business_counts = InvestigationBusiness.unscoped.group(:investigation_id).count
+        @product_counts = InvestigationProduct.unscoped.group(:investigation_id).count
+        @corrective_action_counts = CorrectiveAction.group(:investigation_id).count
+        @correspondence_counts = Correspondence.group(:investigation_id).count
+        @test_counts = Test.group(:investigation_id).count
       end
     end
   end

--- a/psd-web/app/views/investigations/index.xlsx.axlsx
+++ b/psd-web/app/views/investigations/index.xlsx.axlsx
@@ -20,12 +20,12 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
       complainant.present? ? complainant&.email_address : "",
       complainant.present? ? complainant&.phone_number : "",
       complainant&.complainant_type,
-      investigation.products.length,
-      investigation.businesses.length,
-      investigation.activities.length,
-      investigation.correspondences.length,
-      investigation.corrective_actions.length,
-      investigation.tests.length
+      @product_counts[investigation.id] || 0,
+      @business_counts[investigation.id] || 0,
+      @activity_counts[investigation.id] || 0,
+      @correspondence_counts[investigation.id] || 0,
+      @corrective_action_counts[investigation.id] || 0,
+      @test_counts[investigation.id] || 0
     ], types: :text
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Following the adding of the missing database indexes, we are still getting statement timeouts, albeit the query can be run successfully with one less association eager loaded.

I discovered that a lot of the data being pulled in the controller wasn't actually being rendered in the template; we're just displaying the counts of most associated records. This change makes the database queries much more efficient and should hopefully mean that the export works in production.

I've tested and compared the data output before/after the change is the same using the seed data.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
