### PR TITLE
Handle requesting a password reset for an invited email

### DIFF
--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -35,11 +35,7 @@ module Users
   private
 
     def resend_invitation_link_for(user)
-      if user.invitation_expired?
-        NotifyMailer.expired_invitation_email(user).deliver_later
-      else
-        NotifyMailer.invitation_email(user, nil).deliver_later
-      end
+      SendUserInvitationJob.perform_later(user.id, nil)
       redirect_to check_your_email_path
     end
 

--- a/psd-web/app/jobs/send_user_invitation_job.rb
+++ b/psd-web/app/jobs/send_user_invitation_job.rb
@@ -3,11 +3,27 @@ require "notifications/client"
 class SendUserInvitationJob < ApplicationJob
   GOV_UK_NOTIFY_TEMPLATE_ID = "22b3799c-aa3d-43e8-899d-3f30307a488f".freeze
 
-  def perform(user_id, user_inviting_id)
+  # If the user_inviting_id is present, it is implied that the invitation
+  # is being sent (or resent) by a colleague, and so the invited_at time
+  # is reset.
+  #
+  # If absent, it is implied that the user themselves requested a resend of the
+  # invitation (eg by attempting to reset their password), and so the invited_at
+  # time should not be altered, and a different email should be sent if the invitation
+  # has already expired.
+  def perform(user_id, user_inviting_id = nil)
     user = User.find(user_id)
-    user_inviting = User.find(user_inviting_id)
 
-    NotifyMailer.invitation_email(user, user_inviting).deliver_now
-    user.update!(has_been_sent_welcome_email: true, invited_at: Time.current)
+    if user_inviting_id
+      user_inviting = User.find(user_inviting_id)
+
+      NotifyMailer.invitation_email(user, user_inviting).deliver_now
+      user.update!(has_been_sent_welcome_email: true, invited_at: Time.current)
+
+    elsif user.invitation_expired?
+      NotifyMailer.expired_invitation_email(user).deliver_now
+    else
+      NotifyMailer.invitation_email(user, nil).deliver_now
+    end
   end
 end

--- a/psd-web/app/mailers/notify_mailer.rb
+++ b/psd-web/app/mailers/notify_mailer.rb
@@ -7,7 +7,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
       alert: "47fb7df9-2370-4307-9f86-69455597cdc1",
       user_added_to_team: "e3b2bbf5-3002-49fb-adb5-ad18e483c7e4",
       welcome: "035876e3-5b97-4b4c-9bd5-c504b5158a85",
-      invitation: "7b80a680-f8b3-4032-982d-2a3a662b611a"
+      invitation: "7b80a680-f8b3-4032-982d-2a3a662b611a",
+      expired_invitation: "e056e368-5abb-48f4-b98d-ad0933620cc2"
     }.freeze
 
   def reset_password_instructions(user, token)
@@ -21,12 +22,19 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: user.email)
   end
 
-  def invitation_email(user, inviting_user)
+  def invitation_email(user, inviting_user = nil)
     set_template(TEMPLATES[:invitation])
 
     invitation_url = complete_registration_user_url(user.id, invitation: user.invitation_token)
 
-    set_personalisation(invitation_url: invitation_url, inviting_team_member_name: inviting_user.name)
+    invited_by = inviting_user.try(&:name) || "a colleague"
+
+    set_personalisation(invitation_url: invitation_url, inviting_team_member_name: invited_by)
+    mail(to: user.email)
+  end
+
+  def expired_invitation_email(user)
+    set_template(TEMPLATES[:expired_invitation])
     mail(to: user.email)
   end
 

--- a/psd-web/spec/jobs/send_user_invitation_job_spec.rb
+++ b/psd-web/spec/jobs/send_user_invitation_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SendUserInvitationJob do
   describe "#perform" do
     subject(:job) { described_class.new }
 
-    context "with a valid user id" do
+    context "with a valid user id and user inviting id" do
       let(:user_id) { SecureRandom.uuid }
       let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
       let!(:user) { create(:user, id: user_id, invitation_token: SecureRandom.hex(10), invited_at: nil, has_been_sent_welcome_email: false) }
