### PR TITLE
Set PR_NUMBER from github event context

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -10,18 +10,17 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Get GitHub Pull Request number
+      run: |
+        PR_NUMBER=${{ github.event.number }}
+        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
+
     - name: Create GitHub deployment
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         BRANCH: ${{ github.head_ref }}
       run: |
         source psd-web/deploy-github-functions.sh
-
-        # Review apps need the Pull Request number for their environment
-        # name and to be able to be linked to the specific PR checks.
-        PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
-
         gh_deploy_create review-app-${PR_NUMBER}
 
     - name: Initiate deployment status
@@ -54,7 +53,6 @@ jobs:
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
-        export PR_NUMBER=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
         export DB_VERSION=`cat psd-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
         export APP_NAME=psd-pr-$PR_NUMBER
         export DB_NAME=psd-db-$DB_VERSION

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -2,6 +2,9 @@ name: Review application
 
 on: [pull_request]
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   reviewapp:
     name: Deploy
@@ -9,11 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
-    - name: Get GitHub Pull Request number
-      run: |
-        PR_NUMBER=${{ github.event.number }}
-        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
     - name: Create GitHub deployment
       env:
@@ -27,7 +25,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
-        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source psd-web/deploy-github-functions.sh
 
@@ -65,7 +62,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
         LOG_URL: ${{ env.LOG_URL }}
-        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source psd-web/deploy-github-functions.sh
 
@@ -79,7 +75,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
         LOG_URL: ${{ env.LOG_URL }}
-        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source psd-web/deploy-github-functions.sh
         gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL


### PR DESCRIPTION
This should be more reliable than parsing the `GITHUB_REF` environment variable, as that variable doesn’t contain the PR number when re-running a failed workflow.

See https://github.community/t5/GitHub-Actions/GITHUB-REF-is-inconsistent/m-p/48129