### PR TITLE
Remove devise flash message

### DIFF
--- a/psd-web/config/locales/devise.en.yml
+++ b/psd-web/config/locales/devise.en.yml
@@ -7,7 +7,7 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: ""
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."


### PR DESCRIPTION
We don’t need to see a "You are already signed in." message.