### PR TITLE
downgrade sassc to 2.1.0

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem "rubocop-performance"
   gem "ruby-debug-ide"
   gem "sass-rails", "~> 6.0"
+  gem "sassc", "~> 2.1.0" # Unable to upgrade until https://github.com/sass/sassc-ruby/issues/146 is resolved
   gem "scss_lint-govuk"
   gem "selenium-webdriver"
   gem "simplecov"

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -367,7 +367,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -524,6 +524,7 @@ DEPENDENCIES
   ruby-debug-ide
   rubyzip
   sass-rails (~> 6.0)
+  sassc (~> 2.1.0)
   scout_apm
   scss_lint-govuk
   selenium-webdriver


### PR DESCRIPTION
sassc 2.2.0 includes precompiled binaries which aren’t compatible between different processor architectures, which means that we can't cache the rubygems and reuse them on a different platform. Downgrading to 2.1.0 fixes this, until there’s an alternative solution.

See https://github.com/sass/sassc-ruby/issues/146