### PR TITLE
Get pull request number from event context

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   cleanup_reviewapp:
     name: Delete review app
@@ -23,21 +26,7 @@ jobs:
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
 
-    - name: Get Pull Request ID using GitHub API
-      if: github.event.pull_request.merged == true
-      run: |
-        pr_number=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
-        echo "::set-env name=PR_NUMBER::$pr_number"
-
-    - name: Get Pull Request ID from GITHUB_REF
-      if: github.event.pull_request.merged != true
-      run: |
-        pr_number=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
-        echo "::set-env name=PR_NUMBER::$pr_number"
-
     - name: Delete review app
-      env:
-        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
@@ -47,7 +36,6 @@ jobs:
 
     - name: Deactivate Github deploy
       env:
-        PR_NUMBER: ${{ env.PR_NUMBER }}
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
       run: |
         source psd-web/deploy-github-functions.sh


### PR DESCRIPTION
This is a simpler method of getting the pull request number, rather than having to either parse the `GITHUB_REF` env variable, or query the GitHub API.

See https://github.community/t5/GitHub-Actions/GITHUB-REF-is-inconsistent/m-p/48843#M7301