### PR TITLE
Check whether account has been setup, not activated

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -24,7 +24,6 @@ jobs:
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
-        echo $GITHUB_REF
         export PR_NUMBER=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
         export DB_VERSION=`cat psd-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
         export APP_NAME=psd-pr-$PR_NUMBER

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -24,6 +24,7 @@ jobs:
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
+        echo $GITHUB_REF
         export PR_NUMBER=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
         export DB_VERSION=`cat psd-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
         export APP_NAME=psd-pr-$PR_NUMBER

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
     # Some users will bookmark the invitation URL received on the email and may re-use
     # this even once their account has been created. Hence redirecting them to the root page.
-    return redirect_to(root_path) if signed_in_as?(@user) || @user.has_setup_account?
+    return redirect_to(root_path) if signed_in_as?(@user) || @user.has_completed_registration?
     return render(:expired_invitation) if @user.invitation_expired?
     return (render "errors/not_found", status: :not_found) if @user.invitation_token != params[:invitation]
 

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
     # Some users will bookmark the invitation URL received on the email and may re-use
     # this even once their account has been created. Hence redirecting them to the root page.
-    return redirect_to(root_path) if signed_in_as?(@user) || @user.account_activated?
+    return redirect_to(root_path) if signed_in_as?(@user) || @user.has_setup_account?
     return render(:expired_invitation) if @user.invitation_expired?
     return (render "errors/not_found", status: :not_found) if @user.invitation_token != params[:invitation]
 
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     return render("errors/forbidden", status: :forbidden) if params[:invitation] != @user.invitation_token
 
-    @user.assign_attributes(new_user_attributes.merge(account_activated: true))
+    @user.assign_attributes(new_user_attributes)
 
     if @user.save(context: :registration_completion)
       sign_in :user, @user

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -151,6 +151,10 @@ class User < ApplicationRecord
     has_role? :team_admin
   end
 
+  def has_setup_account?
+    encrypted_password.presence && name.presence && mobile_number.presence?
+  end
+
   def self.get_assignees(except: [])
     user_ids_to_exclude = Array(except).collect(&:id)
     self.activated.where.not(id: user_ids_to_exclude).eager_load(:organisation, :teams)

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -152,7 +152,7 @@ class User < ApplicationRecord
   end
 
   def has_completed_registration?
-    encrypted_password.presence && name.presence && mobile_number.presence?
+    encrypted_password.present? && name.present? && mobile_number.present?
   end
 
   def self.get_assignees(except: [])

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -151,7 +151,7 @@ class User < ApplicationRecord
     has_role? :team_admin
   end
 
-  def has_setup_account?
+  def has_completed_registration?
     encrypted_password.presence && name.presence && mobile_number.presence?
   end
 

--- a/psd-web/spec/factories/users.rb
+++ b/psd-web/spec/factories/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     has_viewed_introduction { false }
     account_activated { false }
     hash_iterations { 27_500 }
+    mobile_number { "07700 900 982" }
 
     transient do
       roles { [:psd_user] }
@@ -38,9 +39,14 @@ FactoryBot.define do
     end
 
     trait :invited do
+      skip_password_validation { true }
       invitation_token { SecureRandom.hex(15) }
       invited_at { Time.zone.now }
       account_activated { false }
+      password { nil }
+      password_confirmation { nil }
+      mobile_number { nil }
+      name { nil }
     end
 
     trait :team_admin do

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -328,4 +328,22 @@ RSpec.describe User do
       expect(user.invitation_expired?).to be true
     end
   end
+
+  describe "#has_completed_registration?" do
+    context "when the password, name and mobile number are missing" do
+      let(:user) { build_stubbed(:user, password: nil, name: nil, mobile_number: nil) }
+
+      it "is false" do
+        expect(user.has_completed_registration?).to be false
+      end
+    end
+
+    context "when the password, name and mobile number have all been set" do
+      let(:user) { build_stubbed(:user) }
+
+      it "is true" do
+        expect(user.has_completed_registration?).to be true
+      end
+    end
+  end
 end

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
     end
 
     context "when the user is already signed in" do
-      let(:user) { create(:user, :invited, :activated) }
+      let(:user) { create(:user, :invited, account_activated: true) }
 
       before do
         sign_in user
@@ -58,7 +58,7 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
     end
 
     context "when a different user is already signed in" do
-      let(:other_user) { create(:user, :invited, :activated) }
+      let(:other_user) { create(:user, :activated) }
       let(:invited_user) { create(:user, :invited) }
 
       before do

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
     context "when the user already created an account with the invitation token" do
       let(:user) { create(:user, :invited, :activated) }
 
-      it "shows a message alerting about the account being already setup" do
+      it "redirects to the homepage" do
         get complete_registration_user_path(user.id, invitation: user.invitation_token)
         expect(response).to redirect_to(root_path)
       end
@@ -51,7 +51,7 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
         sign_in user
       end
 
-      it "shows a message alerting about the account being already setup" do
+      it "redirects to the homepage" do
         get complete_registration_user_path(user.id, invitation: user.invitation_token)
         expect(response).to redirect_to(root_path)
       end

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
         user.reload
       end
 
-      it "sets the activated flag on the user" do
-        expect(user).to be_account_activated
+      it "does not set the activated flag on the user" do
+        expect(user).not_to be_account_activated
       end
 
       it "redirects to the root path" do

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
       end
     end
 
-    context "when the user already created an account with the invitation token" do
-      let(:user) { create(:user, :invited, :activated) }
+    context "when the user has already completed their registration" do
+      let(:user) { create(:user, invitation_token: "abc123", invited_at: Time.zone.now, account_activated: false) }
 
       it "redirects to the homepage" do
         get complete_registration_user_path(user.id, invitation: user.invitation_token)


### PR DESCRIPTION
The "activated" flag should only be set after the user has accepted the declaration, so we need a different check within the account setup flow to check that the user hasn't already set up a password and phone number.