### PR TITLE
Add product categories relating to coronavirus

### DIFF
--- a/psd-web/app/views/products/_form.html.slim
+++ b/psd-web/app/views/products/_form.html.slim
@@ -11,10 +11,10 @@
       aria_describedby: "report-product-category-hint",
       is_autocomplete: true,
       label: { text: "Product category", classes: label_class },
-      hint: { text: "For example, ‘Furniture’ or ‘Stationery’" }
+      hint: { text: "COVID-19 categories added: ‘PPE’ and ‘Hand sanitizer’" }
 
 - hint_html = capture do
-  | For example, ‘Dining chair’ or ‘Ballpoint pen’
+  | For example, ‘Face mask’ or ‘Latex gloves’
 = render "form_components/govuk_input", key: :product_type, form: form,
         classes: "app-!-max-width-one-half",
         label: { text: "Product type", classes: label_class },
@@ -23,7 +23,7 @@
 - hint_html = capture do
   | Include brand, model name and model number – information that will help
     others identify the product.
-    For example, ‘Initech Cristal Medium Point (1.0mm), 795487’.
+    For example, ‘Inotech respirator face mask (FFP), 795487’.
 
 = render "form_components/govuk_input", key: :name, form: form,
         classes: "app-!-max-width-three-quarters",

--- a/psd-web/app/views/products/_form.html.slim
+++ b/psd-web/app/views/products/_form.html.slim
@@ -11,7 +11,7 @@
       aria_describedby: "report-product-category-hint",
       is_autocomplete: true,
       label: { text: "Product category", classes: label_class },
-      hint: { text: "COVID-19 categories added: ‘PPE’ and ‘Hand sanitizer’" }
+      hint: { text: "COVID-19 categories added: ‘PPE’ and ‘Hand sanitiser’" }
 
 - hint_html = capture do
   | For example, ‘Face mask’ or ‘Latex gloves’

--- a/psd-web/config/constants/product_constants.yml
+++ b/psd-web/config/constants/product_constants.yml
@@ -29,7 +29,6 @@ product_category:
   - Measuring instruments
   - Motor vehicles
   - Pressure equipment / vessels
-  - Protective equipment
   - Pyrotechnic articles
   - Rail and guided transport
   - Recreational crafts

--- a/psd-web/config/constants/product_constants.yml
+++ b/psd-web/config/constants/product_constants.yml
@@ -1,4 +1,6 @@
 ---
+# The two coranvirus-related categories come first, rather than being
+# alphabetical, to make it quicker to select them from the dropdown.
 product_category:
   - Personal protective equipment (PPE)
   - Hand sanitiser

--- a/psd-web/config/constants/product_constants.yml
+++ b/psd-web/config/constants/product_constants.yml
@@ -1,5 +1,7 @@
 ---
 product_category:
+  - Personal protective equipment (PPE)
+  - Hand sanitizer
   - Chemical products
   - Childcare articles and children’s equipment
   - Clothing, textiles and fashion items

--- a/psd-web/config/constants/product_constants.yml
+++ b/psd-web/config/constants/product_constants.yml
@@ -1,7 +1,7 @@
 ---
 product_category:
   - Personal protective equipment (PPE)
-  - Hand sanitizer
+  - Hand sanitiser
   - Chemical products
   - Childcare articles and children’s equipment
   - Clothing, textiles and fashion items

--- a/psd-web/lib/tasks/update_product_category.rake
+++ b/psd-web/lib/tasks/update_product_category.rake
@@ -1,0 +1,17 @@
+namespace :data_migration do
+  desc "Update product category for investigations and products"
+  task update_product_category: :environment do
+    Investigation
+      .where(product_category: "Protective equipment")
+      .unscoped
+      .update_all(product_category: "Personal protective equipment (PPE)")
+
+    Product
+      .where(category: "Protective equipment")
+      .update_all(category: "Personal protective equipment (PPE)")
+
+    # Update Elasticsearch
+    Investigation.import
+    Product.import
+  end
+end


### PR DESCRIPTION
This adds two product categories relating to the coronavirus response.

As one of these is a rename (`Protective equipment` -> `Personal protective equipment (PPE)`), this also includes a data migration as a separate rake task to update the existing products and cases (as the categories are stored as strings).

## Screenshot

<img width="641" alt="Screenshot 2020-03-30 at 16 10 45" src="https://user-images.githubusercontent.com/30665/77929006-107ab600-72a1-11ea-99b5-44d50fcd6253.png">
