### PR TITLE
Remove keycloak_credentials table from schema

### DIFF
--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -174,17 +174,6 @@ ActiveRecord::Schema.define(version: 2020_02_25_163932) do
     t.index ["updated_at"], name: "index_investigations_on_updated_at"
   end
 
-  create_table "keycloak_credentials", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "credential_type"
-    t.string "email"
-    t.string "encrypted_password"
-    t.integer "hash_iterations"
-    t.binary "salt"
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_keycloak_credentials_on_email"
-  end
-
   create_table "locations", id: :serial, force: :cascade do |t|
     t.string "address_line_1"
     t.string "address_line_2"


### PR DESCRIPTION
This shouldn't be in the schema, as this table isn't added as a migration but instead these columns were added to the users table in the migration `MoveKeycloakCredentialsToUsers`.

I think this was left in the schema accidentally from another branch.