### PR TITLE
Fix pagination

### DIFF
--- a/psd-web/app/controllers/businesses_controller.rb
+++ b/psd-web/app/controllers/businesses_controller.rb
@@ -13,7 +13,7 @@ class BusinessesController < ApplicationController
   # GET /businesses
   # GET /businesses.json
   def index
-    @businesses = search_for_businesses(20).decorate
+    @businesses = search_for_businesses(20)
   end
 
   # GET /businesses/1

--- a/psd-web/app/controllers/products_controller.rb
+++ b/psd-web/app/controllers/products_controller.rb
@@ -12,7 +12,7 @@ class ProductsController < ApplicationController
   # GET /products
   # GET /products.json
   def index
-    @products = search_for_products(20).decorate
+    @products = search_for_products(20)
   end
 
   # GET /products/1

--- a/psd-web/app/decorators/businesses_decorator.rb
+++ b/psd-web/app/decorators/businesses_decorator.rb
@@ -1,3 +1,3 @@
 class BusinessesDecorator < Draper::CollectionDecorator
-  delegate :current_page, :total_pages, :limit_value
+  delegate :current_page, :total_entries, :total_pages, :per_page, :offset
 end

--- a/psd-web/app/decorators/products_decorator.rb
+++ b/psd-web/app/decorators/products_decorator.rb
@@ -1,3 +1,3 @@
 class ProductsDecorator < Draper::CollectionDecorator
-  delegate :current_page, :total_pages, :limit_value
+  delegate :current_page, :total_entries, :total_pages, :per_page, :offset
 end

--- a/psd-web/app/helpers/businesses_helper.rb
+++ b/psd-web/app/helpers/businesses_helper.rb
@@ -8,17 +8,26 @@ module BusinessesHelper
   end
 
   def search_for_businesses(page_size)
-    Business.full_search(search_query)
-      .records
-      .paginate(page: params[:page], per_page: page_size)
+    BusinessDecorator.decorate_collection(
+      Business.full_search(search_query)
+        .page(params[:page])
+        .per_page(page_size)
+        .records
+    )
+  end
+
+  def sorting_params
+    return {} if params[:sort] == "relevance"
+
+    { created_at: :desc }
   end
 
   def sort_column
-    Business.column_names.include?(params[:sort]) ? params[:sort] : "legal_name"
+    Business.column_names.include?(params[:sort]) ? params[:sort] : "created_at"
   end
 
   def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : "desc"
   end
 
   def set_countries

--- a/psd-web/app/helpers/products_helper.rb
+++ b/psd-web/app/helpers/products_helper.rb
@@ -11,17 +11,16 @@ module ProductsHelper
   end
 
   def search_for_products(page_size)
-    Product.full_search(search_query)
-      .records
-      .paginate(page: params[:page], per_page: page_size)
+    ProductDecorator.decorate_collection(
+      Product.full_search(search_query)
+        .page(params[:page]).per_page(page_size).records
+    )
   end
 
-  def sort_column
-    Product.column_names.include?(params[:sort]) ? params[:sort] : "name"
-  end
+  def sorting_params
+    return {} if params[:sort] == "relevance"
 
-  def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+    { created_at: :desc }
   end
 
   # If the user supplies a barcode then just return that.

--- a/psd-web/spec/features/busisnesses_spec.rb
+++ b/psd-web/spec/features/busisnesses_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config  do
+  let(:user) { create :user, :activated }
+
+  before { create_list :business, 21, created_at: 4.days.ago }
+
+  scenario "lists products according to search relevance" do
+    sign_in(as_user: user)
+    visit businesses_path
+
+    expect(page).to have_css(".pagination em.current", text: 1)
+    expect(page).to have_link("2", href: businesses_path(page: 2))
+    expect(page).to have_link("Next →", href: businesses_path(page: 2))
+  end
+end

--- a/psd-web/spec/features/busisnesses_spec.rb
+++ b/psd-web/spec/features/busisnesses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config  do
+RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create :user, :activated }
 
   before { create_list :business, 21, created_at: 4.days.ago }

--- a/psd-web/spec/features/products_spec.rb
+++ b/psd-web/spec/features/products_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config  do
+  let(:user) { create :user, :activated }
+
+  before { create_list :product, 21, created_at: 4.days.ago }
+
+  scenario "lists products according to search relevance" do
+    sign_in(as_user: user)
+    visit products_path
+
+    expect(page).to have_css(".pagination em.current", text: 1)
+    expect(page).to have_link("2", href: products_path(page: 2))
+    expect(page).to have_link("Next →", href: products_path(page: 2))
+  end
+end

--- a/psd-web/spec/features/products_spec.rb
+++ b/psd-web/spec/features/products_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config  do
+RSpec.describe "Busisnesses listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config do
   let(:user) { create :user, :activated }
 
   before { create_list :product, 21, created_at: 4.days.ago }


### PR DESCRIPTION
Fix missing pagination on Business and Product listing pages

https://trello.com/c/1WWJQVmN/266-can-only-view-10-products-on-the-product-page-and-10-businesses-on-the-business-page

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
