### PR TITLE
rename axlsx_rails gem to caxlsx_rails

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -6,7 +6,7 @@ gem "will_paginate", "~> 3.2" # Must be laoded before elasticsearch gems
 
 gem "aws-sdk-s3", "1.60.1"
 gem "axlsx", git: "https://github.com/randym/axlsx.git", ref: "c593a08"
-gem "axlsx_rails"
+gem "caxlsx_rails", "~> 0.6.2"
 gem "cf-app-utils"
 gem "draper"
 gem "elasticsearch", "6.8.0"

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -93,9 +93,6 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    axlsx_rails (0.6.1)
-      actionpack (>= 3.1)
-      caxlsx (>= 3.0)
     backport (1.1.2)
     brakeman (4.7.2)
     builder (3.2.4)
@@ -116,6 +113,9 @@ GEM
       mimemagic (~> 0.3)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
+    caxlsx_rails (0.6.2)
+      actionpack (>= 3.1)
+      caxlsx (>= 3.0)
     cf-app-utils (0.6)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -482,11 +482,11 @@ DEPENDENCIES
   awesome_print
   aws-sdk-s3 (= 1.60.1)
   axlsx!
-  axlsx_rails
   brakeman
   byebug
   capybara
   capybara-screenshot
+  caxlsx_rails (~> 0.6.2)
   cf-app-utils
   coveralls
   database_cleaner


### PR DESCRIPTION
Removes a deprecation warning: the gem has been renamed to match other gems in the Axlsx community organization.

See https://github.com/caxlsx/caxlsx_rails/blob/master/README.md