### PR TITLE
Tweak Capybara/FeatureMethods config for feature specs

### DIFF
--- a/psd-web/spec/features/.rubocop.yml
+++ b/psd-web/spec/features/.rubocop.yml
@@ -5,3 +5,8 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
    Enabled: false
+
+Capybara/FeatureMethods:
+  EnabledMethods:
+    - feature
+    - scenario

--- a/psd-web/spec/features/add_attachment_spec.rb
+++ b/psd-web/spec/features/add_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Adding an attachment to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Adding an attachment to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation) { create(:allegation, assignee: user) }
   let(:file) { Rails.root + "test/fixtures/files/test_result.txt" }
@@ -12,7 +12,7 @@ RSpec.describe "Adding an attachment to a case", :with_stubbed_elasticsearch, :w
     visit new_investigation_new_path(investigation) # TODO: rename this route
   end
 
-  it "requires a file" do
+  scenario "requires a file" do
     expect_to_be_on_add_attachment_page
 
     click_button "Upload"
@@ -21,7 +21,7 @@ RSpec.describe "Adding an attachment to a case", :with_stubbed_elasticsearch, :w
     expect(page).to have_error_summary("Enter file")
   end
 
-  it "requires a title for the document" do
+  scenario "requires a title for the document" do
     expect_to_be_on_add_attachment_page
 
     attach_and_submit_file
@@ -34,7 +34,7 @@ RSpec.describe "Adding an attachment to a case", :with_stubbed_elasticsearch, :w
     expect(page).to have_error_summary("Enter title")
   end
 
-  it "uploading a file without completing the add attachment flow does not save the attachment" do
+  scenario "uploading a file without completing the add attachment flow does not save the attachment" do
     expect_to_be_on_add_attachment_page
 
     attach_and_submit_file
@@ -46,7 +46,7 @@ RSpec.describe "Adding an attachment to a case", :with_stubbed_elasticsearch, :w
     expect(page).not_to have_selector("h2")
   end
 
-  it "completing the add attachment flow saves the attachment" do
+  scenario "completing the add attachment flow saves the attachment" do
     expect_to_be_on_add_attachment_page
 
     attach_and_submit_file

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Adding a correcting action to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation) { create(:allegation, products: [create(:product_washing_machine)], assignee: user) }
 
@@ -17,7 +17,7 @@ RSpec.describe "Adding a correcting action to a case", :with_stubbed_elasticsear
   before { sign_in(as_user: user) }
 
   context "with valid input" do
-    it "shows inputted data on the confirmation page and on the case attachments and activity pages" do
+    scenario "shows inputted data on the confirmation page and on the case attachments and activity pages" do
       visit new_investigation_corrective_action_path(investigation)
 
       expect_to_be_on_record_corrective_action_page
@@ -39,7 +39,7 @@ RSpec.describe "Adding a correcting action to a case", :with_stubbed_elasticsear
       expect_case_attachments_page_to_show_file
     end
 
-    it "going back to the form from the confirmation page shows inputted data" do
+    scenario "going back to the form from the confirmation page shows inputted data" do
       visit new_investigation_corrective_action_path(investigation)
 
       expect_to_be_on_record_corrective_action_page
@@ -57,7 +57,7 @@ RSpec.describe "Adding a correcting action to a case", :with_stubbed_elasticsear
   context "with invalid input" do
     let(:date) { nil }
 
-    it "shows an error message" do
+    scenario "shows an error message" do
       visit new_investigation_corrective_action_path(investigation)
 
       expect_to_be_on_record_corrective_action_page

--- a/psd-web/spec/features/assign_investigation_spec.rb
+++ b/psd-web/spec/features/assign_investigation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Assigning an investigation", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Assigning an investigation", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team], has_viewed_introduction: true) }
   let(:investigation) { create(:allegation, assignee: user) }
