### PR TITLE
Add 2fa to registration flow

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,14 @@ module Users
 
       self.resource = warden.authenticate(auth_options)
 
+
+      # Stop users from signing in if they’ve not completed 2FA verification
+      # of their mobile number during account set up process.
+      if resource && !resource.mobile_number_verified
+        resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
+        return render :new
+      end
+
       if resource
         sign_in(resource_name, resource)
         return respond_with resource, location: after_sign_in_path_for(resource)

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -18,7 +18,6 @@ module Users
 
       self.resource = warden.authenticate(auth_options)
 
-
       # Stop users from signing in if they’ve not completed 2FA verification
       # of their mobile number during account set up process.
       if resource && !resource.mobile_number_verified

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -66,6 +66,8 @@ module Users
       warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
       bypass_sign_in(resource, scope: resource_name)
 
+      resource.update(mobile_number_verified: true)
+
       resource.pass_two_factor_authentication!
 
       redirect_to after_two_factor_success_path_for(resource)

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -63,19 +63,6 @@ module Users
     def after_two_factor_success_for(resource)
       set_remember_two_factor_cookie(resource)
 
-      if session[:name] && session[:mobile_number] && session[:password]
-
-        resource.update(
-          name: session[:name],
-          mobile_number: session[:mobile_number],
-          password: session[:password]
-        )
-
-        session.delete(:name)
-        session.delete(:mobile_number)
-        session.delete(:password)
-      end
-
       warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
       bypass_sign_in(resource, scope: resource_name)
 

--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -63,6 +63,19 @@ module Users
     def after_two_factor_success_for(resource)
       set_remember_two_factor_cookie(resource)
 
+      if session[:name] && session[:mobile_number] && session[:password]
+
+        resource.update(
+          name: session[:name],
+          mobile_number: session[:mobile_number],
+          password: session[:password]
+        )
+
+        session.delete(:name)
+        session.delete(:mobile_number)
+        session.delete(:password)
+      end
+
       warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
       bypass_sign_in(resource, scope: resource_name)
 

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -30,11 +30,9 @@ class UsersController < ApplicationController
     @user.assign_attributes(new_user_attributes)
 
     if @user.save(context: :registration_completion)
-
+      sign_in(:user, @user)
       @user.send_new_otp
       redirect_to user_two_factor_authentication_path
-      # sign_in :user, @user
-      # redirect_to root_path
     else
       render :complete_registration
     end

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
     @user.assign_attributes(new_user_attributes)
 
     if @user.save(context: :registration_completion)
-      sign_in(:user, @user)
+      sign_in :user, @user
       warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
       @user.send_new_otp
       redirect_to user_two_factor_authentication_path

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -30,8 +30,11 @@ class UsersController < ApplicationController
     @user.assign_attributes(new_user_attributes)
 
     if @user.save(context: :registration_completion)
-      sign_in :user, @user
-      redirect_to root_path
+
+      @user.send_new_otp
+      redirect_to user_two_factor_authentication_path
+      # sign_in :user, @user
+      # redirect_to root_path
     else
       render :complete_registration
     end

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -29,24 +29,11 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(new_user_attributes)
 
-    if @user.valid?(context: :registration_completion)
-
-      # Copy these attributes to the session, as we don’t want to
-      # persist them until the user completes 2FA.
-      session[:name] = @user.name
-      session[:mobile_number] = @user.mobile_number
-      session[:password] = @user.password
+    if @user.save(context: :registration_completion)
 
       sign_in :user, @user
       warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
       @user.send_new_otp
-
-      # Reset these as @user.send_new_otp saves the record
-      @user.update_columns(
-        name: nil,
-        mobile_number: nil,
-        encrypted_password: ""
-      )
 
       redirect_to user_two_factor_authentication_path
     else

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -31,6 +31,7 @@ class UsersController < ApplicationController
 
     if @user.save(context: :registration_completion)
       sign_in(:user, @user)
+      warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
       @user.send_new_otp
       redirect_to user_two_factor_authentication_path
     else

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -29,10 +29,25 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(new_user_attributes)
 
-    if @user.save(context: :registration_completion)
+    if @user.valid?(context: :registration_completion)
+
+      # Copy these attributes to the session, as we don’t want to
+      # persist them until the user completes 2FA.
+      session[:name] = @user.name
+      session[:mobile_number] = @user.mobile_number
+      session[:password] = @user.password
+
       sign_in :user, @user
       warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
       @user.send_new_otp
+
+      # Reset these as @user.send_new_otp saves the record
+      @user.update_columns(
+        name: nil,
+        mobile_number: nil,
+        encrypted_password: ""
+      )
+
       redirect_to user_two_factor_authentication_path
     else
       render :complete_registration

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -157,7 +157,7 @@ class User < ApplicationRecord
   end
 
   def has_completed_registration?
-    encrypted_password.present? && name.present? && mobile_number.present?
+    encrypted_password.present? && name.present? && mobile_number.present? && mobile_number_verified
   end
 
   def self.get_assignees(except: [])

