### PR TITLE
Enable 2FA when user attempts to reset password

### DIFF
--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -66,7 +66,10 @@ module Users
     def passed_two_factor_authentication?
       return true if !Rails.configuration.two_factor_authentication_enabled
 
-      current_user && is_fully_authenticated?
+      request.referer &&
+        URI(request.referer).path == user_two_factor_authentication_path &&
+        current_user &&
+        is_fully_authenticated?
     end
 
     def resend_invitation_link_for(user)

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -7,7 +7,7 @@ module Users
                        only: :edit
 
     def edit
-      return render :invalid_link, status: :not_found if params[:reset_password_token].blank? || reset_token_invalid?
+      return render :invalid_link, status: :not_found if reset_token_invalid?
       return render :expired, status: :gone if reset_token_expired?
 
       if passed_two_factor_authentication?
@@ -67,7 +67,7 @@ module Users
     end
 
     def reset_token_invalid?
-      user_with_reset_token.blank?
+      params[:reset_password_token].blank? || user_with_reset_token.blank?
     end
 
     def reset_token_expired?

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -68,7 +68,7 @@ module Users
 
       request.referer &&
         URI(request.referer).path == user_two_factor_authentication_path &&
-        current_user &&
+        user_signed_in? &&
         is_fully_authenticated?
     end
 

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -66,10 +66,7 @@ module Users
     def passed_two_factor_authentication?
       return true if !Rails.configuration.two_factor_authentication_enabled
 
-      request.referer &&
-        URI(request.referer).path == user_two_factor_authentication_path &&
-        user_signed_in? &&
-        is_fully_authenticated?
+      user_signed_in? && is_fully_authenticated?
     end
 
     def resend_invitation_link_for(user)

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -11,7 +11,13 @@ module Users
       return render :expired, status: :gone if reset_token_expired?
 
       if passed_two_factor_authentication?
-        # Password update is based on the "reset_password_token", not in the user session.
+        # Devise password update requires the user to be signed out, as it relies on the "reset password token"
+        # parameter and an user attempting to reset its password because does not remember it is not supposed to be
+        # already signed in.
+        # In order to be able to enforce 2FA, we need to to sign the user in.
+        # Given this contradiction between needing it for 2FA but needing the opposite for the password update,
+        # when the user gets redirected back after 2FA, we have to sign out the users before allowing them to
+        # update their password.
         sign_out(:user)
         super
       else

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -20,6 +20,7 @@ module Users
         sign_in(user_with_reset_token)
         warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
         warden.session(:user)["two_factor_authentication_referrer"] = request.path
+        store_location_for(:user, edit_user_password_path)
         user_with_reset_token.send_new_otp
 
         return redirect_to user_two_factor_authentication_path

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -49,6 +49,8 @@ module Users
       end
     end
 
+    # Overrides from ApplicationController in order to hide the the main navigation links
+    # when the user lands at the password edition page after being signed in by 2FA.
     def hide_nav?
       true
     end

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -19,7 +19,6 @@ module Users
 
         sign_in(user_with_reset_token)
         warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
-        warden.session(:user)["two_factor_authentication_referrer"] = request.path
         store_location_for(:user, edit_user_password_path)
         user_with_reset_token.send_new_otp
 

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -6,8 +6,6 @@ module Users
                        :has_viewed_introduction,
                        only: :edit
 
-
-    # TO DO: Hide user navigation header?
     # TO DO: Do we really want to skip declaration/introduction? Done for tests. Need to figure out desired behaviour.
     # TO DO: Is this safe to do?
     # TO DO: Refactor/Extract 2FA logic bit
@@ -49,6 +47,10 @@ module Users
           return render :expired
         end
       end
+    end
+
+    def hide_nav?
+      true
     end
 
   private

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -49,6 +49,10 @@ module Users
       @otp_code_param ||= resource_params.permit(:otp_code)[:otp_code]
     end
 
+    def referrer
+      warden.session(:user)["two_factor_authentication_referrer"]
+    end
+
     # Suppress unwanted Devise alert.
     # eg: when you try to navigate back to sign-in it alerts about you already being signed in.
     # We only want to show submission errors.
@@ -68,7 +72,11 @@ module Users
 
       resource.pass_two_factor_authentication!
 
-      redirect_to after_two_factor_success_path_for(resource)
+      if referrer
+        redirect_to referrer
+      else
+        redirect_to after_two_factor_success_path_for(resource)
+      end
     end
 
     def after_two_factor_fail_for(resource)

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -72,11 +72,7 @@ module Users
 
       resource.pass_two_factor_authentication!
 
-      if referrer
-        redirect_to referrer
-      else
-        redirect_to after_two_factor_success_path_for(resource)
-      end
+      redirect_to after_two_factor_success_path_for(resource)
     end
 
     def after_two_factor_fail_for(resource)

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -49,10 +49,6 @@ module Users
       @otp_code_param ||= resource_params.permit(:otp_code)[:otp_code]
     end
 