@@ -13,7 +13,7 @@ RSpec.describe "Assigning an investigation", :with_stubbed_elasticsearch, :with_
 
   before { sign_in(as_user: user) }
 
-  it "only shows other active users" do
+  scenario "only shows other active users" do
     visit "/cases/#{investigation.pretty_id}/assign/choose"
 
     expect(page).to have_css("#investigation_select_team_member option[value=\"#{another_active_user.id}\"]")
@@ -23,7 +23,7 @@ RSpec.describe "Assigning an investigation", :with_stubbed_elasticsearch, :with_
     expect(page).not_to have_css("#investigation_select_someone_else option[value=\"#{another_inactive_user_another_team.id}\"]")
   end
 
-  it "assign case to other user in same team" do
+  scenario "assign case to other user in same team" do
     visit new_investigation_assign_path(investigation)
     choose("Someone in your team")
     select another_active_user.name, from: "investigation_select_team_member"
@@ -33,7 +33,7 @@ RSpec.describe "Assigning an investigation", :with_stubbed_elasticsearch, :with_
     expect(page.find("dt", text: "Assigned to")).to have_sibling("dd", text: another_active_user.name.to_s)
   end
 
-  it "assign case to someone else in another team" do
+  scenario "assign case to someone else in another team" do
     visit new_investigation_assign_path(investigation)
     choose("Someone else")
     select another_active_user_another_team.name, from: "investigation_select_someone_else"
@@ -43,7 +43,7 @@ RSpec.describe "Assigning an investigation", :with_stubbed_elasticsearch, :with_
     expect(page.find("dt", text: "Assigned to")).to have_sibling("dd", text: another_active_user_another_team.name.to_s)
   end
 
-  it "once case assigned to other team- cannot re-assign" do
+  scenario "once case assigned to other team- cannot re-assign" do
     visit new_investigation_assign_path(investigation)
     choose("Someone else")
     select another_active_user_another_team.name, from: "investigation_select_someone_else"

--- a/psd-web/spec/features/businesses_spec.rb
+++ b/psd-web/spec/features/businesses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Business listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Business listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user)            { create :user, :activated, has_viewed_introduction: true }
   let!(:business_one)   { create(:business, trading_name: "great value",    created_at: 1.day.ago) }
   let!(:business_two)   { create(:business, trading_name: "mediocre stuff", created_at: 2.days.ago) }
@@ -8,7 +8,7 @@ RSpec.describe "Business listing", :with_elasticsearch, :with_stubbed_mailer, :w
 
   before { create_list :business, 18, created_at: 4.days.ago }
 
-  it "lists products according to search relevance" do
+  scenario "lists products according to search relevance" do
     Business.import refresh: :wait_for
     sign_in(as_user: user)
     visit businesses_path

--- a/psd-web/spec/features/delete_attachment_spec.rb
+++ b/psd-web/spec/features/delete_attachment_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "Deleting an attachment from a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Deleting an attachment from a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation) { create(:allegation, :with_document, assignee: user) }
   let(:document) { investigation.documents.first }
 
   before { sign_in(as_user: user) }
 
-  it "deletes the attachment and creates activity" do
+  scenario "deletes the attachment and creates activity" do
     visit investigation_attachments_path(investigation)
 
     expect_to_be_on_attachments_page

--- a/psd-web/spec/features/edit_attachment_spec.rb
+++ b/psd-web/spec/features/edit_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Editing an attachment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Editing an attachment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation) { create(:allegation, :with_document, assignee: user) }
   let(:document) { investigation.documents.first }
@@ -13,7 +13,7 @@ RSpec.describe "Editing an attachment on a case", :with_stubbed_elasticsearch, :
     visit edit_investigation_document_path(investigation, document)
   end
 
-  it "saves changes and creates activity" do
+  scenario "saves changes and creates activity" do
     expect_to_be_on_edit_attachment_page
 
     fill_and_submit_attachment_details_page

