### PR TITLE
Fix redirects after adding businesses/products to a case and add missing feature spec

### DIFF
--- a/psd-web/app/controllers/investigations/businesses_controller.rb
+++ b/psd-web/app/controllers/investigations/businesses_controller.rb
@@ -127,7 +127,7 @@ private
   end
 
   def redirect_to_investigation_businesses_tab(flash)
-    redirect_to investigation_path(@investigation, anchor: "businesses"), flash: flash
+    redirect_to investigation_businesses_path(@investigation), flash: flash
   end
 
   def set_investigation

--- a/psd-web/app/controllers/investigations/products_controller.rb
+++ b/psd-web/app/controllers/investigations/products_controller.rb
@@ -56,7 +56,7 @@ class Investigations::ProductsController < ApplicationController
 private
 
   def redirect_to_investigation_products_tab(flash)
-    redirect_to investigation_path(@investigation, anchor: "products"), flash: flash
+    redirect_to investigation_products_path(@investigation), flash: flash
   end
 
   def set_investigation

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
 
     click_on "Save business"
 
-    click_on "Businesses (#{investigation.businesses.count})"
+    expect_to_be_on_investigation_businesses_page
 
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Trading name")
     expect(page).to have_css("dd.govuk-summary-list__value", text: trading_name)
@@ -62,5 +62,11 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
     expected_contact = [name, job_title, phone_number, email].join(", ")
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Contact")
     expect(page).to have_css("dd.govuk-summary-list__value", text: expected_contact)
+  end
+
+  def expect_to_be_on_investigation_businesses_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/businesses")
+    expect(page).to have_selector("h1", text: "Businesses")
+    expect(page).not_to have_error_messages
   end
 end

--- a/psd-web/spec/features/add_product_spec.rb
+++ b/psd-web/spec/features/add_product_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsearch, :with_stubbed_keycloak_config do
+  let(:investigation) { create(:enquiry) }
+  let(:product)       { create(:product_iphone) }
+
+  before { sign_in }
+
+  scenario "Adding a product to a case" do
+    visit "/cases/#{investigation.pretty_id}/products/new"
+
+    select product.category, from: "Product category"
+
+    fill_in "Product type", with: product.product_type
+    fill_in "Product name", with: product.name
+    fill_in "Barcode or serial number", with: product.product_code
+    fill_in "Batch number", with: product.batch_number
+    fill_in "Webpage", with: product.webpage
+
+    select product.country_of_origin, from: "Country of origin"
+
+    fill_in "Description of product", with: product.description
+
+    click_on "Save product"
+
+    expect_to_be_on_investigation_products_page
+
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Product name")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.name)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Category")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.category)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Product type")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.product_type)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Barcode or serial number")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.product_code)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Batch number")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.batch_number)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Webpage")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.webpage)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Country of origin")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.country_of_origin)
+    expect(page).to have_css("dt.govuk-summary-list__key",   text: "Description")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: product.description)
+  end
+
+  def expect_to_be_on_investigation_products_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/products")
+    expect(page).to have_selector("h1", text: "Products")
+    expect(page).not_to have_error_messages
+  end
+end

--- a/psd-web/test/controllers/investigations/products_controller_test.rb
+++ b/psd-web/test/controllers/investigations/products_controller_test.rb
@@ -28,7 +28,7 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to investigation_path(@investigation, anchor: "products")
+    assert_redirected_to investigation_products_path(@investigation)
   end
 
   test "should not create product if name is missing" do
@@ -51,7 +51,7 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "InvestigationProduct.count" do
       put link_investigation_product_url(@investigation, @product)
     end
-    assert_redirected_to investigation_path(@investigation, anchor: "products")
+    assert_redirected_to investigation_products_path(@investigation)
   end
 
   test "should unlink product and investigation" do
@@ -60,6 +60,6 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
       delete unlink_investigation_product_url(@investigation, @product)
     end
 
-    assert_redirected_to investigation_path(@investigation, anchor: "products")
+    assert_redirected_to investigation_products_path(@investigation)
   end
 end


### PR DESCRIPTION
https://trello.com/c/iIJVRNOm/242-links-back-to-case-tabs-are-now-broken

## Description
Fixes the redirects after adding a business or product to a case to go to their full paths (e.g. `/cases/1912-0001/products`) instead of the old tab anchor links (e.g. `/cases/1912-0001#products`).

As suggested on the Trello card I checked all other usage of anchor redirects but currently these are the only ones which support full paths.

I also added a missing feature spec to cover adding a product to a case, and corrected a slight problem with the existing add business spec.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Has acceptance criteria been tested by a peer?
