### PR TITLE
Alert team via Slack of deployment failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,3 +134,11 @@ jobs:
       run: |
         source psd-web/deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL
+
+    - name: Alert team via Slack of deployment failure
+      if: failure()
+      env:
+        LOG_URL: ${{ env.LOG_URL }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      run: |
+        curl -X POST --data-urlencode "payload={\"channel\": \"#alerts\", \"username\": \"deploybot\", \"text\": \"Deploy has failed!\n\nSee $LOG_URL\", \"icon_emoji\": \":fire:\"}" $SLACK_WEBHOOK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,6 @@ jobs:
       if: failure()
       env:
         LOG_URL: ${{ env.LOG_URL }}
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{ secrets.SlackWebhookUrl }}
       run: |
         curl -X POST --data-urlencode "payload={\"channel\": \"#alerts\", \"username\": \"deploybot\", \"text\": \"Deploy has failed!\n\nSee $LOG_URL\", \"icon_emoji\": \":fire:\"}" $SLACK_WEBHOOK


### PR DESCRIPTION
This should help us become aware of deployment failures faster.

Requires a new `SLACK_WEBHOOK` secret to be added to GitHub.