### PR TITLE
Update README to use Cloud Foundry v7 CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,39 +145,39 @@ Please run debug app deployment locally. See [".github/workflows/review-apps.yml
 
 ### Deployment from scratch
 
-Once you have a GOV.UK PaaS account as mentioned above, you should install the Cloud Foundry CLI (`cf`) from https://github.com/cloudfoundry/cli#downloads and then run the following commands:
+Once you have a GOV.UK PaaS account as mentioned above, you should install the Cloud Foundry CLI v7 beta (`cf7`) from https://docs.cloudfoundry.org/cf-cli/v7.html and then run the following commands:
 
-    cf login
-    cf target -o beis-opss
+    cf7 login
+    cf7 target -o beis-opss
 
 This will log you in and set the correct target organisation.
 
-If you need to create a new environment, you can run `cf create-space SPACE-NAME`, otherwise, select the correct space using `cf target -o beis-opss -s SPACE-NAME`.
+If you need to create a new environment, you can run `cf7 create-space SPACE-NAME`, otherwise, select the correct space using `cf7 target -o beis-opss -s SPACE-NAME`.
 
 #### Database
 
 To create a database for the current space:
 
-    cf marketplace -s postgres
-    cf enable-service-access postgres
-    cf create-service postgres small-10.5 psd-database
+    cf7 marketplace -s postgres
+    cf7 enable-service-access postgres
+    cf7 create-service postgres small-10.5 psd-database
 
 
 #### Elasticsearch
 
 To create an Elasticsearch instance for the current space:
 
-    cf marketplace -s elasticsearch
-    cf create-service elasticsearch tiny-6.x psd-elasticsearch
+    cf7 marketplace -s elasticsearch
+    cf7 create-service elasticsearch tiny-6.x psd-elasticsearch
 
 
 #### Redis
 
 To create a redis instance for the current space.
 
-    cf marketplace -s redis
-    cf create-service redis tiny-3.2 psd-queue
-    cf create-service redis tiny-3.2 psd-session
+    cf7 marketplace -s redis
+    cf7 create-service redis tiny-3.2 psd-queue
+    cf7 create-service redis tiny-3.2 psd-session
 
 The current worker (sidekiq), which uses `psd-queue` only works with an unclustered instance of redis.
 
@@ -199,7 +199,7 @@ Start by setting up the following credentials:
 * To configure rails to use the production database amongst other things and set the server's encryption key (generate a new value by running `rake secret`):
 
 ```
-    cf cups psd-rails-env -p '{
+    cf7 cups psd-rails-env -p '{
         "RAILS_ENV": "production",
         "SECRET_KEY_BASE": "XXX"
     }'
@@ -208,7 +208,7 @@ Start by setting up the following credentials:
 * To configure AWS (see the S3 section [above](#s3) to get these values):
 
 ```
-    cf cups psd-aws-env -p '{
+    cf7 cups psd-aws-env -p '{
         "AWS_ACCESS_KEY_ID": "XXX",
         "AWS_SECRET_ACCESS_KEY": "XXX",
         "AWS_REGION": "XXX",
@@ -219,7 +219,7 @@ Start by setting up the following credentials:
 * To configure Notify for email sending and previewing (see the GOV.UK Notify account section in [the root README](../README.md#gov.uk-notify) to get this value):
 
 ```
-    cf cups psd-notify-env -p '{
+    cf7 cups psd-notify-env -p '{
         "NOTIFY_API_KEY": "XXX"
     }'
 ```
@@ -227,7 +227,7 @@ Start by setting up the following credentials:
 * To set pgHero http auth username and password for (see confluence for values):
 
 ```
-    cf cups psd-pghero-env -p '{
+    cf7 cups psd-pghero-env -p '{
         "PGHERO_USERNAME": "XXX",
         "PGHERO_PASSWORD": "XXX"
     }'
@@ -236,7 +236,7 @@ Start by setting up the following credentials:
 * To configure Sentry (see the Sentry account section in [the root README](../README.md#sentry) to get these values):
 
 ```
-    cf cups psd-sentry-env -p '{
+    cf7 cups psd-sentry-env -p '{
         "SENTRY_DSN": "XXX",
         "SENTRY_CURRENT_ENV": "<<SPACE>>"
     }'
@@ -245,7 +245,7 @@ Start by setting up the following credentials:
 * To enable and add basic auth to the entire application (useful for deployment or non-production environments):
 
 ```
-    cf cups psd-auth-env -p '{
+    cf7 cups psd-auth-env -p '{
         "BASIC_AUTH_USERNAME": "XXX",
         "BASIC_AUTH_PASSWORD": "XXX"
     }'
@@ -254,7 +254,7 @@ Start by setting up the following credentials:
 * To enable and add basic auth to the health check endpoint at `/health/all`:
 
 ```
-    cf cups psd-health-env -p '{
+    cf7 cups psd-health-env -p '{
         "HEALTH_CHECK_USERNAME": "XXX",
         "HEALTH_CHECK_PASSWORD": "XXX"
     }'
@@ -263,7 +263,7 @@ Start by setting up the following credentials:
 * To enable and add basic auth to the sidekiq monitoring UI at `/sidekiq`:
 
 ```
-    cf cups psd-sidekiq-env -p '{
+    cf7 cups psd-sidekiq-env -p '{
         "SIDEKIQ_USERNAME": "XXX",
         "SIDEKIQ_PASSWORD": "XXX"
     }'
@@ -295,7 +295,7 @@ For each domain, we define a `<<SPACE>>` and `<<SPACE>>-temp` subdomain for host
 It's important that we also allow the `Authorization` header through the CDN for the basic auth on non-production environments.
 The following command can be used to create the `cdn-route` service:
 
-    cf create-service cdn-route cdn-route opss-cdn-route -c '{"domain": "<<domain1>>,<<domain2>>", "headers": ["Authorization"]}'
+    cf7 create-service cdn-route cdn-route opss-cdn-route -c '{"domain": "<<domain1>>,<<domain2>>", "headers": ["Authorization"]}'
 
 
 #### Logging
@@ -335,20 +335,16 @@ However, you will need to add an extra filter in [logstash-filters.conf](https:/
 
 Please take a look into github actions in `.github/workflows` to see how deployments are done.
 
-#### Proper executable
-
-If `cf` is not working, try `cf7`
-
 #### Login to CF Api
 
 ```
-cf login -a api.london.cloud.service.gov.uk -u some@email.com
+cf7 login -a api.london.cloud.service.gov.uk -u some@email.com
 ```
 
 #### SSH to service and run rails console
 
 ```
-cf ssh APP-NAME
+cf7 ssh APP-NAME
 
 cd app && export $(./env/get-env-from-vcap.sh) && /tmp/lifecycle/launcher /home/vcap/app 'rails c' ''
 ```
@@ -356,25 +352,25 @@ cd app && export $(./env/get-env-from-vcap.sh) && /tmp/lifecycle/launcher /home/
 #### List apps
 
 ```
-cf apps
+cf7 apps
 ```
 
 #### Show app details
 
 ```
-cf app APP-NAME
+cf7 app APP-NAME
 ```
 
 #### Show app env
 
 ```
-cf env APP-NAME
+cf7 env APP-NAME
 ```
 
 #### List services
 
 ```
-cf apps
+cf7 apps
 ```
 
 ## BrowserStack


### PR DESCRIPTION
We now rely upon two features which require version 7 (beta) of the Cloud Foundry command line tool (CLI), so this updates the README documentation to reflect this.

The two features requiring the cf7 CLI are:

* Our app manifest includes two separate processes within the same app (`web` and `worker`)
* The deploy script (`deploy.sh`) uses the "rolling deployment" strategy for zero-downtime deploys.