### PR TITLE
Add capybara screenshots on ci failure for flaky spec inspections

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -97,9 +97,8 @@ jobs:
       run: |
         bundle exec rspec spec
 
-    - name: Archive Capybara screenshots
-      working-directory: psd-web
-      uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v1
+      if: failure()
       with:
         name: capybara screenshots
         path: tmp/capybara

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -96,3 +96,10 @@ jobs:
         KEYCLOAK_USER_PASSWORD: ${{ secrets.KeycloakUserPassword }}
       run: |
         bundle exec rspec spec
+
+    - name: Archive Capybara screenshots
+      working-directory: psd-web
+      uses: actions/upload-artifact@v1
+      with:
+        name: capybara screenshots
+        path: tmp/capybara

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -98,6 +98,7 @@ jobs:
         bundle exec rspec spec
 
     - uses: actions/upload-artifact@v1
+      working-directory: psd-web
       if: failure()
       with:
         name: capybara screenshots

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -98,8 +98,7 @@ jobs:
         bundle exec rspec spec
 
     - uses: actions/upload-artifact@v1
-      working-directory: psd-web
       if: failure()
       with:
         name: capybara screenshots
-        path: tmp/capybara
+        path: psd-web/tmp/capybara

--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -59,7 +59,7 @@ group :development, :test do
   gem "rspec-mocks"
   gem "rspec-rails"
   gem "rubocop"
-  gem "rubocop-govuk"
+  gem "rubocop-govuk", "~> 2.0.0"
   gem "rubocop-performance"
   gem "ruby-debug-ide"
   gem "sass-rails", "~> 6.0"
@@ -80,4 +80,5 @@ group :test do
   gem "faker"
   gem "launchy"
   gem "rails-controller-testing"
+  gem "capybara-screenshot"
 end

--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -76,9 +76,9 @@ end
 # rubocop:enable Metrics/BlockLength
 
 group :test do
+  gem "capybara-screenshot"
   gem "database_cleaner"
   gem "faker"
   gem "launchy"
   gem "rails-controller-testing"
-  gem "capybara-screenshot"
 end

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.24)
+      capybara (>= 1.0, < 4)
+      launchy
     caxlsx (3.0.1)
       htmlentities (~> 4.3, >= 4.3.4)
       mimemagic (~> 0.3)
@@ -353,7 +356,7 @@ GEM
       rubocop-rspec (~> 1.28)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.4.1)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     rubocop-rspec (1.37.1)
@@ -413,8 +416,8 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
-    slim_lint (0.20.0)
-      rubocop (>= 0.78.0)
+    slim_lint (0.19.0)
+      rubocop (>= 0.77.0)
       slim (>= 3.0, < 5.0)
     solargraph (0.37.2)
       backport (~> 1.1)
@@ -484,6 +487,7 @@ DEPENDENCIES
   brakeman
   byebug
   capybara
+  capybara-screenshot
   cf-app-utils
   coveralls
   database_cleaner
@@ -522,7 +526,7 @@ DEPENDENCIES
   rspec-mocks
   rspec-rails
   rubocop
-  rubocop-govuk
+  rubocop-govuk (~> 2.0.0)
   rubocop-performance
   ruby-debug-ide
   rubyzip

--- a/psd-web/spec/features/businesses_spec.rb
+++ b/psd-web/spec/features/businesses_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Business listing", :with_elasticsearch, :with_stubbed_mailer, :wi
       expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
     end
 
-    expect(page).to have_css(".pagination em.current", text: 1)
+    expect(page).to have_css(".paginations em.current", text: 1)
     expect(page).to have_link("2", href: businesses_path(page: 2))
     expect(page).to have_link("Next →", href: businesses_path(page: 2))
 

--- a/psd-web/spec/features/businesses_spec.rb
+++ b/psd-web/spec/features/businesses_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Business listing", :with_elasticsearch, :with_stubbed_mailer, :wi
       expect(page).to have_link(business_three.trading_name, href: business_path(business_three))
     end
 
-    expect(page).to have_css(".paginations em.current", text: 1)
+    expect(page).to have_css(".pagination em.current", text: 1)
     expect(page).to have_link("2", href: businesses_path(page: 2))
     expect(page).to have_link("Next →", href: businesses_path(page: 2))
 

--- a/psd-web/spec/support/capybara.rb
+++ b/psd-web/spec/support/capybara.rb
@@ -1,0 +1,2 @@
+require "capybara/rspec"
+require "capybara-screenshot/rspec"


### PR DESCRIPTION
Add capybara screenshots to debug upon flaky spec
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
