### PR TITLE
Cache user roles in application database

### DIFF
--- a/psd-web/app/jobs/sync_keycloak_user_roles_job.rb
+++ b/psd-web/app/jobs/sync_keycloak_user_roles_job.rb
@@ -1,0 +1,5 @@
+class SyncKeycloakUserRolesJob < ApplicationJob
+  def perform(user_id)
+    User.find(user_id).load_roles_from_keycloak
+  end
+end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :investigations, dependent: :nullify, as: :assignable
   has_many :activities, through: :investigations
   has_many :user_sources, dependent: :destroy
+  has_many :user_roles, dependent: :destroy
 
   has_and_belongs_to_many :teams
 
@@ -55,6 +56,8 @@ class User < ApplicationRecord
 
         record.update!(user.slice(:name, :email, :organisation))
         record.teams = user[:teams]
+
+        SyncKeycloakUserRolesJob.perform_later(record.id)
       rescue ActiveRecord::ActiveRecordError => e
         if Rails.env.production?
           Raven.capture_exception(e)
@@ -65,22 +68,23 @@ class User < ApplicationRecord
     end
   end
 
+  def load_roles_from_keycloak
+    roles = KeycloakClient.instance.get_user_roles(id).uniq
+
+    return if roles == user_roles.pluck(:name).map(&:to_sym)
+
+    transaction do
+      user_roles.delete_all
+      roles.each { |role| user_roles.create!(name: role) }
+    end
+  end
+
   def self.current
     RequestStore.store[:current_user]
   end
 
   def self.current=(user)
     RequestStore.store[:current_user] = user
-  end
-
-  def has_role?(role)
-    roles.include?(role)
-  end
-
-  def roles
-    @roles ||= Rails.cache.fetch("user_roles_#{id}", expires_in: 30.minutes) do
-      KeycloakClient.instance.get_user_roles(id)
-    end
   end
 
   def name
@@ -138,9 +142,25 @@ class User < ApplicationRecord
     update has_viewed_introduction: true
   end
 
+  # TODO: Remove these when switching over roles resolution to #user_roles
+  def has_role?(role)
+    roles.include?(role)
+  end
+
+  def roles
+    @roles ||= Rails.cache.fetch("user_roles_#{id}", expires_in: 30.minutes) do
+      KeycloakClient.instance.get_user_roles(id)
+    end
+  end
+
 private
 
   def current_user?
     User.current&.id == id
   end
+
+  # TODO: Enable this when switching over roles resolution to #user_roles
+  # def has_role?(role)
+  #   user_roles.exists?(name: role)
+  # end
 end

--- a/psd-web/app/models/user_role.rb
+++ b/psd-web/app/models/user_role.rb
@@ -1,0 +1,5 @@
+class UserRole < ApplicationRecord
+  belongs_to :user
+  validates_presence_of :name
+  validates :name, uniqueness: { scope: :user }
+end

