### PR TITLE
Fix review db provisioning

### DIFF
--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -19,7 +19,7 @@ fi
 cf7 create-service postgres small-10 $DB_NAME
 
 # Wait until db is prepared, might take up to 10 minutes
-until cf7 service $DB_NAME > /tmp/db_exists && grep "create succeeded" /tmp/db_exists; do sleep 20; echo "Waiting for db"; done
+until cf7 service $DB_NAME > /tmp/db_exists && grep -E "create succeeded|update succeeded" /tmp/db_exists; do sleep 20; echo "Waiting for db"; done
 
 cp -a ${PWD-.}/infrastructure/env/. ${PWD-.}/psd-web/env/
 


### PR DESCRIPTION
Review apps DB provisioning is considering only `'create` but should also work after DB is updated