### PR TITLE
only display Received date and received by for enquiries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2020-03-17
+- Only enquiries will now display Received by and Received date in the source summary list.
+
 ## 2020-03-09
 - Fixed City or town not being displayed when adding an address to a business.
 

--- a/psd-web/app/decorators/investigation/enquiry_decorator.rb
+++ b/psd-web/app/decorators/investigation/enquiry_decorator.rb
@@ -7,7 +7,7 @@ class Investigation < ApplicationRecord
       date_received?
     end
 
-    def should_display_receive_by?
+    def should_display_received_by?
       received_type?
     end
   end

--- a/psd-web/app/decorators/investigation/enquiry_decorator.rb
+++ b/psd-web/app/decorators/investigation/enquiry_decorator.rb
@@ -1,5 +1,14 @@
 class Investigation < ApplicationRecord
   require_dependency "investigation"
   class EnquiryDecorator < InvestigationDecorator
+  private
+
+    def should_display_date_received?
+      date_received?
+    end
+
+    def should_display_receive_by?
+      received_type?
+    end
   end
 end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -94,8 +94,8 @@ class InvestigationDecorator < ApplicationDecorator
                         "Reporter details are restricted because they contain GDPR protected data."
                       end
     rows = [
-      date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,
-      received_type? ? { key: { text: "Received by" }, value: { text: received_type.upcase_first } } : nil,
+      should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,
+      should_display_receive_by? ? { key: { text: "Received by" }, value: { text: received_type.upcase_first } } : nil,
       { key: { text: "Source type" }, value: { text: complainant.complainant_type } },
       { key: { text: "Contact details" }, value: { text: contact_details } }
     ]
@@ -168,4 +168,8 @@ private
       end
   end
   # rubocop:enable Rails/OutputSafety
+
+  def should_display_date_received?; false; end
+
+  def should_display_receive_by?; false; end
 end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -95,7 +95,7 @@ class InvestigationDecorator < ApplicationDecorator
                       end
     rows = [
       should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,
-      should_display_receive_by? ? { key: { text: "Received by" }, value: { text: received_type.upcase_first } } : nil,
+      should_display_received_by? ? { key: { text: "Received by" }, value: { text: received_type.upcase_first } } : nil,
       { key: { text: "Source type" }, value: { text: complainant.complainant_type } },
       { key: { text: "Contact details" }, value: { text: contact_details } }
     ]
@@ -171,5 +171,5 @@ private
 
   def should_display_date_received?; false; end
 
-  def should_display_receive_by?; false; end
+  def should_display_received_by?; false; end
 end

--- a/psd-web/app/models/investigation/enquiry.rb
+++ b/psd-web/app/models/investigation/enquiry.rb
@@ -20,11 +20,7 @@ class Investigation < ApplicationRecord
     end
 
     def partially_filled_date?
-      if errors.messages[:date_received_year].any? || errors.messages[:date_received_day].any? || errors.messages[:date_received_month].any?
-        true
-      else
-        false
-      end
+      errors.messages[:date_received_year].any? || errors.messages[:date_received_day].any? || errors.messages[:date_received_month].any?
     end
 
     def date_cannot_be_in_the_future

--- a/psd-web/spec/decorators/investigation/enquiry_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation/enquiry_decorator_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Investigation::EnquiryDecorator, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  include ActionView::Helpers::DateHelper
+
+  subject(:decorated_investigation) { investigation.decorate }
+
+  let(:user)          { build_stubbed(:user) }
+  let(:investigation) { create(:enquiry, date_received_year: 2020, date_received_month: 1, date_received_day: 1) }
+
+  before do
+    create(:complainant, investigation: investigation)
+  end
+
+  describe "#source_details_summary_list" do
+    let(:source_details_summary_list) { decorated_investigation.source_details_summary_list }
+
+    before do
+      allow(User).to receive(:current).and_return(user)
+    end
+
+    it "displays the Received date" do
+      expect(source_details_summary_list).to summarise("Received date", text: investigation.date_received.to_s(:govuk))
+    end
+
+    it "displays the Received by" do
+      expect(source_details_summary_list).to summarise("Received by", text: investigation.received_type.upcase_first)
+    end
+  end
+end

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -185,12 +185,12 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
       allow(User).to receive(:current).and_return(user)
     end
 
-    it "has displays the Received date" do
-      expect(source_details_summary_list).to summarise("Received date", text: investigation.date_received.to_s(:govuk))
+    it "does not display the Received date" do
+      expect(source_details_summary_list).not_to summarise("Received date", text: investigation.date_received.to_s(:govuk))
     end
 
-    it "has displays the Received by" do
-      expect(source_details_summary_list).to summarise("Received by", text: investigation.received_type.upcase_first)
+    it "does not display the Received by" do
+      expect(source_details_summary_list).not_to summarise("Received by", text: investigation.received_type.upcase_first)
     end
 
     it "has displays the Source type" do


### PR DESCRIPTION
**CHANGES:**

Now only enquiries will display received by and received date

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Has acceptance criteria been tested by a peer?
- [x] Has the CHANGELOG been updated? (If change is worth telling users about.)

![Screen Shot 2020-03-17 at 17 18 33](https://user-images.githubusercontent.com/100796/76883418-081f8580-6874-11ea-913f-be87d42a37b6.png)
![Screen Shot 2020-03-17 at 17 20 31](https://user-images.githubusercontent.com/100796/76883426-0950b280-6874-11ea-83e8-df30e4d6878e.png)
![Screen Shot 2020-03-17 at 17 22 53](https://user-images.githubusercontent.com/100796/76883427-09e94900-6874-11ea-89bb-e5f7fd7b76e1.png)
