### PR TITLE
Render out image rotation rather than using exif

### DIFF
--- a/psd-web/app/views/documents/_image_tag.html.slim
+++ b/psd-web/app/views/documents/_image_tag.html.slim
@@ -1,5 +1,5 @@
 - if image.variable?
   - class_name ||= 'app-image'
-  = image_tag image.variant(resize: dimensions), class: class_name, alt: image.metadata["title"]
+  = image_tag image.variant(resize: dimensions, auto_orient: true), class: class_name, alt: image.metadata["title"]
 - else
     span = "Preview not available: " + image.metadata["title"]


### PR DESCRIPTION
We've started noticing cases with images with the wrong rotation.

After some investigation it seems to be [related to this issue](https://stackoverflow.com/questions/42401203/chrome-image-exif-orienation-issue), where browsers (Chrome and Safari at least) don't respect the exif image orientation. This will tend to effect images taken with smartphones which are more likely to use this attribute.

As we're using ImageMagic to make previews, we can pass an option to fix this, effectively to ['render out' the rotation](https://imagemagick.org/script/command-line-options.php#auto-orient) in our thumbnails.

Before:
![Screenshot 2020-01-20 at 15 22 45](https://user-images.githubusercontent.com/2204224/72738098-bff82580-3b98-11ea-9757-4b0b5078134e.png)

After:
![Screenshot 2020-01-20 at 15 23 17](https://user-images.githubusercontent.com/2204224/72738118-d0a89b80-3b98-11ea-9dc0-89ea484fbfd7.png)