### PR TITLE
CloudFoundry ruby buildpack update

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.16.x
+        node-version: 10.18.x
 
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.18.x
+        node-version: 10.19.x
 
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,8 +52,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.16.x
-
+        node-version: 10.18.x
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.18.x
+        node-version: 10.19.x
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev
 

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.18.x
+        node-version: 10.19.x
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev
 

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -50,8 +50,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.16.x
-
+        node-version: 10.18.x
     - name: Install PostgreSQL client
       run: sudo apt-get install libpq-dev
 

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -618,4 +618,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.10
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
   path: .
   stack: cflinuxfs3
   routes:

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.10
   path: .
   stack: cflinuxfs3
   routes:

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.10
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
   path: .
   stack: cflinuxfs3
   routes:

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.10
   path: .
   stack: cflinuxfs3
   routes:

--- a/psd-web/package.json
+++ b/psd-web/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "engines": {
-    "node": "10.18.x",
-    "yarn": "1.21.x"
+    "node": "10.19.x",
+    "yarn": "1.22.x"
   },
   "dependencies": {
     "@rails/webpacker": "4.2.2",

--- a/psd-web/package.json
+++ b/psd-web/package.json
@@ -2,6 +2,10 @@
   "name": "psd-web",
   "version": "1.0.0",
   "license": "MIT",
+  "engines": {
+    "node": "10.18.x",
+    "yarn": "1.21.x"
+  },
   "dependencies": {
     "@rails/webpacker": "4.2.2",
     "accessible-autocomplete": "2.0.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This updates `bundler`, `node` and `yarn` to the new versions supported by the [CloudFoundry Ruby buildpack v1.8.8](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.8). This is due to be rolled out on PaaS "on or after 2020-01-28", according to the post on the paas-announce mailing list. After this time, the current build will break.

**Important: this cannot be merged until the PaaS team have upgraded their buildpack. If it is merged before then deployments will fail. Review app deploy will also fail until the buildpack has been updated**

I've also specified the node and yarn versions in package.json to ensure compatibility.

After running `yarn install` a couple of redundant node dependencies were removed.