### PR TITLE
Move all captions outside of h1 elements

### DIFF
--- a/psd-web/app/views/application/_business_heading.html.slim
+++ b/psd-web/app/views/application/_business_heading.html.slim
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l
+      | Business
     h1.govuk-heading-l
-      span.govuk-caption-l
-        | Business
       = business.trading_name

--- a/psd-web/app/views/application/_investigation_heading.html.slim
+++ b/psd-web/app/views/application/_investigation_heading.html.slim
@@ -1,3 +1,3 @@
+span.govuk-caption-l = investigation.pretty_description
 h1.govuk-heading-l
-  span.govuk-caption-l = investigation.pretty_description
   = investigation.title

--- a/psd-web/app/views/application/_minimal_investigation_heading.html.slim
+++ b/psd-web/app/views/application/_minimal_investigation_heading.html.slim
@@ -1,4 +1,4 @@
+span.govuk-caption-l
+  = investigation.pretty_description
 h1.govuk-heading-l
-  span.govuk-caption-l
-    = investigation.pretty_description
   = title

--- a/psd-web/app/views/application/_product_heading.html.slim
+++ b/psd-web/app/views/application/_product_heading.html.slim
@@ -1,8 +1,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l
+      | Product
     h1.govuk-heading-l
-      span.govuk-caption-l
-        | Product
       = product.name
       p.gov-uk-caption-m
         = product.created_at.strftime("%d %B %Y")

--- a/psd-web/app/views/businesses/index.html.slim
+++ b/psd-web/app/views/businesses/index.html.slim
@@ -1,9 +1,10 @@
 - content_for :page_title, "Businesses"
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    - if params[:q].present?
+      span.govuk-caption-l Business search results
     h1.govuk-heading-l
       - if params[:q].present?
-        span.govuk-caption-l Business search results
         = params[:q]
         span.govuk-caption-m = "#{@businesses.count} #{'result'.pluralize(@businesses.count)}"
       - else

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -7,8 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       | Add comment
     = form_with(model: @investigation.activities.new, \
       url: investigation_activity_comment_path(@investigation)) do |form|

--- a/psd-web/app/views/contacts/edit.html.slim
+++ b/psd-web/app/views/contacts/edit.html.slim
@@ -7,8 +7,8 @@
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
       - heading_html = capture do
+        span.govuk-caption-l = "Business: #{@business.trading_name}"
         h1.govuk-heading-l
-          span.govuk-caption-l = "Business: #{@business.trading_name}"
           | Edit contact
       = render "form", form: form, label_classes: "govuk-label--m", legend: { html: heading_html }
       = form.submit "Save", class: "govuk-button"

--- a/psd-web/app/views/contacts/new.html.slim
+++ b/psd-web/app/views/contacts/new.html.slim
@@ -7,8 +7,8 @@
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
       - heading_html = capture do
+        span.govuk-caption-l = "Business: #{@business.trading_name}"
         h1.govuk-heading-l
-          span.govuk-caption-l = "Business: #{@business.trading_name}"
           | Add contact
       = render "form", form: form, label_classes: "govuk-label--m", legend: { html: heading_html }
       = form.submit "Save", class: "govuk-button"

--- a/psd-web/app/views/contacts/remove.html.slim
+++ b/psd-web/app/views/contacts/remove.html.slim
@@ -3,9 +3,9 @@
   = link_to "Back to business", @business, class: "govuk-back-link"
 .govuk-grid-row class="govuk-!-padding-bottom-6"
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l
+      = "Business: #{@business.trading_name}"
     h1.govuk-heading-l
-      span.govuk-caption-l
-        = "Business: #{@business.trading_name}"
       | Remove contact
     table.govuk-table
       tbody.govuk-table__body

--- a/psd-web/app/views/documents_flow/metadata.html.slim
+++ b/psd-web/app/views/documents_flow/metadata.html.slim
@@ -6,6 +6,6 @@
 = render "documents/metadata_form", document: @file_blob, edit: false, target_url: wizard_path do
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
+      span.govuk-caption-l = @parent.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @parent.pretty_description
         | Add attachment

