### PR TITLE
Fix file upload field labels and hints

### DIFF
--- a/psd-web/app/assets/javascripts/investigations/attachment_description.js
+++ b/psd-web/app/assets/javascripts/investigations/attachment_description.js
@@ -1,19 +1,17 @@
 import $ from 'jquery';
 
 $(document).ready(() => {
-  const attachmentFileInput = document.getElementById('attachment-file-input');
+  const attachmentFileInput = $('input.govuk-file-upload');
   const attachmentDescription = document.getElementById('attachment-description');
   const currentAttachmentDetails = document.getElementById('current-attachment-details');
 
-  if (attachmentFileInput) {
-    attachmentFileInput.onchange = function onAttachmentInputChange() {
-      if (this.value) {
-        $(attachmentDescription).show();
-      } else {
-        $(attachmentDescription).hide();
-      }
-    };
-  }
+  attachmentFileInput.change(function() {
+    if (this.value) {
+      $(attachmentDescription).show();
+    } else {
+      $(attachmentDescription).hide();
+    }
+  });
 
   if (attachmentDescription) {
     if (currentAttachmentDetails) {

--- a/psd-web/app/views/application/_related_attachment_fields.html.slim
+++ b/psd-web/app/views/application/_related_attachment_fields.html.slim
@@ -10,7 +10,8 @@ fieldset.govuk-fieldset
     = form.fields_for attachment_name do |subform|
       - if file_blob.blank?
         .govuk-form-group
-          = subform.file_field :file, class: "govuk-file-upload", id: "attachment-file-input"
+          = subform.label :file, "Upload a file", class: "govuk-label"
+          = subform.file_field :file, class: "govuk-file-upload"
       #attachment-description
         = render "form_components/govuk_textarea", key: :description, value: file_blob&.metadata&.dig(:description),
               form: subform, label: { text: "Attachment description" }, attributes: { maxlength: 10000 }

--- a/psd-web/app/views/documents_flow/upload.html.slim
+++ b/psd-web/app/views/documents_flow/upload.html.slim
@@ -12,8 +12,7 @@
         | Add attachment
       = form.fields_for :file do |subform|
         .govuk-form-group
-          = subform.label :file, "Browse for file", class: "govuk-label--m"
-          br
+          = subform.label :file, "Upload a file", class: "govuk-label"
           = subform.file_field :file, class: "govuk-file-upload"
       .govuk-form-group
         = form.submit "Upload", class: "govuk-button"

--- a/psd-web/app/views/investigations/creation_flow/allegation_details.html.slim
+++ b/psd-web/app/views/investigations/creation_flow/allegation_details.html.slim
@@ -28,7 +28,8 @@
             ' Currently selected file:
             = link_to @file_blob.filename, @file_blob, target: "_blank", rel: 'noopener'
         = form.fields_for :attachment do |subform|
-          = subform.file_field :file, class: "govuk-file-upload", id: "attachment-file-input"
+          = subform.label :file, "Upload a file", class: "govuk-label"
+          = subform.file_field :file, class: "govuk-file-upload"
 
       .govuk-form-group
         = form.submit "Create allegation", class: "govuk-button"

--- a/psd-web/app/views/investigations/creation_flow/enquiry_details.html.slim
+++ b/psd-web/app/views/investigations/creation_flow/enquiry_details.html.slim
@@ -31,7 +31,8 @@
               ' Currently selected file:
               = link_to @file_blob.filename, @file_blob, target: "_blank", rel: 'noopener'
           = form.fields_for :attachment do |subform|
-            = subform.file_field :file, class: "govuk-file-upload", id: "attachment-file-input"
+            = subform.label :file, "Upload a file", class: "govuk-label"
+            = subform.file_field :file, class: "govuk-file-upload"
 
       .govuk-form-group
         = form.submit "Create enquiry", class: "govuk-button"

--- a/psd-web/app/views/investigations/emails/content.html.slim
+++ b/psd-web/app/views/investigations/emails/content.html.slim
@@ -12,7 +12,11 @@
       = render "form_components/govuk_input", key: :overview, form: form, classes: "govuk-!-width-two-thirds",
               label: { text: "Summary", classes: "govuk-label--m" },
               hint: { text: "Give an overview of the email" }
-      = render "components/govuk_fieldset", legend: { text: "Email content", classes: "govuk-fieldset__legend--m" } do
+      = render "components/govuk_fieldset",
+               legend: { text: "Email content", classes: "govuk-fieldset__legend--m" },
+               describedBy: "email-content-hint" do
+        span#email-content-hint.govuk-hint
+          | Upload the email as a file, or enter the subject and body below
         = form.fields_for :email_file do |subform|
           .govuk-form-group
             - if @email_file_blob
@@ -21,8 +25,7 @@
                 = link_to @email_file_blob.filename, @email_file_blob, target: "_blank", rel: 'noopener'
                 br
                 | Selecting a different one will replace it.
-            span.govuk-hint
-              | Upload the email as a file, or enter the subject and body below
+            = subform.label :file, "Upload a file", class: "govuk-label"
             = subform.file_field :file, class: "govuk-file-upload"
         = render "form_components/govuk_input", key: :email_subject, form: form,
                 classes: "govuk-!-width-two-thirds",

--- a/psd-web/app/views/investigations/meetings/content.html.slim
+++ b/psd-web/app/views/investigations/meetings/content.html.slim
@@ -12,7 +12,11 @@
               classes: "govuk-!-width-two-thirds",
               label: { text: "Summary", classes: "govuk-label--m" },
               hint: { text: "Give an overview of the meeting" }
-      = render "components/govuk_fieldset", legend: { text: "Details", classes: "govuk-fieldset__legend--m" } do
+      = render "components/govuk_fieldset",
+               legend: { text: "Details", classes: "govuk-fieldset__legend--m" },
+               describedBy: "details-hint" do
+        span#details-hint.govuk-hint
+          | Upload the transcript if you have one, or enter notes below
         = form.fields_for :transcript do |subform|
           .govuk-form-group
             - if @transcript_blob
@@ -21,8 +25,7 @@
                 = link_to @transcript_blob.filename, @transcript_blob, target: "_blank", rel: 'noopener'
                 br
                 | Selecting a different one will replace it.
-            span.govuk-hint
-              | Upload the transcript if you have one, or enter notes below
+            = subform.label :file, "Upload a file", class: "govuk-label"
             = subform.file_field :file, class: "govuk-file-upload"
         = render "form_components/govuk_textarea", key: :details, form: form, attributes: { maxlength: 50000 },
                   label: { text: "Notes", classes: "govuk-!-width-two-thirds" }

--- a/psd-web/app/views/investigations/phone_calls/content.html.slim
+++ b/psd-web/app/views/investigations/phone_calls/content.html.slim
@@ -11,7 +11,11 @@
       = render "form_components/govuk_input", key: :overview, form: form, classes: "govuk-!-width-two-thirds",
               label: { text: "Summary", classes: "govuk-label--m" },
               hint: { text: "Give an overview of the phone call" }
-      = render "components/govuk_fieldset", legend: { text: "Details", classes: "govuk-fieldset__legend--m" } do
+      = render "components/govuk_fieldset",
+               legend: { text: "Details", classes: "govuk-fieldset__legend--m" },
+               describedBy: "details-hint" do
+        span#details-hint.govuk-hint class="govuk-!-width-full"
+          | Upload the transcript if you have one, or enter notes below
         = form.fields_for :transcript do |subform|
           .govuk-form-group
             - if @transcript_blob
@@ -20,8 +24,7 @@
                 = link_to @transcript_blob.filename, @transcript_blob, target: "_blank", rel: 'noopener'
                 br
                 | Selecting a different one will replace it.
-            span.govuk-hint class="govuk-!-width-full"
-              | Upload the transcript if you have one, or enter notes below
+            = subform.label :file, "Upload a file", class: "govuk-label"
             = subform.file_field :file, class: "govuk-file-upload"
         = render "form_components/govuk_textarea", key: :details, form: form,
                   attributes: { maxlength: 50000 },

--- a/psd-web/app/views/investigations/ts_investigations/_file_page.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/_file_page.html.slim
@@ -10,7 +10,8 @@ fieldset.govuk-fieldset
     = form.fields_for :file do |subform|
       - if @file_blob.blank?
         .govuk-form-group class=("govuk-form-group--error" if form.object.errors[:file].any?)
-          = subform.file_field :file, class: "govuk-file-upload", id: "attachment-file-input"
+          = subform.label :file, "Upload a file", class: "govuk-label"
+          = subform.file_field :file, class: "govuk-file-upload"
       hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
       = render "form_components/govuk_input", key: :title, form: subform, value: @file_title,
               classes: "govuk-!-width-two-thirds",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes missing `label` tags for file upload fields. It also corrects the hint text relationship in some instances using the `aria-describedby` attribute.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
