### PR TITLE
Show error summary when adding comment

### DIFF
--- a/psd-web/app/controllers/comments_controller.rb
+++ b/psd-web/app/controllers/comments_controller.rb
@@ -2,22 +2,26 @@ class CommentsController < ApplicationController
   before_action :set_investigation
 
   def create
-    activity = @investigation.activities.new(comment_activity_params.merge(investigation: @investigation))
-    activity.source = UserSource.new(user: current_user)
+    @activity = @investigation.activities.new(comment_activity_params.merge(investigation: @investigation))
+    @activity.source = UserSource.new(user: current_user)
 
     respond_to do |format|
-      if activity.save
+      if @activity.save
         format.html do
           redirect_to investigation_url(@investigation), flash: { success: "Comment was successfully added." }
         end
         format.json { render :show, status: :created, location: @activity }
       else
         format.html do
-          redirect_to new_investigation_activity_comment_url(@investigation), flash: { warning: "Comment was not successfully added." }
+          render :new
         end
-        format.json { render json: activity.errors, status: :unprocessable_entity }
+        format.json { render json: @activity.errors, status: :unprocessable_entity }
       end
     end
+  end
+
+  def new
+    @activity = @investigation.activities.new
   end
 
 private

--- a/psd-web/app/controllers/comments_controller.rb
+++ b/psd-web/app/controllers/comments_controller.rb
@@ -2,7 +2,8 @@ class CommentsController < ApplicationController
   before_action :set_investigation
 
   def create
-    @comment = @investigation.activities.new(comment_activity_params.merge(investigation: @investigation))
+    @comment = @investigation.activities.new(comment_activity_params)
+    @comment.investigation = @investigation
     @comment.source = UserSource.new(user: current_user)
 
     respond_to do |format|

--- a/psd-web/app/controllers/comments_controller.rb
+++ b/psd-web/app/controllers/comments_controller.rb
@@ -2,26 +2,26 @@ class CommentsController < ApplicationController
   before_action :set_investigation
 
   def create
-    @activity = @investigation.activities.new(comment_activity_params.merge(investigation: @investigation))
-    @activity.source = UserSource.new(user: current_user)
+    @comment = @investigation.activities.new(comment_activity_params.merge(investigation: @investigation))
+    @comment.source = UserSource.new(user: current_user)
 
     respond_to do |format|
-      if @activity.save
+      if @comment.save
         format.html do
           redirect_to investigation_url(@investigation), flash: { success: "Comment was successfully added." }
         end
-        format.json { render :show, status: :created, location: @activity }
+        format.json { render :show, status: :created, location: @comment }
       else
         format.html do
           render :new
         end
-        format.json { render json: @activity.errors, status: :unprocessable_entity }
+        format.json { render json: @comment.errors, status: :unprocessable_entity }
       end
     end
   end
 
   def new
-    @activity = @investigation.activities.new
+    @comment = @investigation.activities.new
   end
 
 private

--- a/psd-web/app/helpers/application_helper.rb
+++ b/psd-web/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def title_for(any_active_record, title)
+    return content_for(:page_title, title) unless any_active_record.errors.any?
+
+    content_for(:page_title, "Error: #{title}")
+  end
+
   def error_summary(errors)
     return unless errors.any?
 

--- a/psd-web/app/helpers/application_helper.rb
+++ b/psd-web/app/helpers/application_helper.rb
@@ -1,4 +1,11 @@
 module ApplicationHelper
+  def error_summary(errors)
+    return unless errors.any?
+
+    error_list = errors.map { |attribute, error| error ? { text: error, href: "##{attribute}" } : nil }.compact
+    govukErrorSummary(titleText: "There is a problem", errorList: error_list)
+  end
+
   def govuk_hr
     tag(:hr, class: "govuk-section-break govuk-section-break--m govuk-section-break--visible")
   end

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -1,5 +1,5 @@
 - page_title = "Add comment"
-- content_for :page_title, title_for(@activity, page_title)
+- content_for :page_title, title_for(@comment, page_title)
 - content_for :after_header do
   .govuk-grid-row
     .govuk-grid-column-one-third
@@ -8,13 +8,13 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = error_summary(@activity.errors)
+    = error_summary(@comment.errors)
 
     h1.govuk-heading-l
       span.govuk-caption-l = @investigation.pretty_description
       = page_title
 
-    = form_with(model: @activity, \
+    = form_with(model: @comment, \
       url: investigation_activity_comment_path(@investigation)) do |form|
       = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 }, id: "body",
               label: { text: "Comment text", classes: "govuk-visually-hidden" }

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -8,11 +8,13 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    = error_summary(@activity.errors)
+
     h1.govuk-heading-l
       span.govuk-caption-l = @investigation.pretty_description
       | Add comment
     = form_with(model: @investigation.activities.new, \
       url: investigation_activity_comment_path(@investigation)) do |form|
