### PR TITLE
redirect to root path on old bookmarked url

### DIFF
--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -179,6 +179,6 @@ Rails.application.routes.draw do
   unauthenticated do
     root to: "homepage#show"
   end
-  match "/sessions/signin", to: redirect("/"), via: [:get, :post]
+  match "/sessions/signin", to: redirect("/"), via: %i[get post]
 end
 # rubocop:enable Metrics/BlockLength

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -179,5 +179,6 @@ Rails.application.routes.draw do
   unauthenticated do
     root to: "homepage#show"
   end
+  match "/sessions/signin", to: redirect("/"), via: [:get, :post]
 end
 # rubocop:enable Metrics/BlockLength

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -179,6 +179,7 @@ Rails.application.routes.draw do
   unauthenticated do
     root to: "homepage#show"
   end
+  # Handle old post-login redirect URIs from previous implementation which are still bookmarked
   match "/sessions/signin", to: redirect("/"), via: %i[get post]
 end
 # rubocop:enable Metrics/BlockLength

--- a/psd-web/spec/requests/login_spec.rb
+++ b/psd-web/spec/requests/login_spec.rb
@@ -7,4 +7,8 @@ RSpec.describe "Login" do
         .to redirect_to(root_path)
     end
   end
+
+  context "old bookmarked url" do
+    it { expect(get("/sessions/signin")).to redirect_to(root_path) }
+  end
 end


### PR DESCRIPTION

## Description
Some user have bookmarks containing old redirect uri that do not exists anymore.
let's redirect those users to the home page

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
