### PR TITLE
Add interstitial page after changing password

### DIFF
--- a/psd-web/app/controllers/users/password_changed_controller.rb
+++ b/psd-web/app/controllers/users/password_changed_controller.rb
@@ -1,0 +1,8 @@
+module Users
+  class PasswordChangedController < ApplicationController
+    skip_before_action :has_accepted_declaration,
+                       :has_viewed_introduction
+
+    def show; end
+  end
+end

--- a/psd-web/app/controllers/users/password_changed_controller.rb
+++ b/psd-web/app/controllers/users/password_changed_controller.rb
@@ -4,5 +4,9 @@ module Users
                        :has_viewed_introduction
 
     def show; end
+
+    def hide_nav?
+      true
+    end
   end
 end

--- a/psd-web/app/controllers/users/passwords_controller.rb
+++ b/psd-web/app/controllers/users/passwords_controller.rb
@@ -115,5 +115,9 @@ module Users
     def after_sending_reset_password_instructions_path_for(_resource_name)
       check_your_email_path
     end
+
+    def after_resetting_password_path_for(_resource)
+      password_changed_path
+    end
   end
 end

--- a/psd-web/app/views/users/password_changed/show.html.erb
+++ b/psd-web/app/views/users/password_changed/show.html.erb
@@ -1,5 +1,5 @@
 <% title = "You have changed your password successfully" %>
-<% content_for :page_title, title %>
+<% page_title title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/psd-web/app/views/users/password_changed/show.html.erb
+++ b/psd-web/app/views/users/password_changed/show.html.erb
@@ -1,0 +1,10 @@
+<% title = "You have changed your password successfully" %>
+<% content_for :page_title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p class="govuk-body"><%= govukButton href: root_path, text: "Continue" %></p>
+  </div>
+</div>

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     get "missing-mobile-number", to: "users#missing_mobile_number"
   end
 
+  resource :password_changed, controller: "users/password_changed", only: :show
+
   resources :users, only: [:update] do
     member do
       get "complete-registration", action: :complete_registration

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     get "missing-mobile-number", to: "users#missing_mobile_number"
   end
 
-  resource :password_changed, controller: "users/password_changed", only: :show
+  resource :password_changed, controller: "users/password_changed", only: :show, path: "password-changed"
 
   resources :users, only: [:update] do
     member do

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -54,6 +54,10 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
       fill_in "Password", with: "a_new_password"
       click_on "Continue"
 
+      expect_to_be_on_password_changed_page
+
+      click_link "Continue"
+
       expect(page).to have_css("h1", text: "Declaration")
 
       sign_out
@@ -174,5 +178,10 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
 
   def expect_to_be_on_check_your_email_page
     expect(page).to have_css("h1", text: "Check your email")
+  end
+
+  def expect_to_be_on_password_changed_page
+    expect(page).to have_current_path("/password-changed")
+    expect(page).to have_css("h1", text: "You have changed your password successfully")
   end
 end

--- a/psd-web/spec/requests/user_resets_password_spec.rb
+++ b/psd-web/spec/requests/user_resets_password_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe "User resets password", type: :request, with_stubbed_keycloak_con
         }
       end
 
-      it "redirects to the homepage" do
-        expect(response).to redirect_to(root_path)
+      it "redirects to the password changed page" do
+        expect(response).to redirect_to(password_changed_path)
       end
     end
 


### PR DESCRIPTION
This should help make it clearer to the user that their password was successfully updated, rather than just redirecting to the homepage.

Screenshot:

<img width="980" alt="Screenshot 2020-03-27 at 16 26 53" src="https://user-images.githubusercontent.com/30665/77778203-8d5f2300-7048-11ea-88d5-f3b878c0cd26.png">
