### PR TITLE
Backport all relevant database changes and syncing keycloak db

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,5 +2,8 @@ exclude_patterns:
 - "psd-web/db/"
 - "psd-web/test/"
 - "psd-web/spec/"
+- "psd-web/config/initializers/sidekiq.rb"
+- "psd-web/app/models/keycloak_connector.rb"
+- "psd-web/app/assets/10-million-password-list-top-1000000.txt"
 - "infrastructure/"
 - "docker/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,5 @@ exclude_patterns:
 - "psd-web/spec/"
 - "psd-web/config/initializers/sidekiq.rb"
 - "psd-web/app/models/keycloak_connector.rb"
-- "psd-web/app/assets/10-million-password-list-top-1000000.txt"
 - "infrastructure/"
 - "docker/"

--- a/infrastructure/env/get-env-from-vcap.sh
+++ b/infrastructure/env/get-env-from-vcap.sh
@@ -12,3 +12,6 @@ echo $VCAP_SERVICES | ./env/jq -r '
                 | "\(.key)=\(.value)"
         )
         | @tsv'
+
+echo "KEYCLOAK_DATABASE_URI=$(echo $VCAP_SERVICES | ./env/jq -r '.postgres[] | select(.name == "keycloak-database") .credentials .uri')"
+echo "DATABASE_URL=$(echo $VCAP_SERVICES | ./env/jq -r '.postgres[] | select(.name|test("psd-d*")) .credentials .uri')"

--- a/psd-web/app/jobs/sync_keycloak_db_job.rb
+++ b/psd-web/app/jobs/sync_keycloak_db_job.rb
@@ -1,0 +1,5 @@
+class SyncKeycloakDbJob < ApplicationJob
+  def perform
+    KeycloakConnector.copy_keycloak_data
+  end
+end

--- a/psd-web/app/models/keycloak_connector.rb
+++ b/psd-web/app/models/keycloak_connector.rb
@@ -1,0 +1,50 @@
+class KeycloakConnector < ApplicationRecord
+  COLUMNS = <<~SQL.freeze
+    ue.email,
+
+    ue.first_name,
+    ue.last_name,
+    ue.username,
+    ue.created_timestamp,
+
+    c.salt,
+    c.value as crypted_password,
+    c.hash_iterations,
+    c.type,
+
+    ua.value as mobile_number,
+
+    ue.id, ua.user_id, c.user_id, ua.name
+  SQL
+
+  CREDENTIALS_QUERY = <<~SQL.freeze
+    SELECT
+    #{COLUMNS}
+    FROM user_entity ue
+    LEFT JOIN credential c ON ue.id = c.user_id AND c.type = 'password'
+    LEFT JOIN user_attribute ua ON ue.id = ua.user_id AND ua.name = 'mobile_number';
+  SQL
+
+  establish_connection :keycloak
+
+  def self.copy_keycloak_data
+    rows = KeycloakConnector.connection.query(CREDENTIALS_QUERY)
+    rows.each do |row|
+      user = User.find_by(email: row[0])
+      next unless user
+
+      user.keycloak_created_at = Time.zone.at(row[4])
+
+      user.password_salt = row[5]
+      user.encrypted_password = row[6] if row[6] # don't copy over nil password
+      user.hash_iterations = row[7]
+      user.credential_type = row[8]
+
+      user.mobile_number = row[9]
+
+      unless user.save
+        Rails.logger.info("[KeycloakConnector] User with id #{user.id} failed with errors: #{user.errors.try(:full_messages)}")
+      end
+    end
+  end
+end

--- a/psd-web/app/models/keycloak_connector.rb
+++ b/psd-web/app/models/keycloak_connector.rb
@@ -28,7 +28,6 @@ class KeycloakConnector < ApplicationRecord
   establish_connection :keycloak
 
   def self.copy_keycloak_data
