### PR TITLE
Set mobile number as verified during keycloak sync task

### DIFF
--- a/psd-web/app/jobs/sync_keycloak_teams_and_users_job.rb
+++ b/psd-web/app/jobs/sync_keycloak_teams_and_users_job.rb
@@ -1,5 +1,8 @@
 class SyncKeycloakTeamsAndUsersJob < ApplicationJob
   def perform
     KeycloakService.sync_orgs_and_users_and_teams
+
+    # Set mobile phone number as verified for all users who have added a mobile number.
+    User.where.not(mobile_number: nil).update_all(mobile_number_verified: true)
   end
 end


### PR DESCRIPTION
This will be removed later once the `keycloak-replacement` branch is merged.

Merge only after #421 has deployed and run the migration