### PR TITLE
Remove redundant dependabot checks

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,16 +1,8 @@
 version: 1
 
 update_configs:
-  - package_manager: "submodules"
-    directory: "/"
-    update_schedule: "daily"
-
   - package_manager: "javascript"
     directory: "/psd-web"
-    update_schedule: "live"
-
-  - package_manager: "ruby:bundler"
-    directory: "/infrastructure/fluentd"
     update_schedule: "live"
 
   - package_manager: "ruby:bundler"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
These checks are redundant and causing the dependabot status to show a failure.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
