### PR TITLE
Restore PaaS application start timeout setting to avoid crashing

### DIFF
--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -11,6 +11,7 @@ applications:
     PSD_HOST: ((psd-host))
     SIDEKIQ_QUEUE: ((sidekiq-queue))
     SENTRY_CURRENT_ENV: ((sentry-current-env))
+  timeout: 180
   services:
     - ((psd-db-name))
     - psd-elasticsearch

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -9,6 +9,7 @@ applications:
     - route: ((psd-host))
   env:
     PSD_HOST: ((psd-host))
+  timeout: 180
   services:
     - opss-log-drain
     - psd-auth-env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Restores the timeout configuration introduced in https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/178, but inadvertently removed in https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/107.

This should prevent deployments reported as failing, e.g. https://github.com/UKGovernmentBEIS/beis-opss-psd/runs/441015017?check_suite_focus=true

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
