### PR TITLE
proof of concept not saving the password and phone number on the user model

### DIFF
--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -63,17 +63,15 @@ module Users
     def after_two_factor_success_for(resource)
       set_remember_two_factor_cookie(resource)
 
-      if session[:name] && session[:mobile_number] && session[:password]
+
+      if new_user = NewUser.find(resource.email).delete
 
         resource.update(
-          name: session[:name],
-          mobile_number: session[:mobile_number],
-          password: session[:password]
+          name: new_user.name,
+          mobile_number: new_user.mobile_number,
+          password: new_usersession[:password]
         )
-
-        session.delete(:name)
-        session.delete(:mobile_number)
-        session.delete(:password)
+        new_user.delete
       end
 
       warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -64,12 +64,7 @@ module Users
       set_remember_two_factor_cookie(resource)
 
       if (new_user = NewUser.find(resource.id).delete)
-
-        resource.update(
-          name: new_user.name,
-          mobile_number: new_user.mobile_number,
-          password: new_usersession[:password]
-        )
+        resource.update(new_user.as_json)
         new_user.delete
       end
 

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -63,8 +63,7 @@ module Users
     def after_two_factor_success_for(resource)
       set_remember_two_factor_cookie(resource)
 
-
-      if new_user = NewUser.find(resource.email).delete
+      if (new_user = NewUser.find(resource.id).delete)
 
         resource.update(
           name: new_user.name,

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -29,16 +29,14 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(new_user_attributes)
     new_user = NewUser.new(
-      id: @user.id,
-      email_address: @user.email,
-      name: @user.name,
-      mobile_number: @user.mobile_number,
-      user_encrypted_password: @user.encrypted_password)
+      id:                      @user.id,
+      email_address:           @user.email,
+      name:                    @user.name,
+      mobile_number:           @user.mobile_number,
+      user_encrypted_password: @user.encrypted_password
+    )
 
     if new_user.valid?(context: :registration_completion)
-
-      # Copy these attributes to the session, as we don’t want to
-      # persist them until the user completes 2FA.
       new_user.save
 
       sign_in :user, @user

--- a/psd-web/app/jobs/send_user_invitation_job.rb
+++ b/psd-web/app/jobs/send_user_invitation_job.rb
@@ -18,6 +18,9 @@ class SendUserInvitationJob < ApplicationJob
       user_inviting = User.find(user_inviting_id)
 
       NotifyMailer.invitation_email(user, user_inviting).deliver_now
+
+      NewUser.find(id).save(expires_in: Time.current + INVITATION_EXPIRATION_DAYS.days)
+
       user.update!(has_been_sent_welcome_email: true, invited_at: Time.current)
 
     elsif user.invitation_expired?

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -1,7 +1,6 @@
 class NewUser
   include ActiveModel::Model
   include ActiveModel::Attributes
-  include GlobalID::Identification
 
   attribute :email
   attribute :name

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -22,9 +22,7 @@ class NewUser
     new(JSON.parse(Rails.cache.get(id)))
   end
 
-  # TODO: set key expiry to the invitation expiry time
   def save(expires_in:)
-    # TODO: handle not saved
     if expires_in
       Rails.cache.write(id, to_json)
     else
@@ -38,7 +36,6 @@ class NewUser
   end
 
   def delete
-    # TODO: handle not found because exipired?
     Rails.cache.delete(email_address)
     self.freeze
   end

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -19,22 +19,19 @@ class NewUser
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   def self.find(id)
-    new(JSON.parse(redis.get(id)))
+    new(JSON.parse(Rails.cache.get(id)))
   end
 
   # TODO: set key expiry to the invitation expiry time
   def save
     # TODO: handle not saved
-    redis.set(id, to_json.except(:password))
+    Rails.cache.set(id, to_json.except(:password))
     true
   end
 
   def delete
     # TODO: handle not found because exipired?
-    redis.delete(email_address)
-  end
-
-  def redis
-    @redis ||= Redis.new(url: ENV["REDIS_URL"])
+    Rails.cache.delete(email_address)
+    self.freeze
   end
 end

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -23,10 +23,18 @@ class NewUser
   end
 
   # TODO: set key expiry to the invitation expiry time