--- a/psd-web/app/views/documents_flow/upload.html.slim
+++ b/psd-web/app/views/documents_flow/upload.html.slim
@@ -7,8 +7,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form, errors: @errors
+      span.govuk-caption-l = @parent.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @parent.pretty_description
         | Add attachment
       = form.fields_for :file do |subform|
         .govuk-form-group

--- a/psd-web/app/views/investigations/_heading.html.slim
+++ b/psd-web/app/views/investigations/_heading.html.slim
@@ -1,8 +1,9 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    - if params[:q].present?
+      span.govuk-caption-l Case search results
     h1.govuk-heading-l
       - if params[:q].present?
-        span.govuk-caption-l Case search results
         = params[:q]
         span.govuk-caption-m = "#{answer.results.count} #{'result'.pluralize(answer.results.count)}"
       - else

--- a/psd-web/app/views/investigations/activities/new.html.slim
+++ b/psd-web/app/views/investigations/activities/new.html.slim
@@ -9,8 +9,8 @@
       - if error_message
         = render "components/govuk_error_summary", titleText: "There is a problem", errorList: [error_message]
       - header = capture do
+        span.govuk-caption-l = @investigation.pretty_description
         h1.govuk-heading-l
-          span.govuk-caption-l = @investigation.pretty_description
           | New activity
       = render "form_components/govuk_radios", form: form, key: :activity_type,
               errorMessage: error_message,

--- a/psd-web/app/views/investigations/alerts/about_alerts.html.slim
+++ b/psd-web/app/views/investigations/alerts/about_alerts.html.slim
@@ -5,8 +5,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     - if @investigation.is_private
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | You cannot send an alert about a restricted case
       p
         | Email alerts can only be sent for cases that are not restricted.
@@ -15,8 +15,8 @@
       = link_to "Change case visibility", visibility_investigation_path(@investigation),
               class: "govuk-button", role: "button", draggable: false
     - else
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | About alerts
       p When you send an alert:
       ul.govuk-list.govuk-list--bullet

--- a/psd-web/app/views/investigations/alerts/compose.html.slim
+++ b/psd-web/app/views/investigations/alerts/compose.html.slim
@@ -6,9 +6,9 @@
   = render "form_components/govuk_error_summary", form: form
   .govuk-grid-row
     .govuk-grid-column-two-thirds
+      span.govuk-caption-l
+        = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l
-          = @investigation.pretty_description
         | Compose new alert
       = render "form_components/govuk_input",
               form: form,

--- a/psd-web/app/views/investigations/alerts/preview.html.slim
+++ b/psd-web/app/views/investigations/alerts/preview.html.slim
@@ -5,8 +5,8 @@
 = form_with model: @alert, local: true, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Preview your alert
       .email-message
         table.email-message-meta.govuk-table

--- a/psd-web/app/views/investigations/corrective_actions/confirmation.html.slim
+++ b/psd-web/app/views/investigations/corrective_actions/confirmation.html.slim
@@ -2,8 +2,8 @@
 - content_for :page_title, page_title
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
+span.govuk-caption-l = @investigation.pretty_description
 h1.govuk-heading-l
-  span.govuk-caption-l = @investigation.pretty_description
   = page_title
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/psd-web/app/views/investigations/corrective_actions/details.html.slim
+++ b/psd-web/app/views/investigations/corrective_actions/details.html.slim
@@ -7,8 +7,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         = page_title
       = render "investigations/corrective_actions/form", form: form,
             corrective_action: @corrective_action,

--- a/psd-web/app/views/investigations/emails/confirmation.html.slim
+++ b/psd-web/app/views/investigations/emails/confirmation.html.slim
@@ -2,8 +2,8 @@
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
 
+span.govuk-caption-l = @investigation.pretty_description
 h1.govuk-heading-l
