### PR TITLE
Update cookies banner to fix accessibility issues

### DIFF
--- a/psd-web/app/assets/stylesheets/cookie-banner.scss
+++ b/psd-web/app/assets/stylesheets/cookie-banner.scss
@@ -1,4 +1,5 @@
 $govuk-cookie-banner-background: #d5e8f3;
+$cookie-banner-link-colour: #005EA5;
 
 .cookie-banner {
   @include govuk-font($size: 16);
@@ -9,4 +10,10 @@ $govuk-cookie-banner-background: #d5e8f3;
 .cookie-banner__message {
   margin-top: 0;
   margin-bottom: 0;
+}
+
+// Make the links a slightly darker blue for increased contrast
+// against the light-blue background.
+.cookie-banner .govuk-link {
+  color: $cookie-banner-link-colour;
 }

--- a/psd-web/app/assets/stylesheets/helpers/js-only.scss
+++ b/psd-web/app/assets/stylesheets/helpers/js-only.scss
@@ -1,0 +1,9 @@
+// This can be added to any element to hide it when javascript
+// is not enabled or available.
+//
+// This relies upon an inline script which adds the js-enabled class to
+// the <body> element.
+// See https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk#L31
+body:not(.js-enabled) .js-only {
+  display: none;
+}

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -17,6 +17,7 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 @import "stylesheets/footer";
 @import "stylesheets/form";
 @import "stylesheets/header";
+@import "stylesheets/helpers/js-only";
 @import "stylesheets/helpers/field-widths";
 @import "stylesheets/helpers/media-queries";
 @import "stylesheets/images";

--- a/psd-web/app/views/layouts/_cookie_banner.html.erb
+++ b/psd-web/app/views/layouts/_cookie_banner.html.erb
@@ -7,7 +7,7 @@
         or
         <%= link_to "#", id: "hideLink", class: "govuk-link" do %>
           hide this
-          <span class="govuk-visually-hiddenx">cookie</span>
+          <span class="govuk-visually-hidden">cookie</span>
           message
         <% end %>
       </span>

--- a/psd-web/app/views/layouts/_cookie_banner.html.erb
+++ b/psd-web/app/views/layouts/_cookie_banner.html.erb
@@ -1,0 +1,16 @@
+<% if !cookies[:seen_cookie_message] %>
+  <div class="cookie-banner" id="global-cookie-message">
+    <p class="cookie-banner__message govuk-width-container">
+      GOV.UK uses cookies to make the site simpler.
+      <%= link_to "Find out more about cookies", help_privacy_notice_path(anchor: "cookies-policy"), class: "govuk-link" %>
+      <span class="js-only">
+        or
+        <%= link_to "#", id: "hideLink", class: "govuk-link" do %>
+          hide this
+          <span class="govuk-visually-hiddenx">cookie</span>
+          message
+        <% end %>
+      </span>
+    </p>
+  </div>
+<% end %>

--- a/psd-web/app/views/layouts/application.html.slim
+++ b/psd-web/app/views/layouts/application.html.slim
@@ -45,7 +45,7 @@ html.govuk-template.app-html-class[lang="en"]
     a.govuk-skip-link[href="#main-content"]
       | Skip to main content
 
-    = render "components/govuk_cookie_banner", path: help_privacy_notice_path(anchor: "cookies-policy")
+    = render "layouts/cookie_banner"
 
     = render "components/psd_header",
             productName: "Product safety database",


### PR DESCRIPTION
Fixes 2 accessibility issues within the cookies banner:

* Makes the blue links darker, so that they have higher contrast against the light blue background colour. (See [Trello card](https://trello.com/c/BhpqZVSb/417-accessibility-issue-improve-contrast-of-the-links-in-the-cookies-banner) )
* Adds some visually-hidden text so that the "hide this message" link makes sense when announced out of context. (see [Trello card](https://trello.com/c/xCHsFhOk/418-accessibility-issue-make-the-dismiss-cookies-banner-link-make-sense-of-out-context) )

Also hides the "hide this message" link when javascript disabled, as it requires javascript to work.

Note: I've moved this view from the [shared govuk-design-system-rails repo](https://github.com/UKGovernmentBEIS/govuk-design-system-rails/blob/master/app/views/components/_govuk_cookie_banner.html.slim) to within the application, as this isn't part of the GOV.UK Design System, and feels more application-specific.