--- a/psd-web/config/initializers/sidekiq.rb
+++ b/psd-web/config/initializers/sidekiq.rb
@@ -27,7 +27,7 @@ end
 def schedule_keycloak_sync_job
   keycloak_sync_job = Sidekiq::Cron::Job.new(
     name: "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}: Sync users and teams with Keycloak",
-    cron: "*/5 * * * *",
+    cron: "*/10 * * * *",
     class: "SyncKeycloakTeamsAndUsersJob",
     active_job: true,
     queue: ENV["SIDEKIQ_QUEUE"] || "psd"

--- a/psd-web/db/migrate/20200207112514_create_user_roles.rb
+++ b/psd-web/db/migrate/20200207112514_create_user_roles.rb
@@ -1,0 +1,11 @@
+class CreateUserRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_roles do |t|
+      t.belongs_to :user, type: :uuid
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :user_roles, %i[user_id name], unique: true
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_154252) do
+ActiveRecord::Schema.define(version: 2020_02_07_112514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -260,6 +260,15 @@ ActiveRecord::Schema.define(version: 2020_01_21_154252) do
     t.datetime "updated_at", null: false
     t.index ["investigation_id"], name: "index_tests_on_investigation_id"
     t.index ["product_id"], name: "index_tests_on_product_id"
+  end
+
+  create_table "user_roles", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["user_id", "name"], name: "index_user_roles_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
   create_table "users", id: :uuid, default: nil, force: :cascade do |t|

--- a/psd-web/spec/factories/users.rb
+++ b/psd-web/spec/factories/users.rb
@@ -43,8 +43,9 @@ FactoryBot.define do
     end
 
     after(:build) do |user, evaluator|
-      user.instance_variable_set(:@roles, evaluator.roles)
-      allow(KeycloakClient.instance).to receive(:get_user_roles).with(user.id).and_return(user.roles)
+      user.instance_variable_set(:@roles, evaluator.roles) # TODO: Remove this when switching over roles resolution to #user_roles
+      allow(KeycloakClient.instance).to receive(:get_user_roles).with(user.id).and_return(evaluator.roles)
+      # user.load_roles_from_keycloak # TODO: Enable this when switching over roles resolution to #user_roles
     end
   end
 end

--- a/psd-web/spec/models/user_role_spec.rb
+++ b/psd-web/spec/models/user_role_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe UserRole do
+  let(:user) { create(:user) }
+
+  describe "uniqueness validation" do
+    let(:role_name) { "test" }
+
+    it "does not allow more than one role of the same name per user" do
+      described_class.create!(user: user, name: role_name)
+      expect { described_class.create!(user: user, name: role_name) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe User do
     end
   end
 
+  # TODO: Remove this when switching over roles resolution to #user_roles
   describe "#roles" do
     subject(:user) { build(:user) }
 
@@ -125,6 +126,32 @@ RSpec.describe User do
       it "does not query Keycloak" do
         expect(KeycloakClient.instance).not_to receive(:get_user_roles)
         user.roles
+      end
+    end
+  end
+
+  describe "#load_roles_from_keycloak", :with_stubbed_keycloak_config do
+    let(:user) { create(:user, :psd_user) }
+    let(:roles) { %i[test_role another_test_role] }
+
+    before do
+      allow(KeycloakClient.instance).to receive(:get_user_roles).with(user.id).and_return(roles)
+      user.load_roles_from_keycloak
+    end
+
+    it "populates the user roles" do
+      expect(user.user_roles.where(name: roles).count).to eq(2)
+    end
+
+    it "deletes roles no longer assigned to the user" do
+      expect(user.user_roles.where(name: :psd_user)).to be_empty
+    end
+
+    context "when the user already has the same roles" do
+      let(:roles) { %i[test_role test_role another_test_role] }
+
+      it "does not duplicate roles" do
+        expect(user.user_roles.count).to eq(2)
       end
     end
   end

--- a/psd-web/spec/support/login_helpers.rb
+++ b/psd-web/spec/support/login_helpers.rb
@@ -3,6 +3,8 @@ module LoginHelpers
     allow_any_instance_of(ApplicationController).to receive(:access_token).and_return(access_token)
     allow(KeycloakClient.instance).to receive(:user_signed_in?).with(access_token).and_return(true)
     allow(KeycloakClient.instance).to receive(:user_info).and_return(format_user_for_get_userinfo(as_user))
+
+    # TODO: Remove this when switching over roles resolution to #user_roles
     allow(KeycloakClient.instance).to receive(:get_user_roles).with(as_user.id).and_return(as_user.roles)
   end
 

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -135,10 +135,12 @@ class ActiveSupport::TestCase
 
   def set_user_as_team_admin(user = User.current)
     allow(@keycloak_client_instance).to receive(:get_user_roles).with(user.id) { %i[psd_user team_admin] }
+    user.load_roles_from_keycloak
   end
 
   def set_user_as_not_team_admin(user = User.current)
     allow(@keycloak_client_instance).to receive(:get_user_roles).with(user.id) { [:psd_user] }
+    user.load_roles_from_keycloak
   end
 
   def add_user_to_opss_team(user_id:, team_id:)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This saves the user roles from Keycloak in the application database, introducing a new model `UserRole`, in order to help facilitate the eventual removal of Keycloak from the system.

Previously, roles were cached in Redis for 30 minutes. This change reduces the effective cache delay to up to 10 minutes.

Due to limitations of the Keycloak API it is not possible to get all user roles in one, or even a few, requests. You have to iterate over each user. Currently there are around 1200 users, so that's 1200 extra API requests. To reduce the risk of the whole job failing in the event of a failed request I schedule a new job for each user.

I have increased the cron delay to 10 minutes due to the additional API requests required.

Minimal changes were needed to the existing tests which validates the approach.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