-  span.govuk-caption-l = @investigation.pretty_description
   | Confirm email details
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/psd-web/app/views/investigations/emails/content.html.slim
+++ b/psd-web/app/views/investigations/emails/content.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record email
       = render "form_components/govuk_input", key: :overview, form: form, classes: "govuk-!-width-two-thirds",
               label: { text: "Summary", classes: "govuk-label--m" },

--- a/psd-web/app/views/investigations/emails/context.html.slim
+++ b/psd-web/app/views/investigations/emails/context.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record email
       = render "components/govuk_fieldset", legend: { text: "Email details", classes: "govuk-fieldset__legend--m" } do
         = render "form_components/govuk_radios", form: form, key: :email_direction,

--- a/psd-web/app/views/investigations/meetings/confirmation.html.slim
+++ b/psd-web/app/views/investigations/meetings/confirmation.html.slim
@@ -2,8 +2,8 @@
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
 main.govuk-main-wrapper role="main"
+  span.govuk-caption-l = @investigation.pretty_description
   h1.govuk-heading-l
-    span.govuk-caption-l = @investigation.pretty_description
     | Confirm meeting details
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/psd-web/app/views/investigations/meetings/content.html.slim
+++ b/psd-web/app/views/investigations/meetings/content.html.slim
@@ -5,8 +5,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record meeting
       = render "form_components/govuk_input", key: :overview, form: form,
               classes: "govuk-!-width-two-thirds",

--- a/psd-web/app/views/investigations/meetings/context.html.slim
+++ b/psd-web/app/views/investigations/meetings/context.html.slim
@@ -5,8 +5,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record meeting
       = render "form_components/govuk_input", key: :correspondent_name, form: form,
               classes: "govuk-!-width-two-thirds",

--- a/psd-web/app/views/investigations/phone_calls/confirmation.html.slim
+++ b/psd-web/app/views/investigations/phone_calls/confirmation.html.slim
@@ -2,8 +2,8 @@
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
 main.govuk-main-wrapper role="main"
+  span.govuk-caption-l = @investigation.pretty_description
   h1.govuk-heading-l
-    span.govuk-caption-l = @investigation.pretty_description
     | Confirm phone call details
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/psd-web/app/views/investigations/phone_calls/content.html.slim
+++ b/psd-web/app/views/investigations/phone_calls/content.html.slim
@@ -5,8 +5,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record phone call
       = render "form_components/govuk_input", key: :overview, form: form, classes: "govuk-!-width-two-thirds",
               label: { text: "Summary", classes: "govuk-label--m" },

--- a/psd-web/app/views/investigations/phone_calls/context.html.slim
+++ b/psd-web/app/views/investigations/phone_calls/context.html.slim
@@ -5,8 +5,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         | Record phone call
       = render "components/govuk_fieldset",
               legend: { text: "Who was the call with?", classes: "govuk-fieldset__legend--m" } do

--- a/psd-web/app/views/investigations/tabs/_activity.html.slim
+++ b/psd-web/app/views/investigations/tabs/_activity.html.slim
@@ -4,8 +4,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
 
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       = page_heading
 
     p.govuk-body

--- a/psd-web/app/views/investigations/tabs/_attachments.html.slim
+++ b/psd-web/app/views/investigations/tabs/_attachments.html.slim
@@ -4,8 +4,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
 
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       = page_heading
 
     p.govuk-body

--- a/psd-web/app/views/investigations/tabs/_businesses.html.slim
+++ b/psd-web/app/views/investigations/tabs/_businesses.html.slim
@@ -4,8 +4,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
 
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       = page_heading
 
     p.govuk-body

--- a/psd-web/app/views/investigations/tabs/_overview.html.slim
+++ b/psd-web/app/views/investigations/tabs/_overview.html.slim
@@ -5,8 +5,8 @@
 .govuk-grid-row[class="govuk-!-padding-bottom-6"]
   .govuk-grid-column-two-thirds
 
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       = page_heading
 
     p.govuk-body-l = @investigation.title

--- a/psd-web/app/views/investigations/tabs/_products.html.slim
+++ b/psd-web/app/views/investigations/tabs/_products.html.slim
@@ -4,8 +4,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
 
