### PR TITLE
Remove padding fix

### DIFF
--- a/psd-web/app/assets/stylesheets/autocomplete.scss
+++ b/psd-web/app/assets/stylesheets/autocomplete.scss
@@ -4,14 +4,6 @@
   @include govuk-typography-common();
 }
 
-// Override source to fix a bug
-// See https://github.com/alphagov/accessible-autocomplete/issues/405
-.autocomplete__input--show-all-values {
-  padding-top: 5px;
-  padding-bottom: 5px;
-  padding-left: 5px;
-}
-
 // Add a clear button.
 .autocomplete-select-with-clear {
   width: calc(100% - 48px);


### PR DESCRIPTION
Removing as the [fix is now in accessible-autocomplete 2.0.2](https://github.com/alphagov/accessible-autocomplete/pull/406).