### PR TITLE
Un-nest the fieldset within the address form

### DIFF
--- a/psd-web/app/views/locations/_address_form.html.slim
+++ b/psd-web/app/views/locations/_address_form.html.slim
@@ -1,12 +1,13 @@
 = render "components/govuk_fieldset",
         legend: { text: "Address", classes: "govuk-fieldset__legend--m" } do
-  = render "components/govuk_fieldset", legend: { text: "Building and street" } do
-    = render "form_components/govuk_input", key: :address_line_1, form: form,
-            label: { text: "Address line one", classes: "govuk-visually-hidden" },
-            classes: "govuk-!-width-two-thirds"
-    = render "form_components/govuk_input", key: :address_line_2, form: form,
-            label: { text: "Address line two", classes: "govuk-visually-hidden" },
-            classes: "govuk-!-width-two-thirds"
+
+  = render "form_components/govuk_input", key: :address_line_1, form: form,
+          label: { html: "Building and street <span class=\"govuk-visually-hidden\">line 1 of 2</span>".html_safe },
+          classes: "govuk-!-width-two-thirds"
+
+  = render "form_components/govuk_input", key: :address_line_2, form: form,
+          label: { text: "Building and street line 2 of 2", classes: "govuk-visually-hidden" },
+          classes: "govuk-!-width-two-thirds"
 
   = render "form_components/govuk_input", key: :city, form: form,
           label: { text: "Town or city" },

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -30,8 +30,8 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
     end
 
     within_fieldset "Address" do
-      fill_in "Address line one",    with: address_line_one
-      fill_in "Address line two",    with: address_line_two
+      fill_in "Building and street line 1 of 2",    with: address_line_one
+      fill_in "Building and street line 2 of 2",    with: address_line_two
       fill_in "Town or city",        with: city
       fill_in "Postcode",            with: postcode
       select country,                from: "Country"

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -346,18 +346,18 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
   end
 
   def fill_in_business_details_page(with:)
-    fill_in "Trading name",                  with: with[:trading_name]
-    fill_in "Registered or legal name",      with: with[:legal_name]
-    fill_in "Company number",                with: with[:company_number]
-    fill_in "Address line one",              with: with[:address_1]
-    fill_in "Address line two",              with: with[:address_2]
-    fill_in "Town or city",                  with: with[:town]
-    fill_in "County",                        with: with[:county]
-    fill_in "Postcode",                      with: with[:postcode]
-    fill_in "Name",                          with: with[:contact_name]
-    fill_in "Email",                         with: with[:contact_email]
-    fill_in "Phone number",                  with: with[:contact_phone]
-    fill_in "Job title or role description", with: with[:contact_job_title]
+    fill_in "Trading name",                    with: with[:trading_name]
+    fill_in "Registered or legal name",        with: with[:legal_name]
+    fill_in "Company number",                  with: with[:company_number]
+    fill_in "Building and street line 1 of 2", with: with[:address_1]
+    fill_in "Building and street line 2 of 2", with: with[:address_2]
+    fill_in "Town or city",                    with: with[:town]
+    fill_in "County",                          with: with[:county]
+    fill_in "Postcode",                        with: with[:postcode]
+    fill_in "Name",                            with: with[:contact_name]
+    fill_in "Email",                           with: with[:contact_email]
+    fill_in "Phone number",                    with: with[:contact_phone]
+    fill_in "Job title or role description",   with: with[:contact_job_title]
     select with[:country], from: "Country"
     click_button "Continue"
   end


### PR DESCRIPTION
Updates the address form to follow the [Addresses design pattern](https://design-system.service.gov.uk/patterns/addresses/), which avoids nested fieldsets and uses hidden text to label the first two fields as

Building and street [line 1 of 2]
[Building and street line 2 of 2]

https://trello.com/c/iav7T6JZ/419-bugfix-incorrectly-nested-fieldsets-on-address-form