### PR TITLE
Increase CloudFoundry app start timeout from 5 to 10 minutes on review apps

### DIFF
--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -23,6 +23,13 @@ until cf7 service $DB_NAME > /tmp/db_exists && grep -E "create succeeded|update 
 
 cp -a ${PWD-.}/infrastructure/env/. ${PWD-.}/psd-web/env/
 
+# Set the amount of time in minutes that the CLI will wait for all instances to start.
+# Because of the rolling deployment strategy, this should be set to at least the amount of
+# time each app takes to start multiplied by the number of instances.
+#
+# See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
+export CF_STARTUP_TIMEOUT=10
+
 # Deploy the app
 cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --strategy rolling
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Increases the app startup timeout during the deploy process for review apps only. This was already proven successfully on prod/staging as per https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/355. The threshold is set lower for review apps as there is only one instance.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