--- a/psd-web/spec/features/filter_investigations_spec.rb
+++ b/psd-web/spec/features/filter_investigations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:organisation) { create(:organisation) }
   let(:team) { create(:team, organisation: organisation) }
   let(:other_team) { create(:team, organisation: organisation, name: "other team") }
@@ -22,7 +22,7 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     visit investigations_path
   end
 
-  it "selecting filters only shows other active users in the assigned to and created by filters" do
+  scenario "selecting filters only shows other active users in the assigned to and created by filters" do
     expect(page).to have_css("#assigned_to_someone_else_id option[value=\"#{another_active_user.id}\"]")
     expect(page).not_to have_css("#assigned_to_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
 
@@ -30,14 +30,14 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     expect(page).not_to have_css("#created_by_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
   end
 
-  it "no filters applied shows all cases" do
+  scenario "no filters applied shows all cases" do
     expect(page).to have_listed_case(investigation.pretty_id)
     expect(page).to have_listed_case(other_user_investigation.pretty_id)
     expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
     expect(page).to have_listed_case(other_team_investigation.pretty_id)
   end
 
-  it "filtering cases assigned to me" do
+  scenario "filtering cases assigned to me" do
     check "Me", id: "assigned_to_me"
     click_button "Apply filters"
 
@@ -47,7 +47,7 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
   end
 
-  it "filtering cases assigned to my team" do
+  scenario "filtering cases assigned to my team" do
     check "My team", id: "assigned_to_team_0"
     click_button "Apply filters"
 
@@ -57,7 +57,7 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
   end
 
-  it "filtering cases assigned to anyone else" do
+  scenario "filtering cases assigned to anyone else" do
     check "Other person or team", id: "assigned_to_someone_else"
     click_button "Apply filters"
 
@@ -67,7 +67,7 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     expect(page).to have_listed_case(other_team_investigation.pretty_id)
   end
 
-  it "filtering cases assigned to another person or team" do
+  scenario "filtering cases assigned to another person or team" do
     check "Other person or team", id: "assigned_to_someone_else"
     select other_team.name, from: "assigned_to_someone_else_id"
     click_button "Apply filters"
@@ -87,7 +87,7 @@ RSpec.describe "Case filtering", :with_elasticsearch, :with_stubbed_mailer, :wit
     expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
   end
 
-  it "combining filters" do
+  scenario "combining filters" do
     check "My team", id: "assigned_to_team_0"
     check "Other person or team", id: "assigned_to_someone_else"
     select other_user_other_team.name, from: "assigned_to_someone_else_id"

--- a/psd-web/spec/features/forbidden_spec.rb
+++ b/psd-web/spec/features/forbidden_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Access forbidden", :with_stubbed_keycloak_config, type: :feature do
-  it "Logging in when user does not yet exist and has no groups" do
+RSpec.feature "Access forbidden", :with_stubbed_keycloak_config, type: :feature do
+  scenario "Logging in when user does not yet exist and has no groups" do
     sign_in(as_user: build(:user, organisation: nil))
     expect(page).to have_text("You don’t have permission to see this page")
   end

--- a/psd-web/spec/features/home_page_spec.rb
+++ b/psd-web/spec/features/home_page_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, type: :feature do
   context "when user is signed out" do
-    it "shows the home page" do
+    scenario "shows the home page" do
       sign_out(:user)
       visit root_path
 
@@ -45,7 +45,7 @@ RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, 
         let(:has_viewed_introduction) { false }
         let(:user_state) { :inactive }
 
-        it "shows the declaration page before the case list" do
+        scenario "shows the declaration page before the case list" do
           expect(page).to have_current_path(declaration_index_path)
           expect_small_beta_phase_banner
           expect_header_to_have_signed_in_links
@@ -63,7 +63,7 @@ RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, 
       end
 
       context "when the user has previously accepted the declaration" do
-        it "shows the case list" do
+        scenario "shows the case list" do
           expect(page).to have_current_path(investigations_path)
           expect_small_beta_phase_banner
           expect_header_to_have_signed_in_links
@@ -81,7 +81,7 @@ RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, 
         let(:has_viewed_introduction) { false }
         let(:user_state) { :inactive }
 
-        it "shows the declaration page before the introduction" do
+        scenario "shows the declaration page before the introduction" do
           expect(page).to have_current_path(declaration_index_path)
           expect_small_beta_phase_banner
           expect_header_to_have_signed_in_links
@@ -102,7 +102,7 @@ RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, 
         context "when the user has not previously viewed the introduction" do
           let(:has_viewed_introduction) { false }
 
-          it "shows the introduction" do
+          scenario "shows the introduction" do
             expect(page).to have_current_path(introduction_overview_path)
             expect_small_beta_phase_banner
             expect_header_to_have_signed_in_links
@@ -112,7 +112,7 @@ RSpec.describe "Home page", :with_elasticsearch, :with_stubbed_keycloak_config, 
         end
 
         context "when the user has previously viewed the introduction" do
-          it "shows the non-OPSS home page" do
+          scenario "shows the non-OPSS home page" do
             expect(page).to have_current_path(root_path)
             expect_small_beta_phase_banner
             expect_header_to_have_signed_in_links

--- a/psd-web/spec/features/investigation_edit_spec.rb
+++ b/psd-web/spec/features/investigation_edit_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "Ability to edit an investigation", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:investigation) { create(:project) }
 
   before do
     sign_in
   end
 
-  it "allows to edit the summary" do
+  scenario "allows to edit the summary" do
     visit investigation_path(investigation)
 
     click_link "Change summary"

--- a/psd-web/spec/features/investigations_spec.rb
+++ b/psd-web/spec/features/investigations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Investigation listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Investigation listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create :user, :activated, has_viewed_introduction: true }
   let(:pagination_link_params) do
     {
@@ -25,7 +25,7 @@ RSpec.describe "Investigation listing", :with_elasticsearch, :with_stubbed_maile
     create_list :project, 18, updated_at: 4.days.ago
   end
 
-  it "lists cases correctly sorted" do
+  scenario "lists cases correctly sorted" do
     # it is necessary to re-import and wait for the indexing to be done.
     Investigation.import refresh: :wait_for
 

--- a/psd-web/spec/features/products_spec.rb
+++ b/psd-web/spec/features/products_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Products listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Products listing", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user)             { create :user, :activated, has_viewed_introduction: true }
   let!(:iphone)          { create(:product_iphone,          created_at: 1.day.ago) }
   let!(:iphone_3g)       { create(:product_iphone_3g,       created_at: 2.days.ago) }
@@ -8,7 +8,7 @@ RSpec.describe "Products listing", :with_elasticsearch, :with_stubbed_mailer, :w
 
   before { create_list(:product, 18, created_at: 4.days.ago) }
 
-  it "lists products according to search relevance" do
+  scenario "lists products according to search relevance" do
     Product.import refresh: :wait_for
     sign_in(as_user: user)
     visit products_path

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   before { sign_in as_user: create(:user, :activated, :opss_user) }
 
   let(:reference_number) { Faker::Number.number(digits: 10) }
@@ -91,7 +91,7 @@ RSpec.describe "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed
     ]
   }
 
