### PR TITLE
Fix missing arrow

### DIFF
--- a/psd-web/app/assets/stylesheets/autocomplete.scss
+++ b/psd-web/app/assets/stylesheets/autocomplete.scss
@@ -4,6 +4,12 @@
   @include govuk-typography-common();
 }
 
+// Fix invisible arrow when used as dropdown
+// See https://github.com/alphagov/accessible-autocomplete/issues/351
+.autocomplete__wrapper {
+  z-index: 0;
+}
+
 // Add a clear button.
 .autocomplete-select-with-clear {
   width: calc(100% - 48px);


### PR DESCRIPTION
This is an existing issue from the autocomplete, but I'm confused why it's come up now - I don't know of any changes that might have caused this.

Fix from @nickcolley [here](https://github.com/alphagov/accessible-autocomplete/issues/351#issuecomment-582935867).

## Before:
![Screenshot 2020-02-07 at 10 42 07](https://user-images.githubusercontent.com/2204224/74023007-927fea00-4996-11ea-8516-30a0725226df.png)

## After:
![Screenshot 2020-02-07 at 10 42 28](https://user-images.githubusercontent.com/2204224/74023033-9f044280-4996-11ea-8b00-bc2d7abdbd91.png)
