### PR TITLE
Password manager login

### DIFF
--- a/psd-web/app/assets/stylesheets/helpers/password-manager-hidden.scss
+++ b/psd-web/app/assets/stylesheets/helpers/password-manager-hidden.scss
@@ -1,0 +1,4 @@
+.app-\!-password-manager-hidden {
+  opacity: 0;
+  height: 0;
+}

--- a/psd-web/app/assets/stylesheets/helpers/password-manager-hidden.scss
+++ b/psd-web/app/assets/stylesheets/helpers/password-manager-hidden.scss
@@ -1,4 +1,4 @@
-.app-\!-password-manager-hidden {
+.app-password-manager-hidden {
   opacity: 0;
   height: 0;
 }

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -58,8 +58,3 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
   padding-top: 2em;
   border-top: 1px solid govuk-colour("light-grey");
 }
-
-.app-\!-password-manager-hidden {
-  opacity: 0;
-  height: 0;
-}

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -61,5 +61,5 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 
 .app-\!-password-manager-hidden {
   opacity: 0;
-  height: 0px;
+  height: 0;
 }

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -58,3 +58,8 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
   padding-top: 2em;
   border-top: 1px solid govuk-colour("light-grey");
 }
+
+.app-\!-password-manager-hidden {
+  opacity: 0;
+  height: 0px;
+}

--- a/psd-web/app/views/devise/two_factor_authentication/show.html.erb
+++ b/psd-web/app/views/devise/two_factor_authentication/show.html.erb
@@ -16,7 +16,8 @@
           classes: "govuk-input--width-5",
           label: { text: "Enter security code" },
           attributes: { pattern: "[0-9]*", inputmode: "numeric" },
-          errorMessage: format_errors_for(resource, resource.errors.full_messages_for(:otp_code)) %>
+          errorMessage: format_errors_for(resource, resource.errors.full_messages_for(:otp_code)),
+          autocomplete: "one-time-code" %>
 
       <%= govukButton(text: "Continue") %>
     <% end %>

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -14,22 +14,25 @@
           classes: "govuk-visually-hidden"
         },
         label: { text: "Email address" },
-        value: @user.email
+        value: @user.email,
+        autocomplete: "off"
         %>
 
       <%= render "form_components/govuk_input", key: :name, form: form,
         classes: "app-!-max-width-two-thirds",
         label: { text: "Full name" },
-        value: @user.name
+        value: @user.name,
+        autocomplete: "name"
         %>
 
       <%= render "form_components/govuk_input", key: :mobile_number, form: form,
         classes: "app-!-max-width-two-thirds",
         label: { text: "Mobile number" },
-        value: @user.mobile_number
+        value: @user.mobile_number,
+        autocomplete: "tel-national"
         %>
 
-      <%= password_input @user %>
+      <%= password_input @user, autocomplete: "new-password" %>
 
       <%= hidden_field_tag :invitation, params[:invitation] %>
 

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -9,6 +9,14 @@
 
     <%= form_for @user, url: { action: :update } do |form| %>
 
+      <%= render "form_components/govuk_input", key: :email, form: form,
+        formGroup: {
+          classes: "govuk-visually-hidden"
+        },
+        label: { text: "Email address" },
+        value: @user.email
+        %>
+
       <%= render "form_components/govuk_input", key: :name, form: form,
         classes: "app-!-max-width-two-thirds",
         label: { text: "Full name" },

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -28,7 +28,8 @@
           classes: "govuk-visually-hidden"
         },
         label: { text: "Email address" },
-        value: @user.email
+        value: @user.email,
+        autocomplete: "off"
         %>
 
       <%= password_input @user, autocomplete: "new-password" %>

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -20,12 +20,17 @@
         classes: "app-!-max-width-two-thirds",
         label: { text: "Mobile number" },
         value: @user.mobile_number,
-        autocomplete: "tel-national",
+        autocomplete: "tel",
         type: "tel"
         %>
 
-      <%= content_tag :div, style: "opacity: 0; height: 0px" do -%>
-        <%= text_field_tag :username, @user.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
+      <%#
+        This field is to enable password managers to capture the username as
+        well as the password, but should not be visible to users, nor should
+        the controller process the input.
+      %>
+      <%= content_tag :div, class: "app-!-password-manager-hidden" do -%>
+        <%= email_field_tag :username, @user.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
       <% end -%>
 
       <%= password_input @user, autocomplete: "new-password" %>

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -20,7 +20,8 @@
         classes: "app-!-max-width-two-thirds",
         label: { text: "Mobile number" },
         value: @user.mobile_number,
-        autocomplete: "tel-national"
+        autocomplete: "tel-national",
+        type: "tel"
         %>
 
       <%= content_tag :div, style: "opacity: 0; height: 0px" do -%>

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -23,8 +23,8 @@
         autocomplete: "tel-national"
         %>
 
-      <%= content_tag :div do -%>
-        <%= form.text_field :email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true %>
+      <%= content_tag :div, style: "opacity: 0; height: 0px" do -%>
+        <%= text_field_tag :username, @user.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
       <% end -%>
 
       <%= password_input @user, autocomplete: "new-password" %>

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -29,7 +29,7 @@
         well as the password, but should not be visible to users, nor should
         the controller process the input.
       %>
-      <%= content_tag :div, class: "app-!-password-manager-hidden" do -%>
+      <%= content_tag :div, class: "app-password-manager-hidden" do -%>
         <%= email_field_tag :username, @user.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
       <% end -%>
 

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -23,14 +23,9 @@
         autocomplete: "tel-national"
         %>
 
-      <%= render "form_components/govuk_input", key: :email, form: form,
-        formGroup: {
-          classes: "govuk-visually-hidden"
-        },
-        label: { text: "Email address" },
-        value: @user.email,
-        autocomplete: "off"
-        %>
+      <%= content_tag :div do -%>
+        <%= form.text_field :email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true %>
+      <% end -%>
 
       <%= password_input @user, autocomplete: "new-password" %>
 

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -9,15 +9,6 @@
 
     <%= form_for @user, url: { action: :update } do |form| %>
 
-      <%= render "form_components/govuk_input", key: :email, form: form,
-        formGroup: {
-          classes: "govuk-visually-hidden"
-        },
-        label: { text: "Email address" },
-        value: @user.email,
-        autocomplete: "off"
-        %>
-
       <%= render "form_components/govuk_input", key: :name, form: form,
         classes: "app-!-max-width-two-thirds",
         label: { text: "Full name" },
@@ -30,6 +21,14 @@
         label: { text: "Mobile number" },
         value: @user.mobile_number,
         autocomplete: "tel-national"
+        %>
+
+      <%= render "form_components/govuk_input", key: :email, form: form,
+        formGroup: {
+          classes: "govuk-visually-hidden"
+        },
+        label: { text: "Email address" },
+        value: @user.email
         %>
 
       <%= password_input @user, autocomplete: "new-password" %>


### PR DESCRIPTION
https://trello.com/c/5qErVTcP/438-improve-chances-of-passwords-getting-saved-correctly-autocomplete

## Description
Allows password managers to capture the username when completing registration for an account.

We did not want the username to be visible to the user.

Hidden inputs were ignored, as were elements inside a `govuk-visually-hidden` class. Multiple iterations were made to arrive at this solution, which is tested in Chrome and Firefox with 1Password, OSX Keychain and the Okta Password Manager on a BEIS managed laptop. It is not accessible via keyboard or screen readers.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?

### Accessibility testing (author)
- [x] Works keyboard only
- [x] Tested with one screen reader
