### PR TITLE
enforce two factor auth configuration when registering

### DIFF
--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -38,16 +38,21 @@ class UsersController < ApplicationController
     if @user.save(context: :registration_completion)
 
       sign_in :user, @user
-      warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
-      @user.send_new_otp
-
-      redirect_to user_two_factor_authentication_path
+      redirect_user
     else
       render :complete_registration
     end
   end
 
 private
+
+  def redirect_user
+    return redirect_to root_path unless Rails.configuration.two_factor_authentication_enabled
+
+    warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
+    @user.send_new_otp
+    redirect_to user_two_factor_authentication_path
+  end
 
   def new_user_attributes
     params.require(:user).permit(:name, :password, :mobile_number)

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -114,19 +114,29 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_keycl
       end
 
       it "does not set the mobile number as verified" do
-        expect(user.mobile_number_verified).to be false
+        expect(user).not_to be_mobile_number_verified
       end
 
-      it "redirects to the two factor authentication path" do
-        expect(response).to redirect_to(user_two_factor_authentication_path)
+      context "when two factor auth is enabled" do
+        it "redirects to the two factor authentication path", :with_2fa do
+          expect(response).to redirect_to(user_two_factor_authentication_path)
+        end
       end
 
-      it "updates the user’s name" do
-        expect(user.name).to eql("Foo Bar")
+      context "when two factor auth is disabled" do
+        before do
+          allow(Rails.configuration)
+            .to receive(:two_factor_authentication_enabled)
+            .and_return(false)
+        end
+
+        it "redirects to the two factor authentication path" do
+          expect(response).to redirect_to(root_path)
+        end
       end
 
-      it "updates the user’s mobile number" do
-        expect(user.mobile_number).to eql("07700900000")
+      it "updates the user’s attributes" do
+        expect(user).to have_attributes(name: "Foo Bar", mobile_number: "07700900000")
       end
 
       it "updates the user’s password" do


### PR DESCRIPTION
Does not force 2fa when it is disabled.

https://trello.com/c/vhP7aS87/456-complete-registration-should-respect-twofactorauthenticationenabledfalse

## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Has acceptance criteria been tested by a peer?

