### PR TITLE
Fix submitting wrong credentials twice on sign in

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -25,7 +25,7 @@ module Users
         # warden.authenticate(auth_options) above.
         sign_out
         User.current = nil
-        resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
+        add_wrong_credentials_errors
         return render :new
       end
 
@@ -37,8 +37,7 @@ module Users
       end
 
       self.resource = resource_class.new(sign_in_params).decorate
-      resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
-      resource.errors.add(:password, nil)
+      add_wrong_credentials_errors
       render :new
     end
 
@@ -46,6 +45,11 @@ module Users
 
     def sign_in_form
       @sign_in_form ||= SignInForm.new(sign_in_params)
+    end
+
+    def add_wrong_credentials_errors
+      resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
+      resource.errors.add(:password, nil)
     end
   end
 end

--- a/psd-web/app/views/devise/sessions/new.html.erb
+++ b/psd-web/app/views/devise/sessions/new.html.erb
@@ -12,7 +12,7 @@
       If you don’t have an account, ask someone in your team to send you an invite or <%= mail_to("OPSS.enquiries@beis.gov.uk", "email OPSS") %>.
     </p>
 
-    <%= form_for(resource, as: resource_name, url: user_session_path, html: { novalidate: true }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: user_session_path, html: { novalidate: true }, method: :post) do |f| %>
       <%= email_input resource %>
       <%= password_input resource %>
 

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -14,6 +14,14 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     click_on "Continue"
   end
 
+  def expect_incorrect_email_or_password
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter correct email address and password", href: "#email")
+    expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
+
+    expect(page).not_to have_link("Cases")
+  end
+
   context "when succeeeding signin in", :with_2fa do
     context "when in two factor authentication page" do
       it "allows user to sign in with correct two factor authentication code" do
@@ -78,10 +86,14 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       fill_in "Password", with: "2538fhdkvuULE36f"
       click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter correct email address and password", href: "#email")
-      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
-      expect(page).not_to have_link("Cases")
+      expect_incorrect_email_or_password
+
+      # tries again with another wrong password
+      fill_in "Email address", with: user.email
+      fill_in "Password", with: "2538fhdkvuULE36f"
+      click_on "Continue"
+
+      expect_incorrect_email_or_password
     end
   end
 


### PR DESCRIPTION
**CHANGES:**

Upon submitting the wrong credentials twice the form is generated to use PATCH
as the user as an id

https://trello.com/c/8KwrwkSm/472-page-not-found-error-with-half-registered-user 

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [X] Have you documented your changes in the pull request description?