-  it "as a non-OPSS user" do
+  scenario "as a non-OPSS user" do
     visit new_ts_investigation_path
 
     expect_to_be_on_product_page

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sending a product safety alert", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_keycloak_config, type: :feature do
   let(:user) { create(:user, :activated, :opss_user) }
   let(:investigation) { create(:allegation) }
 
@@ -14,7 +14,7 @@ RSpec.describe "Sending a product safety alert", :with_stubbed_elasticsearch, :w
     allow(NotificationsClient.instance).to receive(:generate_template_preview).and_return(OpenStruct.new(html: nil))
   end
 
-  it "shows the number of recipients the alert will be sent to, including active users only" do
+  scenario "shows the number of recipients the alert will be sent to, including active users only" do
     visit investigation_path(investigation)
 
     click_link "Add activity"

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Signing in", :with_stubbed_mailer, :with_stubbed_keycloak_config, :with_elasticsearch, type: :feature do
+RSpec.feature "Signing in", :with_stubbed_mailer, :with_stubbed_keycloak_config, :with_elasticsearch, type: :feature do
   include ActiveSupport::Testing::TimeHelpers
   let(:investigation) { create(:project) }
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
@@ -22,7 +22,7 @@ RSpec.describe "Signing in", :with_stubbed_mailer, :with_stubbed_keycloak_config
     }
   end
 
