### PR TITLE
Track deploys with Github Deploy statuses API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,28 @@ jobs:
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
+
+    - name: Create GitHub deployment for Staging
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: master
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_create staging
+
+    - name: Initiate Staging deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+
+        # URL where the deployment progress can be tracked. Exported for future steps.
+        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Amaster+workflow%3ADeploy")
+        echo "::set-env name=LOG_URL::$log_url"
+
+        gh_deploy_initiate staging $log_url
+
     - name: Deploy to staging
       env:
         SPACE: staging
@@ -35,6 +57,45 @@ jobs:
         chmod +x ./psd-web/deploy.sh
         ./psd-web/deploy.sh
         cf7 logout
+
+    - name: Update Staging deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        environment_url=https://staging.product-safety-database.service.gov.uk/
+        gh_deploy_success staging $LOG_URL $environment_url
+
+    - name: Update Staging deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_failure staging $LOG_URL
+
+    - name: Create GitHub deployment for Production
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: master
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_create production
+
+    - name: Initiate Production deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_initiate production $LOG_URL
+
     - name: Deploy to production
       env:
         SPACE: prod
@@ -52,3 +113,24 @@ jobs:
         cf7 target -o 'beis-opss' -s $SPACE
         ./psd-web/deploy.sh
         cf7 logout
+
+    - name: Update Production deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        environment_url=https://www.product-safety-database.service.gov.uk/
+        gh_deploy_success production $LOG_URL $environment_url
+
+    - name: Update Production deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_failure production $LOG_URL

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -15,28 +15,40 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       if: github.event.pull_request.merged == true
+
     - name: Install cf7 client
       env:
         CF_CLI_VERSION: 7.0.0-beta.25
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
+
     - name: Get Pull Request ID using GitHub API
       if: github.event.pull_request.merged == true
       run: |
-        export PR_NUMBER=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss-psd/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
-        cf7 delete -f -r psd-pr-$PR_NUMBER
-        cf7 logout
+        pr_number=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
+        echo "::set-env name=PR_NUMBER::$pr_number"
+
     - name: Get Pull Request ID from GITHUB_REF
       if: github.event.pull_request.merged != true
       run: |
-        export PR_NUMBER=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
+        pr_number=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
+        echo "::set-env name=PR_NUMBER::$pr_number"
+
+    - name: Delete review app
+      env:
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
         cf7 delete -f -r psd-pr-$PR_NUMBER
         cf7 logout
 
