### PR TITLE
Forgot password manager

### DIFF
--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -20,6 +20,7 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 @import "stylesheets/helpers/js-only";
 @import "stylesheets/helpers/field-widths";
 @import "stylesheets/helpers/media-queries";
+@import "stylesheets/helpers/password-manager-hidden";
 @import "stylesheets/images";
 @import "stylesheets/inverted";
 @import "stylesheets/teams";

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -10,6 +10,8 @@ module Users
       return render :invalid_link, status: :not_found if reset_token_invalid?
       return render :expired, status: :gone if reset_token_expired?
 
+      @email = user_with_reset_token.email
+
       if passed_two_factor_authentication?
         # Devise password update requires the user to be signed out, as it relies on the "reset password token"
         # parameter and an user attempting to reset its password because does not remember it is not supposed to be
@@ -49,6 +51,7 @@ module Users
 
     def update
       super do |_resource|
+        @email = _resource.email
         if reset_password_token_just_expired?
           return render :expired
         end

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -50,8 +50,9 @@ module Users
     end
 
     def update
-      super do |_resource|
-        @email = _resource.email
+      super do |resource|
+        @email = resource.email
+
         if reset_password_token_just_expired?
           return render :expired
         end

--- a/psd-web/app/views/users/complete_registration.html.erb
+++ b/psd-web/app/views/users/complete_registration.html.erb
@@ -30,7 +30,7 @@
         the controller process the input.
       %>
       <%= content_tag :div, class: "app-password-manager-hidden" do -%>
-        <%= email_field_tag :username, @user.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
+        <%= email_field_tag :username, @user.email, disabled: true, tabindex: "-1", 'aria-hidden': true, autocomplete: "username" %>
       <% end -%>
 
       <%= password_input @user, autocomplete: "new-password" %>

--- a/psd-web/app/views/users/passwords/edit.html.erb
+++ b/psd-web/app/views/users/passwords/edit.html.erb
@@ -19,7 +19,7 @@
         the controller process the input.
       %>
       <%= content_tag :div, class: "app-password-manager-hidden" do -%>
-        <%= email_field_tag :username, @user_with_reset_token.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
+        <%= email_field_tag :username, @email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
       <% end -%>
 
       <%= password_input(resource, hint: { text: "At least 8 characters" }, autocomplete: "new-password") %>

--- a/psd-web/app/views/users/passwords/edit.html.erb
+++ b/psd-web/app/views/users/passwords/edit.html.erb
@@ -12,7 +12,17 @@
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
       <%= f.hidden_field :reset_password_token %>
-      <%= password_input(resource, hint: { text: "At least 8 characters" }) %>
+
+      <%#
+        This field is to enable password managers to capture the username as
+        well as the password, but should not be visible to users, nor should
+        the controller process the input.
+      %>
+      <%= content_tag :div, class: "app-password-manager-hidden" do -%>
+        <%= email_field_tag :username, @user_with_reset_token.email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
+      <% end -%>
+
+      <%= password_input(resource, hint: { text: "At least 8 characters" }, autocomplete: "new-password") %>
 
       <%= govukButton(text: "Continue") %>
     <% end %>

--- a/psd-web/app/views/users/passwords/edit.html.erb
+++ b/psd-web/app/views/users/passwords/edit.html.erb
@@ -19,7 +19,7 @@
         the controller process the input.
       %>
       <%= content_tag :div, class: "app-password-manager-hidden" do -%>
-        <%= email_field_tag :username, @email, "disabled" => true, "tabindex" => "-1", "aria-hidden" => true, autocomplete: "username"  %>
+        <%= email_field_tag :username, @email, disabled: true, tabindex: "-1", 'aria-hidden': true, autocomplete: "username" %>
       <% end -%>
 
       <%= password_input(resource, hint: { text: "At least 8 characters" }, autocomplete: "new-password") %>

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -74,6 +74,8 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
     expect(page).to have_current_path(/\/complete-registration?.+$/)
 
     expect(page).to have_h1("Create an account")
+
+    expect(page).to have_field("username", type: "email", with: invited_user.email, disabled: true)
   end
 
   def expect_to_be_on_signed_in_as_another_user_page

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -49,6 +49,8 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
       expect_to_be_on_edit_user_password_page
 
+      expect(page).to have_field("username", type: "email", with: user.email, disabled: true)
+
       fill_in "Password", with: "a_new_password"
       click_on "Continue"
 
@@ -82,6 +84,8 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
         expect(page).to have_link("Password is too short", href: "#password")
+
+        expect(page).to have_field("username", type: "email", with: user.email, disabled: true)
       end
 
       scenario "when the password is empty it shows an error" do
@@ -100,6 +104,8 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
         expect(page).to have_link("Enter a password", href: "#password")
+
+        expect(page).to have_field("username", type: "email", with: user.email, disabled: true)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/FjWmfu1w/453-complete-registration-email-field-is-visible

https://trello.com/c/U4zEMS0p/454-reset-password-form-should-include-user-name-for-password-managers

## Description
Fixes missing CSS on the complete registration form, and embeds the username in the forgot password form so that password managers can pick it up when saving the password.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?

### Accessibility testing (author)
- [x] Works keyboard only
- [x] Tested with one screen reader