-    return
     rows = KeycloakConnector.connection.query(CREDENTIALS_QUERY)
     rows.each do |row|
       user = User.find_by(email: row[0])

--- a/psd-web/app/models/keycloak_connector.rb
+++ b/psd-web/app/models/keycloak_connector.rb
@@ -28,6 +28,7 @@ class KeycloakConnector < ApplicationRecord
   establish_connection :keycloak
 
   def self.copy_keycloak_data
+    return
     rows = KeycloakConnector.connection.query(CREDENTIALS_QUERY)
     rows.each do |row|
       user = User.find_by(email: row[0])

--- a/psd-web/app/models/keycloak_connector.rb
+++ b/psd-web/app/models/keycloak_connector.rb
@@ -33,7 +33,7 @@ class KeycloakConnector < ApplicationRecord
       user = User.find_by(email: row[0])
       next unless user
 
-      user.keycloak_created_at = Time.zone.at(row[4].to_f/1000)
+      user.keycloak_created_at = Time.zone.at(row[4].to_f / 1000)
 
       user.password_salt = row[5]
       user.encrypted_password = row[6] if row[6] # don't copy over nil password

--- a/psd-web/app/models/keycloak_connector.rb
+++ b/psd-web/app/models/keycloak_connector.rb
@@ -33,7 +33,7 @@ class KeycloakConnector < ApplicationRecord
       user = User.find_by(email: row[0])
       next unless user
 
-      user.keycloak_created_at = Time.zone.at(row[4])
+      user.keycloak_created_at = Time.zone.at(row[4].to_f/1000)
 
       user.password_salt = row[5]
       user.encrypted_password = row[6] if row[6] # don't copy over nil password

--- a/psd-web/config/database.yml
+++ b/psd-web/config/database.yml
@@ -12,7 +12,16 @@ test:
   database: psd_test
 
 production:
-  url: <%= ENV["VCAP_SERVICES"] && CF::App::Credentials.find_by_service_label("postgres")["uri"] %>
+  url: <%= ENV.fetch('DATABASE_URL') %>
+  connect_timeout: 2
+  variables:
+    statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "500ms" %>
+
+keycloak:
+  adapter: postgresql
+  encoding: unicode
+  url: <%= ENV.fetch('KEYCLOAK_DATABASE_URI', 'postgres://localhost/keycloak?user=postgres') %>
+  pool: 5
   connect_timeout: 2
   variables:
     statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "500ms" %>

--- a/psd-web/config/initializers/sidekiq.rb
+++ b/psd-web/config/initializers/sidekiq.rb
@@ -57,7 +57,7 @@ Sidekiq.configure_server do |config|
   remove_files_without_attachments_job
   create_log_db_metrics_job
   schedule_keycloak_sync_job
-#  schedule_keycloak_db_job
+  schedule_keycloak_db_job
 end
 
 Sidekiq.configure_client do |config|

--- a/psd-web/config/initializers/sidekiq.rb
+++ b/psd-web/config/initializers/sidekiq.rb
@@ -38,11 +38,26 @@ def schedule_keycloak_sync_job
   end
 end
 
+def schedule_keycloak_db_job
+  keycloak_sync_job = Sidekiq::Cron::Job.new(
+    name: "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}: Sync user db data from Keycloak",
+    cron: "*/5 * * * *",
+    class: "SyncKeycloakDbJob",
+    active_job: true,
+    queue: ENV["SIDEKIQ_QUEUE"] || "psd"
+  )
+  unless keycloak_sync_job.save
+    Rails.logger.error "***** WARNING - Sync Keycloak user db data job was not saved! *****"
+    Rails.logger.error keycloak_sync_job.errors.join("; ")
+  end
+end
+
 Sidekiq.configure_server do |config|
   config.redis = Rails.application.config_for(:redis_store)
   remove_files_without_attachments_job
   create_log_db_metrics_job
   schedule_keycloak_sync_job
+  schedule_keycloak_db_job
 end
 
 Sidekiq.configure_client do |config|

