### PR TITLE
Add "skip to results" link for case searches

### DIFF
--- a/psd-web/app/views/investigations/_filters.html.slim
+++ b/psd-web/app/views/investigations/_filters.html.slim
@@ -7,6 +7,8 @@
                 label: { text: "Keywords", classes: "govuk-label--s" }
         = form.submit "Search", name: nil, class: "search-box--submit"
 
+      = govukSkipLink(text: "Skip to results", href: "#results")
+
       hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
       = render "form_components/govuk_checkboxes", form: form, key: :assigned_to,
         classes: "govuk-checkboxes--small",

--- a/psd-web/app/views/investigations/index.html.slim
+++ b/psd-web/app/views/investigations/index.html.slim
@@ -5,7 +5,7 @@
   = render 'investigations/filters', search: @search,\
       show_relevancy_radion_option: false, submitted_from: "investigation_listing"
 
-  .govuk-grid-column-three-quarters
+  #results.govuk-grid-column-three-quarters
     - if @investigations.any?
       = render partial: "investigations/table", collection: @investigations, as: :investigation,\
          locals: { sorted_by: query_params[:sort_by] }

--- a/psd-web/app/views/searches/show.html.slim
+++ b/psd-web/app/views/searches/show.html.slim
@@ -5,7 +5,7 @@
   = render 'investigations/filters', search: @search,\
       show_relevancy_radion_option: true, submitted_from: "investigation_search"
 
-  .govuk-grid-column-three-quarters
+  #results.govuk-grid-column-three-quarters
     - @investigations.each do |investigation|
       - result = @answer.results.find { |rs| rs.id.to_i == investigation.id }
       - if result.respond_to?(:highlight)

--- a/psd-web/config/initializers/shared_rails_config.rb
+++ b/psd-web/config/initializers/shared_rails_config.rb
@@ -7,3 +7,4 @@ Rails.application.config.action_view.field_error_proc = Proc.new { |html_tag, _|
 Rails.application.config.action_view.form_with_generates_ids = true
 
 ActionView::Base.include GovukDesignSystem::ComponentsHelper
+ActionView::Base.include GovukDesignSystem::SkipLinkHelper


### PR DESCRIPTION
This allows keyboard users to skip past the filters and jump to the search results. The link only appears when tabbing through the page.

## Screenshot

<img width="279" alt="Screenshot 2020-03-12 at 16 58 13" src="https://user-images.githubusercontent.com/30665/76546041-b5645900-6482-11ea-9e07-634a4e272b5b.png">

See https://trello.com/c/xbKqrrYI/421-add-skip-link-to-pages-with-search-results