### PR TITLE
fix ominauth on callback failure

### DIFF
--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   devise_scope :user do
-    resource :session, only: [] do
+    resource :home_page, only: :show, as: :new_session
+    resource :session do
       get :logout, to: "devise/sessions#destroy"
     end
   end


### PR DESCRIPTION
## Description
Fix path redirection to `home_page#show` upon omniauth callback failures

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
