### PR TITLE
Fix silent failure with user with no mobile number

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -25,13 +25,15 @@ module Users
         return render :new
       end
 
-      if resource
+      if resource && resource.mobile_number?
         sign_in(resource_name, resource)
         return respond_with resource, location: after_sign_in_path_for(resource)
+      elsif resource
+        resource.errors.add(:email, I18n.t(:missing, scope: "sign_user_in.mobile_number"))
+        return redirect_to missing_mobile_number_path
       end
 
-      self.resource ||= resource_class.new(sign_in_params)
-      resource.decorate
+      self.resource = resource_class.new(sign_in_params).decorate
       resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
       resource.errors.add(:password, nil)
       render :new

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -25,7 +25,7 @@ module Users
         return render :new
       end
 
-      if resource && resource.mobile_number?
+      if resource&.mobile_number?
         sign_in(resource_name, resource)
         return respond_with resource, location: after_sign_in_path_for(resource)
       elsif resource

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -29,7 +29,6 @@ module Users
         sign_in(resource_name, resource)
         return respond_with resource, location: after_sign_in_path_for(resource)
       elsif resource
-        resource.errors.add(:email, I18n.t(:missing, scope: "sign_user_in.mobile_number"))
         return redirect_to missing_mobile_number_path
       end
 

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -30,7 +30,8 @@ module Users
         return respond_with resource, location: after_sign_in_path_for(resource)
       end
 
-      self.resource = resource_class.new(sign_in_params).decorate
+      self.resource ||= resource_class.new(sign_in_params)
+      resource.decorate
       resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
       resource.errors.add(:password, nil)
       render :new

--- a/psd-web/app/views/users/missing_mobile_number.html.erb
+++ b/psd-web/app/views/users/missing_mobile_number.html.erb
@@ -1,5 +1,5 @@
 <% title = "No mobile number for this account" %>
-<% content_for :page_title, title %>
+<% page_title(title) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/psd-web/app/views/users/missing_mobile_number.html.erb
+++ b/psd-web/app/views/users/missing_mobile_number.html.erb
@@ -1,0 +1,11 @@
+<% title = "No mobile number for this account" %>
+<% content_for :page_title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p class="govuk-body">This account does not have a mobile number set up. Mobile numbers are required for account security. Speak to your PSD team admin or <%= mail_to t(:enquiries_email), "email OPSS", class: "govu-link" %> to add it.</p>
+  </div>
+</div>

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -173,6 +173,8 @@ en:
     email:
       wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
   sign_user_in:
+    mobile_number:
+      missing: "This account does not have a mobile number set up. Mobile numbers are required for account security. Speak to your PSD team admin or email [OPSS](opss email) to add it."
     email:
       wrong_email_or_password: "Enter correct email address and password"
   support:

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -173,8 +173,6 @@ en:
     email:
       wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
   sign_user_in:
-    mobile_number:
-      missing: "This account does not have a mobile number set up. Mobile numbers are required for account security. Speak to your PSD team admin or email [OPSS](opss email) to add it."
     email:
       wrong_email_or_password: "Enter correct email address and password"
   support:

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     resource :check_your_email, path: "check-your-email", only: :show, controller: "users/check_your_email"
+    get "missing-mobile-number", to: "users#missing_mobile_number"
   end
 
   resources :users, only: [:update] do

--- a/psd-web/spec/requests/login_spec.rb
+++ b/psd-web/spec/requests/login_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe "Login", type: :request do
   context "with an old bookmarked URL" do
     it { expect(get("/sessions/signin")).to redirect_to(root_path) }
   end
+
+  describe "a user without a mobile number", :with_stubbed_mailer do
+    let(:user) { create(:user, :activated, mobile_number: nil) }
+
+    it "displays an error message" do
+      stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/sms")
+        .and_return(body: {}.to_json, status: 200)
+
+      post new_user_session_path, params: { user: { email: user.email, password: user.password } }
+
+      expect(response.body).to include(I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
+    end
+  end
 end

--- a/psd-web/spec/requests/login_spec.rb
+++ b/psd-web/spec/requests/login_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe "Login", type: :request do
       stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/sms")
         .and_return(body: {}.to_json, status: 200)
 
-      post new_user_session_path, params: { user: { email: user.email, password: user.password } }
-
-      expect(response.body).to include(I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
+      expect(post(new_user_session_path, params: { user: { email: user.email, password: user.password } }))
+        .to redirect_to(missing_mobile_number_path)
     end
   end
 end

--- a/psd-web/spec/requests/login_spec.rb
+++ b/psd-web/spec/requests/login_spec.rb
@@ -12,13 +12,10 @@ RSpec.describe "Login", type: :request do
     it { expect(get("/sessions/signin")).to redirect_to(root_path) }
   end
 
-  describe "a user without a mobile number", :with_stubbed_mailer do
+  describe "a user without a mobile number", :with_stubbed_mailer, :with_stubbed_notify do
     let(:user) { create(:user, :activated, mobile_number: nil) }
 
     it "displays an error message" do
-      stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/sms")
-        .and_return(body: {}.to_json, status: 200)
-
       expect(post(new_user_session_path, params: { user: { email: user.email, password: user.password } }))
         .to redirect_to(missing_mobile_number_path)
     end


### PR DESCRIPTION
**CHANGES:**

For now display the wrong password or email message when a use logs in but does not have a mobile number associated with their account.
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Has acceptance criteria been tested by a peer?