--- a/psd-web/config/initializers/sidekiq.rb
+++ b/psd-web/config/initializers/sidekiq.rb
@@ -57,7 +57,7 @@ Sidekiq.configure_server do |config|
   remove_files_without_attachments_job
   create_log_db_metrics_job
   schedule_keycloak_sync_job
-  schedule_keycloak_db_job
+#  schedule_keycloak_db_job
 end
 
 Sidekiq.configure_client do |config|

--- a/psd-web/db/migrate/20200211150409_add_devise_to_users.rb
+++ b/psd-web/db/migrate/20200211150409_add_devise_to_users.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddDeviseToUsers < ActiveRecord::Migration[5.2]
+  # rubocop:disable Rails/BulkChangeTable
+  def change
+    safety_assured do
+      change_table :users do |t|
+        ## Database authenticatable
+        t.string :encrypted_password, null: false, default: ""
+
+        ## Recoverable
+        t.string   :reset_password_token
+        t.datetime :reset_password_sent_at
+
+        ## Rememberable
+        t.datetime :remember_created_at
+
+        ## Trackable
+        t.integer  :sign_in_count, default: 0, null: false
+        t.datetime :current_sign_in_at
+        t.datetime :last_sign_in_at
+        t.inet     :current_sign_in_ip
+        t.inet     :last_sign_in_ip
+      end
+
+      add_index :users, :reset_password_token, unique: true
+    end
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/psd-web/db/migrate/20200214155213_add_invitation_token_to_users.rb
+++ b/psd-web/db/migrate/20200214155213_add_invitation_token_to_users.rb
@@ -1,0 +1,10 @@
+class AddInvitationTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      change_table :users, bulk: true do |t|
+        t.text :invitation_token
+        t.datetime :invited_at
+      end
+    end
+  end
+end

--- a/psd-web/db/migrate/20200220142847_add_mobile_number.rb
+++ b/psd-web/db/migrate/20200220142847_add_mobile_number.rb
@@ -1,0 +1,5 @@
+class AddMobileNumber < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :mobile_number, :text
+  end
+end

--- a/psd-web/db/migrate/20200221134756_move_keycloak_credentials_to_users.rb
+++ b/psd-web/db/migrate/20200221134756_move_keycloak_credentials_to_users.rb
@@ -1,0 +1,11 @@
+class MoveKeycloakCredentialsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      change_table :users, bulk: true do
+        add_column :users, :password_salt, :binary
+        add_column :users, :hash_iterations, :integer, default: 27_500
+        add_column :users, :credential_type, :string
+      end
+    end
+  end
+end

--- a/psd-web/db/migrate/20200225103836_enable_pgcrypto.rb
+++ b/psd-web/db/migrate/20200225103836_enable_pgcrypto.rb
@@ -1,0 +1,7 @@
+class EnablePgcrypto < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      enable_extension "pgcrypto"
+    end
+  end
+end

--- a/psd-web/db/migrate/20200225103936_generate_uuid_for_organizations_teams_and_users.rb
+++ b/psd-web/db/migrate/20200225103936_generate_uuid_for_organizations_teams_and_users.rb
@@ -1,0 +1,9 @@
+class GenerateUuidForOrganizationsTeamsAndUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      change_column_default(:organisations, :id, from: nil, to: "gen_random_uuid()")
+      change_column_default(:users, :id, from: nil, to: "gen_random_uuid()")
+      change_column_default(:teams, :id, from: nil, to: "gen_random_uuid()")
+    end
+  end
+end

--- a/psd-web/db/migrate/20200309120706_add_keycloak_import_fields_to_users.rb
+++ b/psd-web/db/migrate/20200309120706_add_keycloak_import_fields_to_users.rb
@@ -1,0 +1,9 @@
+class AddKeycloakImportFieldsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      change_table(:users, bulk: true) do |t|
+        t.datetime :keycloak_created_at
+      end
+    end
+  end
+end

