### PR TITLE
Remove migration which will be moved to different PR

### DIFF
--- a/psd-web/db/migrate/20200225163932_remove_path_from_team_and_organisation.rb
+++ b/psd-web/db/migrate/20200225163932_remove_path_from_team_and_organisation.rb
@@ -1,8 +1,0 @@
-class RemovePathFromTeamAndOrganisation < ActiveRecord::Migration[5.2]
-  def change
-    safety_assured do
-      remove_column :organisations, :path, :string
-      remove_column :teams, :path, :string
-    end
-  end
-end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -192,7 +192,9 @@ ActiveRecord::Schema.define(version: 2020_03_10_170356) do
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
+    t.string "path"
     t.datetime "updated_at", null: false
+    t.index ["path"], name: "index_organisations_on_path"
   end
 
   create_table "products", id: :serial, force: :cascade do |t|
@@ -230,10 +232,12 @@ ActiveRecord::Schema.define(version: 2020_03_10_170356) do
     t.datetime "created_at", null: false
     t.string "name"
     t.uuid "organisation_id"
+    t.string "path"
     t.string "team_recipient_email"
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_teams_on_name"
     t.index ["organisation_id"], name: "index_teams_on_organisation_id"
+    t.index ["path"], name: "index_teams_on_path"
   end
 
   create_table "teams_users", force: :cascade do |t|
@@ -288,9 +292,6 @@ ActiveRecord::Schema.define(version: 2020_03_10_170356) do
     t.text "invitation_token"
     t.datetime "invited_at"
     t.datetime "keycloak_created_at"
-    t.string "keycloak_first_name"
-    t.string "keycloak_last_name"
-    t.string "keycloak_username"
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
     t.text "mobile_number"


### PR DESCRIPTION
Removes all db removals so we can use production db with `keycloak-replacement` branch.