### PR TITLE
Fix bug where city would not appear in summary list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 2020-03-09
-- City or town not being displayed when adding a an address to a business.
+- Fixed City or town not being displayed when adding an address to a business.
 
 ## 2020-03-06
 - Fixed an error which was displayed when deleting an attachment from a product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2020-03-09
+- City or town not being displayed when adding a an address to a business.
+
 ## 2020-03-06
 - Fixed an error which was displayed when deleting an attachment from a product.
 

--- a/psd-web/app/helpers/businesses_helper.rb
+++ b/psd-web/app/helpers/businesses_helper.rb
@@ -40,7 +40,7 @@ module BusinessesHelper
       :legal_name,
       :trading_name,
       :company_number,
-      locations_attributes: %i[id name address_line_1 address_line_2 phone_number county country postal_code],
+      locations_attributes: %i[id name address_line_1 address_line_2 phone_number city county country postal_code],
       contacts_attributes: %i[id name email phone_number job_title]
     )
   end

--- a/psd-web/app/models/location.rb
+++ b/psd-web/app/models/location.rb
@@ -14,6 +14,7 @@ class Location < ApplicationRecord
       address_line_1,
       address_line_2,
       postal_code,
+      city,
       country_from_code(country)
     ].reject(&:blank?).join(", ")
   end

--- a/psd-web/app/models/location.rb
+++ b/psd-web/app/models/location.rb
@@ -13,8 +13,8 @@ class Location < ApplicationRecord
     [
       address_line_1,
       address_line_2,
-      postal_code,
       city,
+      postal_code,
       country_from_code(country)
     ].reject(&:blank?).join(", ")
   end

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticsearch, :with_stubbed_keycloak_config, type: :feature do
+RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticsearch, :with_stubbed_keycloak_config do
   let(:city)          { Faker::Space.planet }
   let(:trading_name)  { Faker::Company.name }
   let(:investigation) { create(:enquiry) }

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
 
 RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticsearch, :with_stubbed_keycloak_config do
-  let(:city)          { Faker::Space.planet }
-  let(:trading_name)  { Faker::Company.name }
-  let(:investigation) { create(:enquiry) }
+  let(:city)             { Faker::Address.city }
+  let(:trading_name)     { Faker::Company.name }
+  let(:business_details) { Faker::Company.buzzword }
+  let(:company_number)   { SecureRandom.hex }
+  let(:address_line_one) { Faker::Address.street_address }
+  let(:address_line_two) { Faker::Address.secondary_address }
+  let(:postcode)         { Faker::Address.postcode }
+  let(:country)          { Country.all.sample.first }
+  let(:name)             { Faker::TvShows::TheITCrowd.character }
+  let(:email)            { Faker::TvShows::TheITCrowd.email }
+  let(:phone_number)     { Faker::PhoneNumber.phone_number  }
+  let(:job_title)        { Faker::Job.title }
+  let(:investigation)    { create(:enquiry) }
 
   before { sign_in }
 
@@ -13,13 +23,44 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
     choose "Manufacturer"
     click_on "Continue"
 
-    fill_in "Trading name", with: trading_name
-    fill_in "Town or city", with: city
+    within_fieldset "Business details" do
+      fill_in "Trading name",             with: trading_name
+      fill_in "Registered or legal name", with: business_details
+      fill_in "Company number",           with: company_number
+    end
+
+    within_fieldset "Address" do
+      fill_in "Address line one",    with: address_line_one
+      fill_in "Address line two",    with: address_line_two
+      fill_in "Town or city",        with: city
+      fill_in "Postcode",            with: postcode
+      select country,                from: "Country"
+    end
+
+    within_fieldset "Contact" do
+      fill_in "Name",                          with: name
+      fill_in "Email",                         with: email
+      fill_in "Phone number",                  with: phone_number
+      fill_in "Job title or role description", with: job_title
+    end
+
     click_on "Save business"
 
     click_on "Businesses (#{investigation.businesses.count})"
 