-      = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 },
+      = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 }, id: "body",
               label: { text: "Comment text", classes: "govuk-visually-hidden" }
       = form.submit "Continue", class: "govuk-button"

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -12,7 +12,8 @@
 
     h1.govuk-heading-l
       span.govuk-caption-l = @investigation.pretty_description
-      | Add comment
+      = page_title
+
     = form_with(model: @investigation.activities.new, \
       url: investigation_activity_comment_path(@investigation)) do |form|
       = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 }, id: "body",

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -10,12 +10,10 @@
   .govuk-grid-column-two-thirds
     = error_summary(@comment.errors)
 
-    h1.govuk-heading-l
-      span.govuk-caption-l = @investigation.pretty_description
-      = page_title
+    span.govuk-caption-l = @investigation.pretty_description
 
     = form_with(model: @comment, \
       url: investigation_activity_comment_path(@investigation)) do |form|
       = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 }, id: "body",
-              label: { text: "Comment text", classes: "govuk-visually-hidden" }
+              label: { text: page_title, classes: "govuk-label--l", isPageHeading: true }
       = form.submit "Continue", class: "govuk-button"

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -1,4 +1,5 @@
-- content_for :page_title, "Add activity"
+- page_title = "Add comment"
+- content_for :page_title, title_for(@activity, page_title)
 - content_for :after_header do
   .govuk-grid-row
     .govuk-grid-column-one-third

--- a/psd-web/app/views/comments/new.html.slim
+++ b/psd-web/app/views/comments/new.html.slim
@@ -14,7 +14,7 @@
       span.govuk-caption-l = @investigation.pretty_description
       = page_title
 
-    = form_with(model: @investigation.activities.new, \
+    = form_with(model: @activity, \
       url: investigation_activity_comment_path(@investigation)) do |form|
       = render "form_components/govuk_textarea", key: :body, form: form, attributes: { maxlength: 10000 }, id: "body",
               label: { text: "Comment text", classes: "govuk-visually-hidden" }

--- a/psd-web/config/initializers/shared_rails_config.rb
+++ b/psd-web/config/initializers/shared_rails_config.rb
@@ -7,4 +7,5 @@ Rails.application.config.action_view.field_error_proc = Proc.new { |html_tag, _|
 Rails.application.config.action_view.form_with_generates_ids = true
 
 ActionView::Base.include GovukDesignSystem::ComponentsHelper
+ActionView::Base.include GovukDesignSystem::ErrorSummaryHelper
 ActionView::Base.include GovukDesignSystem::SkipLinkHelper

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -98,6 +98,10 @@ en:
               blank: "Enter date of the test request"
               invalid: "Enter a real date of the test request"
               date_missing_component: "Enter date of the test request and include a %{missing_components}"
+        comment_activity:
+          attributes:
+            body:
+              blank: "Enter a comment"
         corrective_action:
           attributes:
             product:

--- a/psd-web/spec/requests/add_comment_spec.rb
+++ b/psd-web/spec/requests/add_comment_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Adding a comment to a case", type: :request, with_stubbed_keycloak_config: true, with_stubbed_mailer: true, with_stubbed_elasticsearch: true do
+  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:investigation) { create(:investigation) }
+
+  before { sign_in(user) }
+
+  context "with an empty comment" do
+    before do
+      post investigation_activity_comment_path(investigation),
+           params: {
+             comment_activity: {
+               body: ""
+             }
+           }
+    end
+
+    it "renders the comment form again" do
+      expect(response).to render_template(:new)
+    end
+
+    it "renders an error" do
+      expect(response.body).to include("Enter a comment")
+    end
+  end
+
+  context "with a valid comment" do
+    before do
+      post investigation_activity_comment_path(investigation),
+           params: {
+             comment_activity: {
+               body: "Test"
+             }
+           }
+    end
+
+    it "redirects to the case page" do
+      expect(response).to redirect_to(investigation_path(investigation))
+    end
+  end
+end


### PR DESCRIPTION
The "add comment to a case" flow currently doesn’t use the standard error summary component, and instead uses a flash message. This fixes that.

Also makes sure that `Error: ` is prefixed the the page `<title>` tag.

See https://trello.com/c/S40mJNig/425-add-comment-to-case-doesnt-show-an-error-summary-when-there-are-validation-errors

## Before

<img width="745" alt="Screenshot 2020-03-13 at 15 18 16" src="https://user-images.githubusercontent.com/30665/76638079-c4f7a680-6543-11ea-9d23-921f7280f639.png">

## After

<img width="802" alt="Screenshot 2020-03-13 at 16 00 40" src="https://user-images.githubusercontent.com/30665/76638112-d04ad200-6543-11ea-8bf5-9e66083b262d.png">
