### PR TITLE
Use RAILS_MAX_THREADS env var for db concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
         WORKER_MEMORY: 1G
         WEB_INSTANCES: 1
         WORKER_INSTANCES: 1
+        WEB_MAX_THREADS: 5
+        WORKER_MAX_THREADS: 10
         CF_USERNAME: ${{ secrets.PaaSUsernameStaging }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordStaging }}
       run: |
@@ -105,6 +107,8 @@ jobs:
         WORKER_MEMORY: 1G
         WEB_INSTANCES: 4
         WORKER_INSTANCES: 2
+        WEB_MAX_THREADS: 5
+        WORKER_MAX_THREADS: 10
         CF_USERNAME: ${{ secrets.PaaSUsernameProduction }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordProduction }}
       run: |

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -46,6 +46,8 @@ jobs:
         SPACE: int
         CF_USERNAME: ${{ secrets.PaaSUsernameInt }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordInt }}
+        WEB_MAX_THREADS: 5
+        WORKER_MAX_THREADS: 10
       run: |
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth

--- a/psd-web/config/database.yml
+++ b/psd-web/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
-  pool: 5
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default

--- a/psd-web/config/sidekiq.yml
+++ b/psd-web/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 10
+:concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
 :queues:
   - <%= ENV['SIDEKIQ_QUEUE'] || "psd" %>
   - <%= ENV['SIDEKIQ_QUEUE'] || "psd" %>-mailers

--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -31,7 +31,7 @@ cp -a ${PWD-.}/infrastructure/env/. ${PWD-.}/psd-web/env/
 export CF_STARTUP_TIMEOUT=10
 
 # Deploy the app
-cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --strategy rolling
+cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
 
 
 # Remove the copied infrastructure env files to clean up

--- a/psd-web/deploy.sh
+++ b/psd-web/deploy.sh
@@ -15,7 +15,7 @@ cp -a ./infrastructure/env/. ./psd-web/env/
 export CF_STARTUP_TIMEOUT=15
 
 # Deploy the app
-cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var psd-host=$DOMAIN --var web-memory=$WEB_MEMORY --var worker-memory=$WORKER_MEMORY --var web-instances=$WEB_INSTANCES --var worker-instances=$WORKER_INSTANCES --strategy rolling
+cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var psd-host=$DOMAIN --var web-memory=$WEB_MEMORY --var worker-memory=$WORKER_MEMORY --var web-instances=$WEB_INSTANCES --var worker-instances=$WORKER_INSTANCES --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
 
 # Remove the copied infrastructure env files to clean up
 rm -R psd-web/env/

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -33,10 +33,14 @@ applications:
     - keycloak-database
   processes:
     - type: web
+      env:
+        RAILS_MAX_THREADS: ((web-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate keycloak:sync db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
       memory: 1G
     - type: worker
+      env:
+        RAILS_MAX_THREADS: ((worker-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 1

--- a/psd-web/manifest.yml
+++ b/psd-web/manifest.yml
@@ -31,10 +31,14 @@ applications:
     - keycloak-database
   processes:
     - type: web
+      env:
+        RAILS_MAX_THREADS: ((web-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate keycloak:sync && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: ((web-instances))
       memory: ((web-memory))
     - type: worker
+      env:
+        RAILS_MAX_THREADS: ((worker-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: ((worker-instances))


### PR DESCRIPTION
This fixes an issue we’ve [seen in production (~4000 times)](https://sentry.io/organizations/beis/issues/1588837243/?project=1329381) whereby a Sidekiq worker process throws a `ActiveRecord::ConnectionTimeoutError (could not obtain a connection from the pool within 5 seconds)` error.

This happens because currently we’ve set the database connection pool to a fixed size of 5, but the number of Sidekiq threads to 10.

To fix this, the database connection pool size now defaults to the value of `RAILS_MAX_THREADS` if set (or 5 otherwise), and this env var is also used to set the Sidekiq concurrency and the number of Puma threads (which was already the case).

The `RAILS_MAX_THREADS` is set to 5 for Puma (web process) and 10 for Sidekiq (worker process) as currently, with these values fed through from the Github deploy scripts.

See:

* [Sidekiq advanced options: concurrency](https://github.com/mperham/sidekiq/wiki/Advanced-Options#concurrency)
* [Heroku: deploying Rails applications with Puma](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#database-connections)