-    expect(page).to have_css("dt.govuk-summary-list__key", text: "Address")
-    expect(page).to have_css("dd.govuk-summary-list__value", text: city)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Trading name")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: trading_name)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Registered or legal name")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: business_details)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Company number")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: company_number)
+
+    expected_address = [address_line_one, address_line_two, city, postcode, country].join(", ")
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Address")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: expected_address)
+
+    expected_contact = [name, job_title, phone_number, email].join(", ")
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Contact")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: expected_contact)
   end
 end

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticsearch, :with_stubbed_keycloak_config, type: :feature do
+  let(:city)          { Faker::Space.planet }
+  let(:trading_name)  { Faker::Company.name }
+  let(:investigation) { create(:enquiry) }
+
+  before { sign_in }
+
+  it "allows the relevent params to be posted" do
+    visit "/cases/#{investigation.pretty_id}/businesses/new"
+
+    choose "Manufacturer"
+    click_on "Continue"
+
+    fill_in "Trading name", with: trading_name
+    fill_in "Town or city", with: city
+    click_on "Save business"
+
+    click_on "Businesses (#{investigation.businesses.count})"
+
+    expect(page).to have_css("dt.govuk-summary-list__key", text: "Address")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: city)
+  end
+end

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
 
   before { sign_in }
 
-  it "allows the relevent params to be posted" do
+  scenario "Adding a business" do
     visit "/cases/#{investigation.pretty_id}/businesses/new"
 
     choose "Manufacturer"

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -275,7 +275,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
   def expect_case_businesses_page_to_show(label:, business:)
     expect(page).to have_selector("h1", text: "Businesses")
 
-    expected_address = business.slice(:address_1, :address_2, :postcode, :country).values.join(", ")
+    expected_address = business.slice(:address_1, :address_2, :town, :postcode, :country).values.join(", ")
     expected_contact = business.slice(:contact_name, :contact_job_title, :contact_phone, :contact_email).values.join(", ")
 
     section = page.find("h2", text: label).find("+dl")

--- a/psd-web/test/system/investigation_business_test.rb
+++ b/psd-web/test/system/investigation_business_test.rb
@@ -13,17 +13,8 @@ class InvestigationBusinessTest < ApplicationSystemTestCase
     visit new_investigation_business_path(@investigation)
   end
 
-  test "create a business on investigation" do
-    select_business_type
-    click_on "Continue"
-    fill_in_business_details
-    click_on "Save business"
-    click_on "Businesses_id"
-    assert_text @business.trading_name
-  end
-
   test "should not create business if name is missing" do
-    select_business_type
+    choose "business_type_importer", visible: false
     click_on "Continue"
     fill_in "business[legal_name]", with: @business.legal_name
     fill_in "business[trading_name]", with: ""
@@ -48,23 +39,5 @@ class InvestigationBusinessTest < ApplicationSystemTestCase
     assert_text @business.trading_name
     click_on "Remove business"
     assert_no_text @business.trading_name
-  end
-
-  def select_business_type
-    choose "business_type_importer", visible: false
-  end
-
-  def select_business_type_other
-    choose "business_type_other", visible: false
-    fill_in "business[type_other]", with: "Other"
-  end
-
-  def fill_in_business_details
-    fill_in "business[legal_name]", with: @business.legal_name
-    fill_in "business[trading_name]", with: @business.trading_name
-    fill_in "business[company_number]", with: @business.company_number
-    fill_in "business_locations_attributes_0_address_line_1", with: @location.address_line_1
-    fill_in "business_locations_attributes_0_postal_code", with: @location.postal_code
-    fill_in "business_contacts_attributes_0_name", with: @contact.name
   end
 end


### PR DESCRIPTION
https://trello.com/c/P1g6aPTq/342-town-or-city-does-not-appear-when-added-to-a-case

## Description
1. The city params wasn't permitted in strong params
2. The city was simply not used in summary

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [x] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [x] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?

![Screen Shot 2020-03-09 at 15 00 46](https://user-images.githubusercontent.com/100796/76231269-e6435480-621c-11ea-9781-723537068fae.png)
![Screen Shot 2020-03-09 at 15 01 06](https://user-images.githubusercontent.com/100796/76231278-e7748180-621c-11ea-9acf-5d2e375a368e.png)