+    - name: Deactivate Github deploy
+      env:
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_deactivate_dangling review-app-$PR_NUMBER

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -9,12 +9,42 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+
+    - name: Create GitHub deployment
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: ${{ github.head_ref }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+
+        # Review apps need the Pull Request number for their environment
+        # name and to be able to be linked to the specific PR checks.
+        PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
+
+        gh_deploy_create review-app-${PR_NUMBER}
+
+    - name: Initiate deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+
+        # URL where the deployment progress can be tracked. Exported for future steps.
+        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER/checks")
+        echo "::set-env name=LOG_URL::$log_url"
+
+        gh_deploy_initiate review-app-${PR_NUMBER} $log_url
+
     - name: Install cf client
       env:
         CF_CLI_VERSION: 7.0.0-beta.28
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
+
     - name: Deploy
       env:
         SPACE: int
@@ -30,3 +60,28 @@ jobs:
         export DB_NAME=psd-db-$DB_VERSION
         ./psd-web/deploy-review.sh
         cf7 logout
+
+    - name: Update deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+
+        environment_url=https://psd-pr-${PR_NUMBER}.london.cloudapps.digital/
+
+        gh_deploy_success review-app-${PR_NUMBER} $LOG_URL $environment_url
+
+    - name: Update deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
+        source psd-web/deploy-github-functions.sh
+        gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL

--- a/psd-web/deploy-github-functions.sh
+++ b/psd-web/deploy-github-functions.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -e
+
+# Creates a Deploy in Github
+#
+# Input:
+# - 1. Name of the environment to deploy at.
+# - eg:  $ gh_deploy_create staging
+#
+# Required environment variables:
+# - GITHUB_TOKEN      - Github user token with deploy rights.
+# - GITHUB_REPOSITORY - Set by default by Github. Formatted as "org/repo".
+# - BRANCH            - Branch to be deployed.
+# - GITHUB_REF        - Set by default by Github.
+#
+# Required system tools:
+# - getopt
+# - curl
+# - jq
+# - awk
+gh_deploy_create() {
+  environment_name=$1
+
+  deploy_url=$(curl -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
+    -d '{
+    "ref": "'"$BRANCH"'",
+    "description": "'"$environment_name"' deploy created",
+    "environment": "'"$environment_name"'",
+    "auto_merge": false,
+    "required_contexts": []
+    }' | jq -r '.url?') # Gets 'url' field from the response
+
+  if [ -z "$deploy_url" ]; then
+    echo "Failed to create Github deployment"
+  else
+    # Need to be shared between steps
+    echo "::set-env name=DEPLOY_STATUSES_URL::$deploy_url/statuses"
+    echo "Github deployment created: $deploy_url"
+  fi
+}
+
+# Sets Github deploy status as "in_progress"
+#
+# Input:
+# - 1. Name of the deployment environment to update the status at.
+# - 2. Url where the deployment progress can be tracked.
+# - eg: $ gh_deploy_initiate staging https://github.com/user/repo/pull/15/checks
+#
+# Required environment variables:
+# - GITHUB_TOKEN        - Github user token with deploy rights.
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set up by "gh_deploy_create".
+#
+# Required system tools:
+# - curl
+gh_deploy_initiate() {
+  environment_name=$1
+  log_url=$2
+
+  curl -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    -H "Accept: application/vnd.github.flash-preview+json" \
+    $DEPLOY_STATUSES_URL \
+    -d '{
+      "environment": "'"$environment_name"'",
+      "state": "in_progress",
+      "description": "'"$environment_name"' deployment initiated",
+      "log_url": "'"$log_url"'"
+    }'
+}
+
+# Sets Github deploy status as "success"
+#
+# Input:
+# - 1. Name of the deployment environment to update the status at.
+# - 2. Url where the deployment progress can be tracked.
+# - 3. Environment url where the deployed changes can be viewed.
+# - eg: $ gh_deploy_success staging https://github.com/user/repo/pull/15/checks https://opss-service.digital/
+#
+# Required environment variables:
+# - GITHUB_TOKEN        - Github user token with deploy rights.
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set by "gh_deploy_create".
+#
+# Required system tools:
+# - curl
+gh_deploy_success() {
+  environment_name=$1
+  log_url=$2
+  environment_url=$3
+
+  curl -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    $DEPLOY_STATUSES_URL \
+    -d '{
+      "environment": "'"$environment_name"'",
+      "state": "success",
+      "description": "'"$environment_name"' deployment succeeded",
+      "environment_url": "'"$environment_url"'",
+      "log_url": "'"$log_url"'"
+    }'
+}
+
+# Sets Github deploy status as "failure"
+#
+# Input:
+# - 1. Name of the deployment environment to update the status at.
+# - 2. Url where the deployment progress can be tracked.
+# - eg: $ gh_deploy_failure staging https://github.com/user/repo/pull/15/checks
+#
+# Required environment variables:
+# - GITHUB_TOKEN        - Github user token with deploy rights.
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set by "gh_deploy_create".
+#
+# Required system tools:
+# - curl
+gh_deploy_failure() {
+  environment_name=$1
+  log_url=$2
+  curl -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    $DEPLOY_STATUSES_URL \
+    -d '{
+      "environment": "'"$environment_name"'",
+      "state": "failure",
+      "description": "'"$environment_name"' deployment failed",
+      "log_url": "'"$log_url"'"
+    }'
+}
+
+# Sets Github deploy status as "inactive"
+#
+# Input:
+# - 1. ID of the deploy to have the status updated.
+# - eg: $ gh_deploy_deactivate staging
+#
+# Required environment variables:
+# - GITHUB_TOKEN        - Github user token with deploy rights.
+# - DEPLOY_STATUSES_URL - URL for Github deploy statuses. Set by "gh_deploy_create".
+#
+# Required system tools:
+# - curl
+#
+gh_deploy_deactivate() {
+  deploy_id=$1
+  curl -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.ant-man-preview+json" \
+    https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments/${deploy_id}/statuses \
+    -d '{ "state": "inactive" }'
+}
+
+# Gets list of Github repository deployments.
+#
+# Input:
+# - 1. Environment (optional).
+# - eg: $ gh_deploy_list
+# - eg: $ gh_deploy_list review-app-156
+#
+# Required environment variables:
+# - GITHUB_REPOSITORY - Set by default by Github. Formatted as "org/repo".
+#
+# Required system tools:
+# - curl
+#
+gh_deploy_list() {
+  environment=$1
+  url="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
+  # Filters by environment if provided.
+  if [ -n $environment ]; then
+    url="${url}?environment=${environment}"
+  fi
+  curl -X GET $url
+}
+
+# Deactivates Dangling deploys
+#
+# This function checks all the review app active deploys and deactivates them if
+# the branch associated to the deploy has no open PRs.
+#
+# Input:
+# 1. Environment. Deactivates dangling deploys only for the given environment.
+# - eg: $ gh_deactivate_dangling
+# - eg: $ gh_deactivate_dangling review-app-156
+#
+# Required environment variables:
+# - GITHUB_REPOSITORY - Set by default by Github. Formatted as "org/repo".
+#
+# Required system tools:
+# - curl
+# - jq
+#
+gh_deploy_deactivate_dangling() {
+  environment=$1
+  if [ -n $environment ]; then
+    deploy_list_command="gh_deploy_list $environment"
+  else
+    deploy_list_command="gh_deploy_list"
+  fi
+
+  # Iterates over all the deploys and gets their id, environment and references.
+  # Format: "id@environment@reference".
+  for deploy in $(eval $deploy_list_command |  jq -r '.[] | (.id|tostring) + "@" + .environment + "@" + .ref'); do
+    # Parses id, environment and reference into separate variables.
+    # '@' is used as separator for the splitting.
+    IFS='@' read deploy_id deploy_environment deploy_ref <<< $deploy
+    # We only want to deactivate Review Apps.
+    if [[ $deploy_environment != "staging" && $deploy_environment != "production" ]]; then
+      # Extracts Organization name from "org/repo".
+      IFS='/' read -r org repo <<< $GITHUB_REPOSITORY
+      # Number of open Pull Requests belonging to the branch.
+      # We assume "deploy_ref" is a branch as our GH deploys use branch as ref.
+      open_prs=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=open&head=${org}:${deploy_ref}" | jq '. | length')
+      # If there are no open PRs from the branch we can safely deactivate this branch deploys.
+      if [[ $open_prs -eq 0 ]]; then
+        # Gets most recent status for the deploy.
+        deploy_status=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments/$deploy_id/statuses | jq -r '.[0].state')
+        if [[ $deploy_status != "inactive" ]]; then
+          echo "Deactivating $deploy_environment deployment $deploy_id for branch $deploy_ref"
+          gh_deploy_deactivate $deploy_id
+        fi
+      fi
+    fi
+  done
+}


### PR DESCRIPTION
This will allow us to track the status and progress of review apps, staging and production deploys.

Github will display a link to the deployed environment or a link to the deployment log when is ongoing or failed.
