### PR TITLE
Remove basic auth config from production

### DIFF
--- a/psd-web/deploy.sh
+++ b/psd-web/deploy.sh
@@ -66,11 +66,6 @@ fi
 # Unmap the temporary hostname from the new app
 cf unmap-route $NEW_APP $DOMAIN --hostname $NEW_HOSTNAME
 
-# Remove basic auth if we're deploying to production
-if [[ $SPACE == "prod" ]]; then
-    cf unbind-service $NEW_APP psd-auth-env
-fi
-
 # Map the live hostname to the new app
 cf set-env $NEW_APP PSD_HOST "$HOSTNAME.$DOMAIN"
 cf restart $NEW_APP

--- a/psd-web/manifest.prod.yml
+++ b/psd-web/manifest.prod.yml
@@ -12,7 +12,6 @@ web_defaults: &web_defaults
   services:
     - opss-log-drain
     - psd-aws-env
-    - psd-auth-env
     - psd-database
     - psd-elasticsearch
     - psd-email-whitelist-env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
We no longer need basic auth on production.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