-  def save
+  def save(expires_in:)
     # TODO: handle not saved
-    Rails.cache.set(id, to_json.except(:password))
+    if expires_in
+      Rails.cache.write(id, to_json)
+    else
+      Rails.cache.write(id, to_json, expires_in: time.to_i)
+    end
     true
+  end
+
+  def as_json
+    attributes.except(:password)
   end
 
   def delete

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -3,7 +3,10 @@ class NewUser
   include ActiveModel::Attributes
   include GlobalID::Identification
 
-  attributes :email, :name, :mobile_number, :password
+  attribute :email
+  attribute :name
+  attribute :mobile_number
+  attribute :password
   attribute :encrypted_password, default: ""
 
   with_options on: :registration_completion do |registration_completion|
@@ -32,7 +35,7 @@ class NewUser
   end
 
   def as_json
-    attributes.except(:password)
+    attributes.except("password")
   end
 
   def delete

--- a/psd-web/app/models/new_user.rb
+++ b/psd-web/app/models/new_user.rb
@@ -1,7 +1,40 @@
 class NewUser
   include ActiveModel::Model
+  include ActiveModel::Attributes
+  include GlobalID::Identification
 
-  attr_accessor :email_address
+  attributes :email, :name, :mobile_number, :password
+  attribute :encrypted_password, default: ""
 
-  validates :email_address, format: { with: URI::MailTo::EMAIL_REGEXP }
+  with_options on: :registration_completion do |registration_completion|
+    registration_completion.validates :mobile_number, presence: true
+    registration_completion.validates :mobile_number,
+                                      phone: { message: I18n.t(:invalid, scope: %i[activerecord errors models user attributes mobile_number]) },
+                                      unless: -> { mobile_number.blank? }
+    registration_completion.validates :name, presence: true
+    registration_completion.validates :password, presence: true
+    registration_completion.validates :password, length: { minimum: 8 }, allow_blank: true
+  end
+
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  def self.find(id)
+    new(JSON.parse(redis.get(id)))
+  end
+
+  # TODO: set key expiry to the invitation expiry time
+  def save
+    # TODO: handle not saved
+    redis.set(id, to_json.except(:password))
+    true
+  end
+
+  def delete
+    # TODO: handle not found because exipired?
+    redis.delete(email_address)
+  end
+
+  def redis
+    @redis ||= Redis.new(url: ENV["REDIS_URL"])
+  end
 end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -22,16 +22,6 @@ class User < ApplicationRecord
             common_password: { message: I18n.t(:too_common, scope: %i[activerecord errors models user attributes password]) },
             unless: Proc.new { |user| !password_required? || user.errors.messages[:password].any? }
 
-  with_options on: :registration_completion do |registration_completion|
-    registration_completion.validates :mobile_number, presence: true
-    registration_completion.validates :mobile_number,
-                                      phone: { message: I18n.t(:invalid, scope: %i[activerecord errors models user attributes mobile_number]) },
-                                      unless: -> { mobile_number.blank? }
-    registration_completion.validates :name, presence: true
-    registration_completion.validates :password, presence: true
-    registration_completion.validates :password, length: { minimum: 8 }, allow_blank: true
-  end
-
   attribute :skip_password_validation, :boolean, default: false
 
   def self.activated


### PR DESCRIPTION
In order to avoid saving password and telephone numbers, which could lead to users with odd states and potential security concerns, this separated the the pending invitation from the user. 
The only the NewUser object  handles registration concerns and does not polute the `User` object which needs not to know about invitation. 

This is using the already existing `NewUser` model, adding some of the attributes that needs to be validated and saved to the corresponding `User` model.
Save the `new_user` to rails cache setting the key expiration at the same date as the invitation expiration (that's the key part!).
Upon successful 2fa, the `new_user` is fetched from rails cache, the attributes are copied over to the corresponding `user` and the cache is then deleted. 

**Note:**
`NewUser` already existed and so I've used that but could renamed to `Invitation`

This is a proof of concept, by no mean ready to be reviewed as merged, tests need to be added.