-    def referrer
-      warden.session(:user)["two_factor_authentication_referrer"]
-    end
-
     # Suppress unwanted Devise alert.
     # eg: when you try to navigate back to sign-in it alerts about you already being signed in.
     # We only want to show submission errors.

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -65,20 +65,6 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
       expect(page).to have_css("h1", text: "Declaration")
     end
 
-    scenario "a signed user coming from an URL other than 2FA gets forced to go through 2FA before being able to edit their password" do
-      request_password_reset
-
-      sign_in(user)
-
-      visit edit_user_password_url_with_token
-
-      expect_to_be_on_two_factor_authentication_page
-
-      complete_two_factor_authentication_with(user.reload.direct_otp)
-
-      expect_to_be_on_edit_user_password_page
-    end
-
     context "when the password does not fit the criteria" do
       scenario "when the password is too short it shows an error" do
         request_password_reset

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -38,6 +38,23 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
   end
 
   context "with a valid token" do
+    scenario "requests a 2 factor authentication" do
+      request_password_reset_with_2fa
+
+      visit edit_user_password_url_with_token
+      expect_to_be_on_two_factor_authentication_page
+
+      fill_in "Enter security code", with: user.reload.direct_otp
+      click_on "Continue"
+
+      expect_to_be_on_edit_user_password_page
+
+      fill_in "Password", with: "a_new_password"
+      click_on "Continue"
+
+      expect(page).to have_css("h1", text: "Declaration")
+    end
+
     scenario "entering a valid password resets your password", :with_stubbed_notify do
       request_password_reset
 
@@ -134,8 +151,47 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
     end
   end
 
+  # TO DO: Resolve this awful lazy duplication
+  def request_password_reset_with_2fa
+    user.update!(reset_password_token: reset_token)
+
+    visit "/sign-in"
+
+    click_link "Forgot your password?"
+
+    perform_enqueued_jobs do
+      body = {
+        email_address: user.email,
+        template_id: NotifyMailer::TEMPLATES[:reset_password_instruction],
+        reference: "Password reset",
+        personalisation: {
+          name: user.name,
+          edit_user_password_url_with_token: edit_user_password_url_with_token
+        }
+      }
+
+      stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email")
+        .with(body: body.to_json).to_return(status: 200, body: {}.to_json, headers: {})
+
+      expect_to_be_on_reset_password_page
+
+      expect(page).to have_css("h1", text: "Reset your password")
+
+      fill_in "Email address", with: user.email
+      click_on "Send email"
+    end
+  end
+
+  def expect_to_be_on_two_factor_authentication_page
+    expect(page).to have_current_path("/two-factor")
+  end
+
   def expect_to_be_on_reset_password_page
     expect(page).to have_current_path("/password/new")
+  end
+
+  def expect_to_be_on_edit_user_password_page
+    expect(page).to have_current_path("/password/edit")
   end
 
   def expect_to_be_on_check_your_email_page

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -43,7 +43,9 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
       visit edit_user_password_url_with_token
 
-      complete_two_factor_authentication
+      expect_to_be_on_two_factor_authentication_page
+
+      complete_two_factor_authentication_with(user.reload.direct_otp)
 
       expect_to_be_on_edit_user_password_page
 
@@ -69,7 +71,9 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
         visit edit_user_password_url_with_token
 
-        complete_two_factor_authentication
+        expect_to_be_on_two_factor_authentication_page
+
+        complete_two_factor_authentication_with(user.reload.direct_otp)
 
         expect_to_be_on_edit_user_password_page
 
@@ -85,7 +89,9 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
         visit edit_user_password_url_with_token
 
-        complete_two_factor_authentication
+        expect_to_be_on_two_factor_authentication_page
+
+        complete_two_factor_authentication_with(user.reload.direct_otp)
 
         expect_to_be_on_edit_user_password_page
 
@@ -143,10 +149,8 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
     end
   end
 
-  def complete_two_factor_authentication
-    expect_to_be_on_two_factor_authentication_page
-
-    fill_in "Enter security code", with: user.reload.direct_otp
+  def complete_two_factor_authentication_with(security_code)
+    fill_in "Enter security code", with: security_code
     click_on "Continue"
   end
 

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -65,6 +65,20 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
       expect(page).to have_css("h1", text: "Declaration")
     end
 
+    scenario "a signed user coming from an URL other than 2FA gets forced to go through 2FA before being able to edit their password" do
+      request_password_reset
+
+      sign_in(user)
+
+      visit edit_user_password_url_with_token
+
+      expect_to_be_on_two_factor_authentication_page
+
+      complete_two_factor_authentication_with(user.reload.direct_otp)
+
+      expect_to_be_on_edit_user_password_page
+    end
+
     context "when the password does not fit the criteria" do
       scenario "when the password is too short it shows an error" do
         request_password_reset

