### PR TITLE
bump govuk-design-system-rails from 0.6.3 to 0.6.4

### DIFF
--- a/psd-web/Gemfile
+++ b/psd-web/Gemfile
@@ -42,7 +42,7 @@ gem "strong_migrations", "0.6.2"
 gem "webpacker", "4.2.2"
 gem "wicked"
 
-gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.3", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.6.4", require: "govuk_design_system"
 
 # rubocop:disable Metrics/BlockLength
 group :development, :test do

--- a/psd-web/Gemfile.lock
+++ b/psd-web/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
-  revision: b86c294c043beffa409f4d0afc56d857c31378b5
-  tag: 0.6.3
+  revision: b44505ea1abf3d5fdaffd722fdd1c24583f414cc
+  tag: 0.6.4
   specs:
-    govuk-design-system-rails (0.6.3)
+    govuk-design-system-rails (0.6.4)
 
 GIT
   remote: https://github.com/randym/axlsx.git


### PR DESCRIPTION
Fixes bugs:

* Remove unneeded id and class (https://github.com/UKGovernmentBEIS/govuk-design-system-rails/pull/19)
* Add space before visually hidden text (https://github.com/UKGovernmentBEIS/govuk-design-system-rails/pull/20)