### PR TITLE
Bump govuk-design-system-rails to fix checkbox aria attribute

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -39,7 +39,7 @@ gem "strong_migrations", "0.6.0"
 gem "webpacker", "4.2.2"
 gem "wicked"
 
-gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.0", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.1", require: "govuk_design_system"
 
 # rubocop:disable Metrics/BlockLength
 group :development, :test do
@@ -67,7 +67,7 @@ group :development, :test do
   gem "selenium-webdriver"
   gem "simplecov"
   gem "simplecov-console"
-  gem "slim_lint"
+  gem "slim_lint", "0.19.0"
   gem "solargraph"
   gem "spring"
   gem "spring-commands-rspec"

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
-  revision: 5dff7adcf0f18a4930afccf6b3d5ab699d9d4b06
-  tag: 0.6.0
+  revision: f8d95f3153e636f95dda5aaa5f3e7fca2fe28f11
+  tag: 0.6.1
   specs:
     govuk-design-system-rails (0.5.0)
 
@@ -413,8 +413,8 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
-    slim_lint (0.20.0)
-      rubocop (>= 0.78.0)
+    slim_lint (0.19.0)
+      rubocop (>= 0.77.0)
       slim (>= 3.0, < 5.0)
     solargraph (0.37.2)
       backport (~> 1.1)
@@ -536,7 +536,7 @@ DEPENDENCIES
   simplecov
   simplecov-console
   slim-rails
-  slim_lint
+  slim_lint (= 0.19.0)
   solargraph
   spring
   spring-commands-rspec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This pulls the latest design system gem update to address a bug with the `aria-describedby` attribute as described by https://github.com/UKGovernmentBEIS/govuk-design-system-rails/pull/14

Also resolved a `rubocop` gemfile conflict.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