-  it "allows to sign in and times you out in due time" do
+  scenario "allows to sign in and times you out in due time" do
     visit investigation_path(investigation)
     expect(page).not_to have_css("h2#error-summary-title", text: "You need to sign in or sign up before continuing.")
 

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-
-RSpec.describe "Your team page", :with_stubbed_keycloak_config, :with_stubbed_mailer, :with_stubbed_elasticsearch, type: :feature do
+RSpec.feature "Your team page", :with_stubbed_keycloak_config, :with_stubbed_mailer, :with_stubbed_elasticsearch, type: :feature do
   let(:team) { create(:team) }
   let(:user) { create(:user, :activated, teams: [team], has_viewed_introduction: true) }
 
@@ -14,7 +13,7 @@ RSpec.describe "Your team page", :with_stubbed_keycloak_config, :with_stubbed_ma
     visit team_path(team)
   end
 
-  it "shows the current user" do
+  scenario "shows the current user" do
     expect(page).to have_css(".teams--user .teams--user-email:contains(\"#{user.email}\")")
     expect(page).to have_css(".teams--user .teams--user-email:contains(\"#{another_active_user.email}\")")
     expect(page).to have_css(".teams--user .teams--user-email:contains(\"#{another_inactive_user.email}\")")
@@ -29,12 +28,12 @@ RSpec.describe "Your team page", :with_stubbed_keycloak_config, :with_stubbed_ma
     context "when the user is a team admin" do
       let(:user) { create(:user, :activated, :team_admin, teams: [team], has_viewed_introduction: true) }
 
-      it "only displays the link for inactive users" do
+      scenario "only displays the link for inactive users" do
         expect(page).to have_css(resend_link_selector(another_inactive_user.email))
         expect(page).not_to have_css(resend_link_selector(another_active_user.email))
       end
 
-      it "inviting an existing user shows an error message" do
+      scenario "inviting an existing user shows an error message" do
         click_link "Invite a team member"
         expect(page).to have_css("h1", text: "Invite a team member")
         fill_in "new_user_email_address", with: user.email
@@ -47,12 +46,12 @@ RSpec.describe "Your team page", :with_stubbed_keycloak_config, :with_stubbed_ma
   context "when the user is not a team admin" do
     let(:user) { create(:user, :activated, :psd_user, teams: [team], has_viewed_introduction: true) }
 
-    it "does not display the resend invite link for any users" do
+    scenario "does not display the resend invite link for any users" do
       expect(page).to have_css("h1", text: "test organisation")
       expect(page).not_to have_link(resend_link_selector(another_inactive_user.email))
     end
 
-    it "does not display the invite a team member link" do
+    scenario "does not display the invite a team member link" do
       expect(page).to have_css("h1", text: "test organisation")
       expect(page).not_to have_button("Invite a team member")
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Following discussion around the auto-corrected changes to feature spec syntax in https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/321 we have decided to reinstate `feature`/`scenario` methods in feature specs only.

I have therefore replaced the `describe`/`it` method calls so that the tests are written as previously. I have not attempted to correct any semantics in the descriptions.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
