### PR TITLE
Extend Readme with needed environment vars setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Refer to the `docker-compose.yml` file for a list of available services.
 You will need to have Redis, PostgreSQL and Elasticsearch running, either locally or via Docker as detailed above.
 
 Copy the file in the `psd-web` directory called `.env.development.example` to `.env.development`, and modify as appropriate.
+You will need to set `KEYCLOAK_CLIENT_SECRET` value corresponding to `KEYCLOAK_CLIENT_ID` value. The client secret is accessible through the Keycloak admin console.
 
 See the [accounts section](#accounts) below for information on how to obtain some of the optional variables.
 
@@ -60,6 +61,7 @@ Start the services:
 
 
 ### Tests
+Copy the file in the `psd-web` directory called `.env.test.example` to `.env.test`, and modify as appropriate.
 
 New tests are written in RSpec. There should be a feature spec covering new user journeys, and unit testing of all code components.
 
@@ -96,7 +98,7 @@ The development instance of Keycloak is configured with the following default us
 * Trading Standards user: `msa@example.com` / `password`
 * Admin Console: `admin` / `admin`
 
-Log in to the [Keycloak admin console](http://keycloak:8080/auth/admin) to add or edit users.
+Log in to the [Keycloak admin console](http://keycloak:8080/auth/admin) to add/edit users or to obtain client credentials.
 
 Ask someone on the team to create an account for you on the Int and Staging environments.
 


### PR DESCRIPTION
## Description

While trying to run the project in my machine I noticed that:

- KEYCLOACK_CLIENT_SECRET value is needed in order to correctly run the
  service locally without authentication errors against KEYCLOACK.

- The .env.test file needs to be setup in order to successfully run the
  tests locally.

This commit documents both processes in the Readme.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.

### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
