### PR TITLE
Bugfix: Don’t prefill name and mobile number after abandoned registration

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,7 @@ module Users
 
       # Stop users from signing in if they’ve not completed 2FA verification
       # of their mobile number during account set up process.
-      if Rails.configuration.two_factor_authentication_enabled && !resource.mobile_number_verified
+      if Rails.configuration.two_factor_authentication_enabled && resource && !resource.mobile_number_verified
         # Need to sign the user out here as they will have been signed in by
         # warden.authenticate(auth_options) above.
         sign_out

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -7,6 +7,12 @@ class UsersController < ApplicationController
   def complete_registration
     @user = User.find(params[:id])
 
+    # Reset name and mobile number in case they’ve been remembered
+    # from a previous registration that was abandoned before the mobile number
+    # was verified via two-factor authentication.
+    @user.name = ""
+    @user.mobile_number = ""
+
     return render :signed_in_as_another_user if user_signed_in? && !signed_in_as?(@user)
 
     # Some users will bookmark the invitation URL received on the email and may re-use

--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -7,12 +7,6 @@ class UsersController < ApplicationController
   def complete_registration
     @user = User.find(params[:id])
 
-    # Reset name and mobile number in case they’ve been remembered
-    # from a previous registration that was abandoned before the mobile number
-    # was verified via two-factor authentication.
-    @user.name = ""
-    @user.mobile_number = ""
-
     return render :signed_in_as_another_user if user_signed_in? && !signed_in_as?(@user)
 
     # Some users will bookmark the invitation URL received on the email and may re-use
@@ -20,6 +14,12 @@ class UsersController < ApplicationController
     return redirect_to(root_path) if signed_in_as?(@user) || @user.has_completed_registration?
     return render(:expired_invitation) if @user.invitation_expired?
     return (render "errors/not_found", status: :not_found) if @user.invitation_token != params[:invitation]
+
+    # Reset name and mobile number in case they’ve been remembered
+    # from a previous registration that was abandoned before the mobile number
+    # was verified via two-factor authentication.
+    @user.name = ""
+    @user.mobile_number = ""
 
     render :complete_registration
   end

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -78,8 +78,8 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
       expect_to_be_on_complete_registration_page
 
       # Form should NOT contain values from previous abandoned registration
-      expect(find_field("Full name").value).to eql("")
-      expect(find_field("Mobile number").value).to eql("")
+      expect(find_field("Full name").value).to eq ""
+      expect(find_field("Mobile number").value).to eq ""
 
       # Deliberately leave password blank
       fill_in_account_details_with full_name: "Bob Jones", mobile_number: "07731123345", password: ""
@@ -87,8 +87,8 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
       click_button "Continue"
 
       # Form SHOULD now contain pre-filled values from previous submission
-      expect(find_field("Full name").value).to eql("Bob Jones")
-      expect(find_field("Mobile number").value).to eql("07731123345")
+      expect(find_field("Full name").value).to eq("Bob Jones")
+      expect(find_field("Mobile number").value).to eq("07731123345")
 
       # Now add a password
       fill_in "Password", with: "testpassword123@"

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -85,6 +85,21 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     end
   end
 
+  context "when email address does not belong to any user", :with_2fa do
+    it "shows a generic error message" do
+      visit "/sign-in"
+
+      fill_in "Email address", with: "notarealuser@example.com"
+      fill_in "Password", with: "notarealpassword"
+      click_on "Continue"
+
+      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+      expect(page).to have_link("Enter correct email address and password", href: "#email")
+      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
+      expect(page).to have_css("span#password-error", text: "")
+    end
+  end
+
   context "with credentials entered incorrectly" do
     it "highlights email field" do
       visit "/sign-in"


### PR DESCRIPTION
If you've completed the first step of registration (adding name, password and mobile number) but didn't complete the 2FA, and then you later go back and attempt to start again using the invite link, it probably makes sense not to prefill the form with your name and mobile number from last time...

See https://trello.com/c/dm7gIfWt/449-account-details-pre-filled-after-abandoning-account-registration