### PR TITLE
Bump govuk-design-system-rails

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -42,7 +42,7 @@ gem "strong_migrations", "0.6.2"
 gem "webpacker", "4.2.2"
 gem "wicked"
 
-gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.2", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.3", require: "govuk_design_system"
 
 # rubocop:disable Metrics/BlockLength
 group :development, :test do

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
-  revision: 23cecd7a133b6f26d1924cddf9f39b29330e91a3
-  tag: 0.6.2
+  revision: b86c294c043beffa409f4d0afc56d857c31378b5
+  tag: 0.6.3
   specs:
-    govuk-design-system-rails (0.6.2)
+    govuk-design-system-rails (0.6.3)
 
 GIT
   remote: https://github.com/randym/axlsx.git


### PR DESCRIPTION
Bump the `govuk-design-system-rails` gem to [0.6.3](https://github.com/UKGovernmentBEIS/govuk-design-system-rails/releases/tag/0.6.3).

Includes a bugfix for an ARIA attribute: https://github.com/UKGovernmentBEIS/govuk-design-system-rails/commit/baddb391fd7f684c752e7f6649f142dae51f4210

https://trello.com/c/F2xTxkMv/415-bugfix-typo-in-aria-attribute