@@ -37,6 +37,48 @@ RSpec.describe SendUserInvitationJob do
 
       it "raises an error" do
         expect { job.perform(user_id, user_inviting.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with no user inviting id and user whose invitation is still valid" do
+      let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+      let(:invited_at) { 2.hours.ago }
+      let!(:user) { create(:user, :invited, invited_at: invited_at) }
+
+      before do
+        allow(NotifyMailer).to receive(:invitation_email).and_return(message_delivery_instance)
+      end
+
+      it "re-sends the invitation email via the NotifyMailer" do
+        allow(NotifyMailer).to receive(:invitation_email).with(user).and_return(message_delivery_instance)
+        job.perform(user.id)
+        expect(message_delivery_instance).to have_received(:deliver_now)
+      end
+
+      it "does not change the the time that the user was invited at" do
+        job.perform(user.id)
+        expect(user.reload.invited_at).to be_within(1.second).of(invited_at)
+      end
+    end
+
+    context "with no user inviting id and user whose invitation is has expired" do
+      let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+      let(:invited_at) { 30.days.ago }
+      let!(:user) { create(:user, :invited, invited_at: invited_at) }
+
+      before do
+        allow(NotifyMailer).to receive(:expired_invitation_email).and_return(message_delivery_instance)
+      end
+
+      it "sends an email about the expired notification via the NotifyMailer" do
+        allow(NotifyMailer).to receive(:expired_invitation_email).with(user).and_return(message_delivery_instance)
+        job.perform(user.id)
+        expect(message_delivery_instance).to have_received(:deliver_now)
+      end
+
+      it "does not change the the time that the user was invited at" do
+        job.perform(user.id)
+        expect(user.reload.invited_at).to be_within(1.second).of(invited_at)
       end
     end
   end

--- a/psd-web/spec/mailers/notify_mailer_spec.rb
+++ b/psd-web/spec/mailers/notify_mailer_spec.rb
@@ -23,4 +23,41 @@ RSpec.describe NotifyMailer do
         .to eq(name: user.name, edit_user_password_url_token: edit_user_password_url(reset_password_token: token))
     end
   end
+
+  describe "#invitation_email" do
+    context "when called with a user and an inviting user" do
+      let(:user)  { create(:user, :invited) }
+      let(:inviting_user) { build(:user) }
+
+      let(:mail) { described_class.invitation_email(user, inviting_user) }
+
+      it "sets the recipient of the email" do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it "sets the template ID" do
+        expect(mail.govuk_notify_template).to eq("7b80a680-f8b3-4032-982d-2a3a662b611a")
+      end
+
+      it "sets the personalisation attributes" do
+        invitation_url = complete_registration_user_url(user.id, invitation: user.invitation_token)
+
+        expect(mail.govuk_notify_personalisation)
+          .to eq(invitation_url: invitation_url, inviting_team_member_name: inviting_user.name)
+      end
+    end
+
+    context "when called with a user and no inviting user" do
+      let(:user)  { create(:user, :invited) }
+
+      let(:mail)  { described_class.invitation_email(user, nil) }
+
+      it "sets the personalisation attributes" do
+        invitation_url = complete_registration_user_url(user.id, invitation: user.invitation_token)
+
+        expect(mail.govuk_notify_personalisation)
+          .to eq(invitation_url: invitation_url, inviting_team_member_name: "a colleague")
+      end
+    end
+  end
 end

--- a/psd-web/spec/requests/user_requests_password_reset_spec.rb
+++ b/psd-web/spec/requests/user_requests_password_reset_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "User requests password reset", type: :request, with_stubbed_keycloak_config: true, with_stubbed_mailer: true do
+    let(:user) { create(:user, :invited, invited_at: 1.hour.ago) }
+    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+  context "when the user hasn’t previously set up an account, but the invite is still valid" do
+    subject(:request_password_reset) do
+      post user_password_path, params: {
+        user: {
+          email: user.email
+        }
+      }
+    end
+
+    before do
+      allow(NotifyMailer).to receive(:invitation_email).with(user, nil).and_return(message_delivery)
+    end
+
+    it "does not set a password reset token" do
+      request_password_reset
+      expect(user.reload.reset_password_token).to be_nil
+    end
+
+    it "renders the check your email page" do
+      request_password_reset
+      expect(response).to redirect_to(check_your_email_path)
+    end
+
+    it "re-sends the invitation email" do
+      request_password_reset
+      expect(message_delivery).to have_received(:deliver_later)
+    end
+  end
+
+
+  context "when the user hasn’t previously set up an account, and the invite has expired" do
+    let(:user) { create(:user, :invited, invited_at: 30.days.ago) }
+    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    subject(:request_password_reset) do
+      post user_password_path, params: {
+        user: {
+          email: user.email
+        }
+      }
+    end
+
+    before do
+      allow(NotifyMailer).to receive(:expired_invitation_email).with(user).and_return(message_delivery)
+    end
+
+    it "does not set a password reset token" do
+      request_password_reset
+      expect(user.reload.reset_password_token).to be_nil
+    end
+
+    it "renders the check your email page" do
+      request_password_reset
+      expect(response).to redirect_to(check_your_email_path)
+    end
+
+    it "sends an email saying their invite has expired" do
+      request_password_reset
+      expect(message_delivery).to have_received(:deliver_later)
+    end
+  end
+end

--- a/psd-web/spec/requests/user_requests_password_reset_spec.rb
+++ b/psd-web/spec/requests/user_requests_password_reset_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "User requests password reset", type: :request, with_stubbed_keycloak_config: true, with_stubbed_mailer: true do
-    let(:user) { create(:user, :invited, invited_at: 1.hour.ago) }
-    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+  let(:user) { create(:user, :invited, invited_at: 1.hour.ago) }
+  let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
   context "when the user hasn’t previously set up an account, but the invite is still valid" do
     subject(:request_password_reset) do
@@ -35,9 +35,6 @@ RSpec.describe "User requests password reset", type: :request, with_stubbed_keyc
 
 
   context "when the user hasn’t previously set up an account, and the invite has expired" do
-    let(:user) { create(:user, :invited, invited_at: 30.days.ago) }
-    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
-
     subject(:request_password_reset) do
       post user_password_path, params: {
         user: {
@@ -45,6 +42,10 @@ RSpec.describe "User requests password reset", type: :request, with_stubbed_keyc
         }
       }
     end
+
+    let(:user) { create(:user, :invited, invited_at: 30.days.ago) }
+    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
 
     before do
       allow(NotifyMailer).to receive(:expired_invitation_email).with(user).and_return(message_delivery)

--- a/psd-web/spec/requests/user_requests_password_reset_spec.rb
+++ b/psd-web/spec/requests/user_requests_password_reset_spec.rb
@@ -1,10 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "User requests password reset", type: :request, with_stubbed_keycloak_config: true, with_stubbed_mailer: true do
-  let(:user) { create(:user, :invited, invited_at: 1.hour.ago) }
-  let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
-
-  context "when the user hasn’t previously set up an account, but the invite is still valid" do
+  context "when the user hasn’t previously set up an account" do
     subject(:request_password_reset) do
       post user_password_path, params: {
         user: {
@@ -13,8 +10,11 @@ RSpec.describe "User requests password reset", type: :request, with_stubbed_keyc
       }
     end
 
+    let(:user) { create(:user, :invited, invited_at: 1.hour.ago) }
+
+
     before do
-      allow(NotifyMailer).to receive(:invitation_email).with(user, nil).and_return(message_delivery)
+      allow(SendUserInvitationJob).to receive(:perform_later).with(user.id, nil)
     end
 
     it "does not set a password reset token" do
@@ -27,43 +27,9 @@ RSpec.describe "User requests password reset", type: :request, with_stubbed_keyc
       expect(response).to redirect_to(check_your_email_path)
     end
 
-    it "re-sends the invitation email" do
+    it "queues the resend invitation job" do
       request_password_reset
-      expect(message_delivery).to have_received(:deliver_later)
-    end
-  end
-
-
-  context "when the user hasn’t previously set up an account, and the invite has expired" do
-    subject(:request_password_reset) do
-      post user_password_path, params: {
-        user: {
-          email: user.email
-        }
-      }
-    end
-
-    let(:user) { create(:user, :invited, invited_at: 30.days.ago) }
-    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
-
-
-    before do
-      allow(NotifyMailer).to receive(:expired_invitation_email).with(user).and_return(message_delivery)
-    end
-
-    it "does not set a password reset token" do
-      request_password_reset
-      expect(user.reload.reset_password_token).to be_nil
-    end
-
-    it "renders the check your email page" do
-      request_password_reset
-      expect(response).to redirect_to(check_your_email_path)
-    end
-
-    it "sends an email saying their invite has expired" do
-      request_password_reset
-      expect(message_delivery).to have_received(:deliver_later)
+      expect(SendUserInvitationJob).to have_received(:perform_later).with(user.id, nil)
     end
   end
 end


### PR DESCRIPTION
If a password reset is requested for an e-mail address which has been invited, but hasn't yet set up an account, then we want to send a different e-mail from the regular reset password one, depending on the invitation status.

If the invitation is still valid (within the set time period), then we should re-send the invitation e-mail, allowing the user to continue with setting up their account.

If the invitation has expired, then we should block the password reset process, and instead send a different e-mail asking the user to ask a colleague to re-send their invitation.

Based on a suggestion from @scruti, I've refactored some of the controller conditions into the existing `SendUserInvitationJob` job, in a separate branch (see #347). The only user-facing difference will be _when_ the check for the existing invitation expiry takes place, either synchronously within the request, or asynchronously within the job. I think the latter is probably better, as it moves the check closer to when the e-mail is actually sent, reducing the likelihood of the the invitation expiring before the user can use it.

Trello card: https://trello.com/c/7CHn7yzy/391-reset-password-for-people-who-have-received-an-invite-but-have-not-completed-account-set-up

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Has acceptance criteria been tested by a peer?