### PR TITLE
bump govuk-design-system-rails to 0.6.2

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -39,7 +39,7 @@ gem "strong_migrations", "0.6.1"
 gem "webpacker", "4.2.2"
 gem "wicked"
 
-gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.1", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.2", require: "govuk_design_system"
 
 # rubocop:disable Metrics/BlockLength
 group :development, :test do

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
-  revision: f8d95f3153e636f95dda5aaa5f3e7fca2fe28f11
-  tag: 0.6.1
+  revision: 23cecd7a133b6f26d1924cddf9f39b29330e91a3
+  tag: 0.6.2
   specs:
-    govuk-design-system-rails (0.5.0)
+    govuk-design-system-rails (0.6.2)
 
 GIT
   remote: https://github.com/randym/axlsx.git


### PR DESCRIPTION
This includes a bugfix for the date component: https://github.com/UKGovernmentBEIS/govuk-design-system-rails/pull/15

See https://trello.com/c/b3N6BwTm/33-date-component-doesnt-have-the-correct-error-styling