--- a/psd-web/db/migrate/20200310170356_trigger_schema_for_review_app.rb
+++ b/psd-web/db/migrate/20200310170356_trigger_schema_for_review_app.rb
@@ -1,0 +1,5 @@
+class TriggerSchemaForReviewApp < ActiveRecord::Migration[5.2]
+  def change
+    # Not the most elegant way, but works. To prevent clash with `keycloak-replacement` review apps DBs, update schema version
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_120706) do
+ActiveRecord::Schema.define(version: 2020_03_10_170356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_120801) do
+ActiveRecord::Schema.define(version: 2020_03_09_120706) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
@@ -188,7 +189,7 @@ ActiveRecord::Schema.define(version: 2020_02_12_120801) do
     t.index ["business_id"], name: "index_locations_on_business_id"
   end
 
-  create_table "organisations", id: :uuid, default: nil, force: :cascade do |t|
+  create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
     t.string "path"
@@ -227,7 +228,7 @@ ActiveRecord::Schema.define(version: 2020_02_12_120801) do
     t.index ["user_id"], name: "index_sources_on_user_id"
   end
 
-  create_table "teams", id: :uuid, default: nil, force: :cascade do |t|
+  create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
     t.uuid "organisation_id"
@@ -271,20 +272,37 @@ ActiveRecord::Schema.define(version: 2020_02_12_120801) do
     t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
-  create_table "users", id: :uuid, default: nil, force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "account_activated", default: false
     t.datetime "created_at", null: false
+    t.string "credential_type"
+    t.datetime "current_sign_in_at"
+    t.inet "current_sign_in_ip"
     t.string "email"
+    t.string "encrypted_password", default: "", null: false
     t.boolean "has_accepted_declaration", default: false
     t.boolean "has_been_sent_welcome_email", default: false
     t.boolean "has_viewed_introduction", default: false
+    t.integer "hash_iterations", default: 27500
+    t.text "invitation_token"
+    t.datetime "invited_at"
+    t.datetime "keycloak_created_at"
+    t.datetime "last_sign_in_at"
+    t.inet "last_sign_in_ip"
+    t.text "mobile_number"
     t.string "name"
     t.uuid "organisation_id"
+    t.binary "password_salt"
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["account_activated"], name: "index_users_on_account_activated"
     t.index ["email"], name: "index_users_on_email"
     t.index ["name"], name: "index_users_on_name"
     t.index ["organisation_id"], name: "index_users_on_organisation_id"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "activities", "businesses"

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   path: .
   stack: cflinuxfs3
   routes:
@@ -30,9 +30,10 @@ applications:
     - psd-sentry-env
     - psd-sidekiq-env
     - antivirus-auth-env
+    - keycloak-database
   processes:
     - type: web
-      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate keycloak:sync && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate keycloak:sync db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
       memory: 1G
     - type: worker

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
   path: .
   stack: cflinuxfs3
   routes:

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   path: .
   stack: cflinuxfs3
   routes:
@@ -28,6 +28,7 @@ applications:
     - psd-sidekiq-env
     - psd-web-scout-env
     - antivirus-auth-env
+    - keycloak-database
   processes:
     - type: web
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate keycloak:sync && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.13
   path: .
   stack: cflinuxfs3
   routes:


### PR DESCRIPTION
This is first step of rolling out devise to production. This PR:
* backports all database schema changes from `keycloak-replacement` branch to master
* adds code to synchronize keycloak credentials into `users` table

This way we will be able to deploy `keycloak-replacement` branch alongside production to test it. It will assure zero-downtime switch.

It will require running `cf update-service database -c '{"enable_extensions": ["pgcrypto"], "reboot": true}'` on staging and production environemnts

Checks
- [ ] Review app is working properly
- [x] Changing password on keycloak will be copied over
- [x] No bugs in jobs, all jobs are running