--- a/psd-web/db/migrate/20200320144542_add_mobile_number_verified_to_users.rb
+++ b/psd-web/db/migrate/20200320144542_add_mobile_number_verified_to_users.rb
@@ -10,6 +10,5 @@ class AddMobileNumberVerifiedToUsers < ActiveRecord::Migration[5.2]
         end
       end
     end
-
   end
 end

--- a/psd-web/db/migrate/20200320144542_add_mobile_number_verified_to_users.rb
+++ b/psd-web/db/migrate/20200320144542_add_mobile_number_verified_to_users.rb
@@ -1,0 +1,15 @@
+class AddMobileNumberVerifiedToUsers < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      add_column :users, :mobile_number_verified, :boolean, default: false, null: false
+
+      # Set all existing mobile numbers as verified
+      reversible do |dir|
+        dir.up do
+          User.where.not(mobile_number: nil).update_all(mobile_number_verified: true)
+        end
+      end
+    end
+
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_170356) do
+ActiveRecord::Schema.define(version: 2020_03_20_144542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -295,6 +295,7 @@ ActiveRecord::Schema.define(version: 2020_03_10_170356) do
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
     t.text "mobile_number"
+    t.boolean "mobile_number_verified", default: false, null: false
     t.string "name"
     t.uuid "organisation_id"
     t.binary "password_salt"

--- a/psd-web/spec/factories/users.rb
+++ b/psd-web/spec/factories/users.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     account_activated { false }
     hash_iterations { 27_500 }
     mobile_number { "07700 900 982" }
+    mobile_number_verified { true }
     direct_otp_sent_at { Time.current }
     direct_otp { "12345" }
 
@@ -48,6 +49,7 @@ FactoryBot.define do
       password { nil }
       password_confirmation { nil }
       mobile_number { nil }
+      mobile_number_verified { false }
       name { nil }
     end
 

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -33,11 +33,8 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
     fill_in "Password", with: "testpassword123@"
     click_on "Continue"
 
-    expect(page).to have_current_path("/two-factor")
-    expect(page).to have_css("h1", text: "Check your phone")
-
-    fill_in "Enter security code", with: invited_user.reload.direct_otp
-    click_on "Continue"
+    # Skips 2FA as cookie was set to not require
+    # 2FA for 7 days.
 
     expect_to_be_on_declaration_page
     expect_to_be_signed_in

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
     expect_to_be_signed_in
 
     # Now sign out and use those credentials to sign back in
-    find_link("Sign out", match: :first).click()
+    find_link("Sign out", match: :first).click
 
     expect_to_be_on_the_homepage
 

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "support/feature_helpers"
 
-RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, :with_stubbed_notify do
+RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, :with_stubbed_notify, :with_2fa do
   let(:invited_user) { create(:user, :invited, direct_otp: nil) }
   let(:existing_user) { create(:user) }
 

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -14,6 +14,11 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
 
     click_button "Continue"
 
+    expect_to_be_on_two_factor_authentication_page
+
+    fill_in "Enter security code", with: invited_user.reload.direct_otp
+    click_on "Continue"
+
     expect_to_be_on_declaration_page
     expect_to_be_signed_in
   end
@@ -35,6 +40,12 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
 
     expect_to_be_on_declaration_page
     expect_to_be_signed_in
+  end
+
+  def expect_to_be_on_two_factor_authentication_page
+    expect(page).to have_current_path(/^\/two-factor$/)
+
+    expect(page).to have_h1("Check your phone")
   end
 
   def expect_to_be_on_complete_registration_page

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "support/feature_helpers"
 
-RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config do
+RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_keycloak_config, :with_stubbed_notify do
   let(:invited_user) { create(:user, :invited) }
   let(:existing_user) { create(:user) }
 
@@ -37,6 +37,11 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
     fill_in_account_details_with full_name: "Bob Jones", mobile_number: "07731123345", password: "testpassword123@"
 
     click_button "Continue"
+
+    expect_to_be_on_two_factor_authentication_page
+
+    fill_in "Enter security code", with: invited_user.reload.direct_otp
+    click_on "Continue"
 
     expect_to_be_on_declaration_page
     expect_to_be_signed_in

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -68,6 +68,22 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     end
   end
 
+  context "when the user hasn’t verified their mobile number" do
+    let(:user) { create(:user, mobile_number_verified: false) }
+
+    it "doesn’t let them sign in" do
+      visit "/sign-in"
+
+      fill_in "Email address", with: user.email
+      fill_in "Password", with: "2538fhdkvuULE36f"
+      click_on "Continue"
+
+      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+      expect(page).to have_link("Enter correct email address and password", href: "#email")
+      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
+    end
+  end
+
   context "with credentials entered incorrectly" do
     it "highlights email field" do
       visit "/sign-in"

--- a/psd-web/spec/requests/two_factor_authentication_spec.rb
+++ b/psd-web/spec/requests/two_factor_authentication_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe "User submits two factor authentication code", :with_stubbed_noti
 
     let(:previous_attempts_count) { 1 }
     let(:user) do
-      create(:user, :activated, direct_otp: "12345", second_factor_attempts_count: previous_attempts_count)
+      create(:user, :activated, direct_otp: "12345",
+        mobile_number_verified: false,
+        second_factor_attempts_count: previous_attempts_count)
     end
 
     context "when not signed in prior to submit the 2FA page" do
@@ -66,6 +68,11 @@ RSpec.describe "User submits two factor authentication code", :with_stubbed_noti
           submit_2fa
           follow_redirect!
           expect(response.body).to include("Sign out")
+        end
+
+        it "marks the mobile number as verified" do
+          submit_2fa
+          expect(user.reload.mobile_number_verified).to be true
         end
       end
 

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
       end
     end
 
+    context "when the user has set a name, password and mobile number but hasn’t yet verified their mobile number via 2FA" do
+      let(:user) { create(:user, invitation_token: "abc123", invited_at: Time.zone.now, account_activated: false, mobile_number_verified: false) }
+
+      before do
+        get complete_registration_user_path(user.id, invitation: user.invitation_token)
+      end
+
+      it "renders the complete registration page" do
+        expect(response).to render_template(:complete_registration)
+      end
+    end
+
     context "when the user has already completed their registration" do
       let(:user) { create(:user, invitation_token: "abc123", invited_at: Time.zone.now, account_activated: false) }
 
@@ -99,6 +111,10 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
 
       it "does not set the activated flag on the user" do
         expect(user).not_to be_account_activated
+      end
+
+      it "does not set the mobile number as verified" do
+        expect(user.mobile_number_verified).to be false
       end
 
       it "redirects to the two factor authentication path" do

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -105,16 +105,16 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
         expect(response).to redirect_to(user_two_factor_authentication_path)
       end
 
-      it "updates the user name" do
-        expect(user.name).to eq("Foo Bar")
+      it "doesn’t update the user name" do
+        expect(user.read_attribute(:name)).to be_nil
       end
 
-      it "updates the user mobile number" do
-        expect(user.mobile_number).to eq("07235671232")
+      it "doesn’t update the user mobile number" do
+        expect(user.mobile_number).to be_nil
       end
 
-      it "updates the user password" do
-        expect(user.encrypted_password).not_to be_blank
+      it "doesn’t update the user password" do
+        expect(user.encrypted_password).to be_blank
       end
     end
 

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User completes registration", type: :request, with_stubbed_keycloak_config: true do
+RSpec.describe "User completes registration", type: :request, with_stubbed_keycloak_config: true, with_stubbed_notify: true do
   let(:user) { create(:user, :invited) }
 
   describe "viewing the form" do
@@ -101,8 +101,8 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
         expect(user).not_to be_account_activated
       end
 
-      it "redirects to the root path" do
-        expect(response).to redirect_to(root_path)
+      it "redirects to the two factor authentication path" do
+        expect(response).to redirect_to(user_two_factor_authentication_path)
       end
 
       it "updates the user name" do

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -105,16 +105,16 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
         expect(response).to redirect_to(user_two_factor_authentication_path)
       end
 
-      it "doesn’t update the user name" do
-        expect(user.read_attribute(:name)).to be_nil
+      it "updates the user’s name" do
+        expect(user.name).to eql("Foo Bar")
       end
 
-      it "doesn’t update the user mobile number" do
-        expect(user.mobile_number).to be_nil
+      it "updates the user’s mobile number" do
+        expect(user.mobile_number).to eql("07235671232")
       end
 
-      it "doesn’t update the user password" do
-        expect(user.encrypted_password).to be_blank
+      it "updates the user’s password" do
+        expect(user.encrypted_password).not_to be_blank
       end
     end
 


### PR DESCRIPTION
This requires users to complete a mobile phone number verification step (entering a code received via text message) when completing their account details after being invited to use the service.

Because entering name, password and mobile number is a previous step, the user can potentially be left in a state where they have set those details but haven't verified their mobile number. In this (hopefully rare) state, they:

* Can still go back and start their account setup process again (from the link in the e-mail), provided it’s within the expiry period.
* Cannot login - if they do, they get a generic error message (this prevents a user from ending up in a state where they have an active account but can't sign in because their mobile number is invalid).

See https://trello.com/c/Huo9xSPj/389-2fa-on-registration-page

## Implementation approach

To keep track of whether the mobile number has been verified (via 2FA), a new `mobile_number_verified` boolean attribute is added to the User model. This is set to true after a user completes 2FA. The sign in page checks that this is true. Until it becomes `true`, the invitation to set up an account remains valid.

## Alternative approaches 

* #398 doesn’t save the name, password and mobile number to the database at all until the 2FA is complete. Instead it saves it to the redis session store.
* #404 as above, but saving to the Rails cache instead (which I think is also backed by Redis).

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)
