### PR TITLE
switch rack gem to use released 2.1.2 version

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -22,7 +22,7 @@ gem "pg"
 gem "pghero"
 gem "puma"
 gem "pundit"
-gem "rack", github: "rack/rack", ref: "8659d9f073c79dac9ddd7ab84b8e647a1ad4d34e" # Until https://github.com/rack/rack/pull/1428 is released
+gem "rack", "~> 2.1.2"
 gem "rails", "5.2.3"
 gem "redcarpet"
 gem "redis-rails"

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
     govuk-design-system-rails (0.5.0)
 
 GIT
-  remote: https://github.com/rack/rack.git
-  revision: 8659d9f073c79dac9ddd7ab84b8e647a1ad4d34e
-  ref: 8659d9f073c79dac9ddd7ab84b8e647a1ad4d34e
-  specs:
-    rack (2.2.0)
-
-GIT
   remote: https://github.com/randym/axlsx.git
   revision: c593a08b2a929dac7aa8dc418b55e26b4c49dc34
   ref: c593a08
@@ -256,6 +249,7 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     raabro (1.1.6)
+    rack (2.1.2)
     rack-protection (2.0.7)
       rack
     rack-proxy (0.6.5)
@@ -514,7 +508,7 @@ DEPENDENCIES
   pry-doc
   puma
   pundit
-  rack!
+  rack (~> 2.1.2)
   rails (= 5.2.3)
   rails-controller-testing
   redcarpet


### PR DESCRIPTION
https://github.com/rack/rack/pull/1428 has now been merged and released, so we no longer need to pin to a specific commit.