+    span.govuk-caption-l = @investigation.pretty_description
     h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
       = page_heading
 
     p.govuk-body

--- a/psd-web/app/views/investigations/tests/confirmation.html.slim
+++ b/psd-web/app/views/investigations/tests/confirmation.html.slim
@@ -2,8 +2,8 @@
 - content_for :page_title, page_title
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
+span.govuk-caption-l = @investigation.pretty_description
 h1.govuk-heading-l
-  span.govuk-caption-l = @investigation.pretty_description
   = page_title
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/psd-web/app/views/investigations/tests/details.html.slim
+++ b/psd-web/app/views/investigations/tests/details.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l = @investigation.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l = @investigation.pretty_description
         = page_title
       = render "form", form: form, test: @test, investigation: @investigation, allow_product_linking: true
       = form.submit "Continue", class: "govuk-button"

--- a/psd-web/app/views/investigations/ts_investigations/_repeatable_info.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/_repeatable_info.html.slim
@@ -7,8 +7,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l Report an unsafe or non-compliant product
       h1.govuk-heading-l
-        span.govuk-caption-l Report an unsafe or non-compliant product
         = page_heading
       = yield(form)
 

--- a/psd-web/app/views/investigations/ts_investigations/business.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/business.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l Report an unsafe or non-compliant product
       h1.govuk-heading-l
-        span.govuk-caption-l Report an unsafe or non-compliant product
         = page_heading
 
       = form.hidden_field :business_type, value: @business_type

--- a/psd-web/app/views/investigations/ts_investigations/has_corrective_action.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/has_corrective_action.html.slim
@@ -7,8 +7,8 @@
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
       - heading = capture do
+        span.govuk-caption-l Report an unsafe or non-compliant product
         h1.govuk-heading-l
-          span.govuk-caption-l Report an unsafe or non-compliant product
           = page_heading
       = render "form_components/govuk_radios", form: form, key: :further_corrective_action,
               fieldset: { legend: { html: heading } },

--- a/psd-web/app/views/investigations/ts_investigations/other_information.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/other_information.html.slim
@@ -5,8 +5,8 @@
 = form_with model: @investigation, scope: :information, url: wizard_path, method: :put, local: true do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
+      span.govuk-caption-l Reporting an unsafe product
       h1.govuk-heading-l
-        span.govuk-caption-l Reporting an unsafe product
         = page_heading
       = render "form_components/govuk_checkboxes", form: form, key: :information_types,
         fieldset: { legend: { text: "What information do you have?", classes: "govuk-fieldset__legend--m" } },

--- a/psd-web/app/views/investigations/ts_investigations/product.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/product.html.slim
@@ -6,7 +6,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l Report an unsafe or non-compliant product
       h1.govuk-heading-l
-        span.govuk-caption-l Report an unsafe or non-compliant product
         = page_heading
       = render "products/form", form: form, product: @product, countries: @countries, submit_text: "Continue"

--- a/psd-web/app/views/investigations/ts_investigations/reference_number.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/reference_number.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l Reporting an unsafe product
       h1.govuk-heading-l
-        span.govuk-caption-l Reporting an unsafe product
         = page_heading
       p.govuk-body
         | The Product safety database assigns each case an ID.

--- a/psd-web/app/views/investigations/ts_investigations/which_businesses.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/which_businesses.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row#which-businesses-page
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l Report an unsafe or non-compliant product
       h1.govuk-heading-l
-        span.govuk-caption-l Report an unsafe or non-compliant product
         = page_heading
       - other_business_html = render "form_components/govuk_input",
                key: :other_business_type, form: form,

--- a/psd-web/app/views/investigations/ts_investigations/why_reporting.html.slim
+++ b/psd-web/app/views/investigations/ts_investigations/why_reporting.html.slim
@@ -7,8 +7,8 @@
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
       - heading_html = capture do
+        span.govuk-caption-l Report an unsafe or non-compliant product
         h1.govuk-heading-l
-          span.govuk-caption-l Report an unsafe or non-compliant product
           = page_heading
       - unsafe_details = capture do
         #hazard-type-auto-complete-container

