### PR TITLE
Fix sign-in link in header (short term fix)

### DIFF
--- a/psd-web/app/controllers/application_controller.rb
+++ b/psd-web/app/controllers/application_controller.rb
@@ -91,7 +91,7 @@ class ApplicationController < ActionController::Base
       items.push text: "Your account", href: KeycloakClient.instance.user_account_url
       items.push text: "Sign out", href: logout_session_path
     else
-      items.push text: "Sign in", href: user_openid_connect_omniauth_authorize_path
+      items.push text: "Sign in", href: root_path
     end
     items
   end


### PR DESCRIPTION
As a short term fix to our [broken sign in ](https://trello.com/c/sWxr7Mgh/374-sign-in-links-in-header-no-longer-work)links, make the links point to the homepage. From here the user can use the main 'sign in' button.