### PR TITLE
Dont set account activated until declaration accepted

### DIFF
--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     return render("errors/forbidden", status: :forbidden) if params[:invitation] != @user.invitation_token
 
-    @user.assign_attributes(new_user_attributes.merge(account_activated: true))
+    @user.assign_attributes(new_user_attributes)
 
     if @user.save(context: :registration_completion)
       sign_in :user, @user


### PR DESCRIPTION
Accounts are only considered "active" once the declaration has been accapted, which happens in a future step.