### PR TITLE
Bugfix ensure user cant sign in with unverified mobile number

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,11 @@ module Users
 
       # Stop users from signing in if they’ve not completed 2FA verification
       # of their mobile number during account set up process.
-      if resource && !resource.mobile_number_verified
+      if Rails.configuration.two_factor_authentication_enabled && !resource.mobile_number_verified
+        # Need to sign the user out here as they will have been signed in by
+        # warden.authenticate(auth_options) above.
+        sign_out
+        User.current = nil
         resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
         return render :new
       end

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     end
   end
 
-  context "when the user hasn’t verified their mobile number" do
+  context "when the user hasn’t verified their mobile number", :with_2fa do
     let(:user) { create(:user, mobile_number_verified: false) }
 
     it "doesn’t let them sign in" do
@@ -81,6 +81,8 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
       expect(page).to have_link("Enter correct email address and password", href: "#email")
       expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
+      expect(page).not_to have_link("Cases")
+
     end
   end
 

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -82,7 +82,6 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       expect(page).to have_link("Enter correct email address and password", href: "#email")
       expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
       expect(page).not_to have_link("Cases")
-
     end
   end
 


### PR DESCRIPTION
The existing test checked that the user gets an immediate "Enter correct email address and password" error if they try to login after having abandoned the registration flow before verifying their e-mail.

However, if the user subsequently tried to visit another URL, such as the homepage, they were then presented with the 2FA page, as `warden.authenticate(auth_options)` will have signed them in.

This fixes that, but signing the user back out again from within the controller.