### PR TITLE
Fix typo in .env example file

### DIFF
--- a/psd-web/.env.development.example
+++ b/psd-web/.env.development.example
@@ -17,4 +17,4 @@ ANTIVIRUS_URL=http://localhost:3006/safe
 ANTIVIRUS_USERNAME=av
 ANTIVIRUS_PASSWORD=password
 
-KEYCLOACK_REDIRECT_URI=http://localhost:3000/users/auth/openid_connect/callback
+KEYCLOAK_REDIRECT_URI=http://localhost:3000/users/auth/openid_connect/callback


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Fixes "Invalid parameter: redirect_uri" error from Keycloak when attempting to sign in in development mode.