--- a/psd-web/app/views/locations/edit.html.slim
+++ b/psd-web/app/views/locations/edit.html.slim
@@ -6,8 +6,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l
+        = @business.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l
-          = @business.pretty_description
         | Edit location
       = render "form", form: form

--- a/psd-web/app/views/locations/new.html.slim
+++ b/psd-web/app/views/locations/new.html.slim
@@ -5,8 +5,8 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
+      span.govuk-caption-l
+        = @business.pretty_description
       h1.govuk-heading-l
-        span.govuk-caption-l
-          = @business.pretty_description
         | Add location
       = render "form", form: form

--- a/psd-web/app/views/locations/remove.html.slim
+++ b/psd-web/app/views/locations/remove.html.slim
@@ -3,9 +3,9 @@
   = link_to "Back to business", @business, class: "govuk-back-link"
 .govuk-grid-row class="govuk-!-padding-bottom-6"
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l
+      = "Business: #{@business.trading_name}"
     h1.govuk-heading-l
-      span.govuk-caption-l
-        = "Business: #{@business.trading_name}"
       | Remove location
     table.govuk-table
       tbody.govuk-table__body

--- a/psd-web/app/views/products/index.html.slim
+++ b/psd-web/app/views/products/index.html.slim
@@ -2,9 +2,10 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    - if params[:q].present?
+      span.govuk-caption-xl Product search results
     h1.govuk-heading-l
       - if params[:q].present?
-        span.govuk-caption-xl Product search results
         = params[:q]
         span.govuk-caption-m = "#{@products.count} #{'result'.pluralize(@products.count)}"
       - else

--- a/psd-web/app/views/products/index.html.slim
+++ b/psd-web/app/views/products/index.html.slim
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     - if params[:q].present?
-      span.govuk-caption-xl Product search results
+      span.govuk-caption-l Product search results
     h1.govuk-heading-l
       - if params[:q].present?
         = params[:q]

--- a/psd-web/app/views/products/show.html.slim
+++ b/psd-web/app/views/products/show.html.slim
@@ -5,9 +5,9 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    span.govuk-caption-l
+      | Product
     h1.govuk-heading-l
-      span.govuk-caption-l
-        | Product
       = @product.name
 
     - if @product.product_type_and_category_label.present?

--- a/psd-web/test/system/create_project_test.rb
+++ b/psd-web/test/system/create_project_test.rb
@@ -44,7 +44,7 @@ class CreateProjectTest < ApplicationSystemTestCase
     project = Investigation::Project.find_by(user_title: @project.user_title).decorate
 
     assert_css ".hmcts-banner--success", text: "Project was successfully created"
-    assert_css "h1.govuk-heading-l span.govuk-caption-l", text: project.pretty_description
+    assert_css "span.govuk-caption-l", text: project.pretty_description
     assert_css "dt.govuk-summary-list__key", text: "Status"
     assert_css "dd.govuk-summary-list__value", text: "Open"
     assert_no_css "h2.govuk-heading-m", text: project.type.demodulize.titleize


### PR DESCRIPTION
This looks the same visually, but means that when the page title is "read out", eg by screen reader software using the headings for navigation or document outlines, then the page title will be less verbose.

This is especially significant where the `<h1>` is also embedded within a form `<legend>` as that can be read out multiple times, eg:

<img width="937" alt="Screenshot 2020-03-13 at 10 00 57" src="https://user-images.githubusercontent.com/30665/76619256-57874e00-6522-11ea-9b25-3b15fe1b3c2e.png">


The [headings in the GOV.UK Design System](https://design-system.service.gov.uk/styles/typography/#headings) allow for captions to be within or before the headings, depending on the context.

Review notes: because there are _so many_ pages, I've not viewed them all in browser – instead I just went through each template and moved any captions outside the `<h1>` without checking the rendering. I think this should be safe, but it might be worth checking a sample of pages.

See https://trello.com/c/ro2ymta9/422-remove-captions-from-inside-h1-elements-to-just-befor