--- a/psd-web/spec/requests/user_resets_password_spec.rb
+++ b/psd-web/spec/requests/user_resets_password_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User resets password", type: :request, with_stubbed_keycloak_config: true do
+RSpec.describe "User resets password", type: :request, with_stubbed_keycloak_config: true, with_stubbed_notify: true, with_2fa: true do
   describe "viewing the form" do
     context "with a valid reset token" do
       let(:reset_token) { SecureRandom.hex(20) }
@@ -8,18 +8,32 @@ RSpec.describe "User resets password", type: :request, with_stubbed_keycloak_con
 
       before do
         reset_password_digest = Devise.token_generator.digest(user, :reset_password_token, reset_token)
-
         user.update!(reset_password_token: reset_password_digest, reset_password_sent_at: 1.minute.ago)
-
-        get(edit_user_password_path(reset_password_token: reset_token))
       end
 
-      it "return a 200 status code" do
-        expect(response).to have_http_status(:ok)
-      end
+      # rubocop:disable RSpec/AnyInstance
+      context "when user already passed two factor authentication" do
+        before do
+          allow_any_instance_of(Users::PasswordsController).to receive(:current_user).and_return(user)
+          allow_any_instance_of(Users::PasswordsController).to receive(:is_fully_authenticated?).and_return(true)
+          get(edit_user_password_path(reset_password_token: reset_token))
+        end
 
-      it "displays a reset password form" do
-        expect(response).to render_template("passwords/edit")
+        it "returns a 200 status code" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "displays a reset password form" do
+          expect(response).to render_template("passwords/edit")
+        end
+      end
+      # rubocop:enable RSpec/AnyInstance
+
+      context "when user needs to pass two factor authentication" do
+        it "redirects the user to the two factor authentication page" do
+          get(edit_user_password_path(reset_password_token: reset_token))
+          expect(response).to redirect_to(user_two_factor_authentication_path)
+        end
       end
     end
 

--- a/psd-web/spec/requests/user_resets_password_spec.rb
+++ b/psd-web/spec/requests/user_resets_password_spec.rb
@@ -11,29 +11,9 @@ RSpec.describe "User resets password", type: :request, with_stubbed_keycloak_con
         user.update!(reset_password_token: reset_password_digest, reset_password_sent_at: 1.minute.ago)
       end
 
-      # rubocop:disable RSpec/AnyInstance
-      context "when user already passed two factor authentication" do
-        before do
-          allow_any_instance_of(Users::PasswordsController).to receive(:current_user).and_return(user)
-          allow_any_instance_of(Users::PasswordsController).to receive(:is_fully_authenticated?).and_return(true)
-          get(edit_user_password_path(reset_password_token: reset_token))
-        end
-
-        it "returns a 200 status code" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "displays a reset password form" do
-          expect(response).to render_template("passwords/edit")
-        end
-      end
-      # rubocop:enable RSpec/AnyInstance
-
-      context "when user needs to pass two factor authentication" do
-        it "redirects the user to the two factor authentication page" do
-          get(edit_user_password_path(reset_password_token: reset_token))
-          expect(response).to redirect_to(user_two_factor_authentication_path)
-        end
+      it "redirects the user to the two factor authentication page" do
+        get(edit_user_password_path(reset_password_token: reset_token))
+        expect(response).to redirect_to(user_two_factor_authentication_path)
       end
     end
 


### PR DESCRIPTION
Trello ticket: https://trello.com/c/rwtnglov/427-2fa-on-forgot-password

When an user reaches the reset password page after receiving the link by email, it will be redirected to the 2FA page as a security check before being able to reset its password.

In order to achieve this we use the following process:
1 - Anonymous user lands at "edit password" and its email gets identified.
2 - The user gets signed in based on its email address.
3 - User session gets marked as "needs 2FA".
4 - A 2FA code is sent to the user.
5 - User gets redirected to the 2FA page so can introduce its code.
6 - Once the correct code is introduced, the user gets redirected back to the "Edit password" page keeping the same "reset password token" that had in the reset password email link.
7 - When landing as a completely signed in user, the user session gets destroyed so the user depends only int the "reset password token" for updating the password.
8 - User can update its password.

## Security and implementation considerations
The solution partially signs in the user in order to go through the 2FA authentication.
Users partially signed in with "needs 2FA" state won't be able to navigate outside 2FA page until the correct code its introduced.
When being redirected back to the edit password page, the user session gets automatically destroyed, so should be safe.

## Overloaded functionality
No new overloaded methods introduced but all this behaviour  heavily depends on overloading devise methods and setting values for Warden user session.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [x] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
