### PR TITLE
Fix Sidekiq Web Forbidden errors

### DIFF
--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -1,6 +1,8 @@
 require "sidekiq/web"
 require "sidekiq/cron/web"
 
+Sidekiq::Web.set :session_secret, Rails.application.credentials[:secret_key_base]
+
 if Rails.env.production?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     ActiveSupport::SecurityUtils.secure_compare(username, ENV["SIDEKIQ_USERNAME"]) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
I've been getting a lot of `Forbidden` error messages on Sidekiq web in production when re-queueing failed jobs. The web application log shows errors such as:

```
   2020-01-24T14:51:10.36+0000 [APP/PROC/WEB/0] ERR W, [2020-01-24T14:51:10.365192 #17]  WARN -- : attack prevented by Rack::Protection::AuthenticityToken
```

This seems to be related to https://github.com/mperham/sidekiq/wiki/Monitoring#forbidden so I've applied the suggested fix here.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
