### PR TITLE
Update privacy policy page to remove reference to keycloak cookies

### DIFF
--- a/psd-web/app/views/help/privacy_notice.html.slim
+++ b/psd-web/app/views/help/privacy_notice.html.slim
@@ -287,27 +287,6 @@
     p
       | The cookies we use, what they are used for and how long they remain on your device are set out below:
 
-    h2.govuk-heading-m Keycloak and PSD:
-    table.govuk-table
-      thead.govuk-table__head
-        tr.govuk-table__row
-          th.govuk-table__header Name
-          th.govuk-table__header Purpose
-          th.govuk-table__header Lifetime of cookie
-      tbody.govuk-table__body
-        tr.govuk-table__row
-          td.govuk-table__cell _ga
-          td.govuk-table__cell This helps us count how many people visit our site by tracking if you’ve visited before.
-          td.govuk-table__cell 2 years
-        tr.govuk-table__row
-          td.govuk-table__cell _gid
-          td.govuk-table__cell This helps us count how many people visit our site by tracking if you’ve visited before.
-          td.govuk-table__cell 24 hours
-        tr.govuk-table__row
-          td.govuk-table__cell _gat
-          td.govuk-table__cell Used to manage the rate at which page view requests are made.
-          td.govuk-table__cell 1 minute
-
     h2.govuk-heading-m PSD:
     table.govuk-table
       thead.govuk-table__head
@@ -323,37 +302,27 @@
               For example, partial information from a wizard.
           td.govuk-table__cell When you close your browser
         tr.govuk-table__row
+          td.govuk-table__cell remember_tfa
+          td.govuk-table__cell
+            | This allows you to sign in without re-entering a security code.
+          td.govuk-table__cell
+            = distance_of_time_in_words(Rails.application.config.devise.remember_otp_session_for_seconds)
+        tr.govuk-table__row
           td.govuk-table__cell seen_cookie_message
           td.govuk-table__cell Saves a message to let us know that you’ve seen our cookie message
           td.govuk-table__cell 1 year
-
-    h2.govuk-heading-m Keycloak:
-    table.govuk-table
-      thead.govuk-table__head
         tr.govuk-table__row
-          th.govuk-table__header Name
-          th.govuk-table__header Purpose
-          th.govuk-table__header Lifetime of cookie
-      tbody.govuk-table__body
+          td.govuk-table__cell _ga
+          td.govuk-table__cell This helps us count how many people visit our site by tracking if you’ve visited before.
+          td.govuk-table__cell 2 years
         tr.govuk-table__row
-          td.govuk-table__cell AUTH_SESSION_ID
-          td.govuk-table__cell This ensures that the same server is used to deal with a given user's requests.
-          td.govuk-table__cell When you close your browser
+          td.govuk-table__cell _gid
+          td.govuk-table__cell This helps us count how many people visit our site by tracking if you’ve visited before.
+          td.govuk-table__cell 24 hours
         tr.govuk-table__row
-          td.govuk-table__cell KC_RESTART
-          td.govuk-table__cell
-            | This stores information about the login flow, for example, where we should redirect you after you login.
-          td.govuk-table__cell When you close your browser
-        tr.govuk-table__row
-          td.govuk-table__cell KEYCLOAK_IDENTITY
-          td.govuk-table__cell This stores details about the currently logged in user.
-          td.govuk-table__cell When you close your browser
-        tr.govuk-table__row
-          td.govuk-table__cell KEYCLOAK_SESSION
-          td.govuk-table__cell
-            | This stores information relating to recent actions that have been taken whilst managing an account.
-          td.govuk-table__cell 10 hours
-
+          td.govuk-table__cell _gat
+          td.govuk-table__cell Used to manage the rate at which page view requests are made.
+          td.govuk-table__cell 1 minute
     h2.govuk-heading-m How are cookies deleted?
     p
       | To delete or stop cookies being placed on your device, please check the help menu of your internet browser.


### PR DESCRIPTION
Remove reference to the Keycloak cookies, and add reference to the two factor authentication cookie.

## Before

<img width="448" alt="Screenshot 2020-04-02 at 09 51 05" src="https://user-images.githubusercontent.com/30665/78229210-95dfaf80-74c7-11ea-92cb-3f4e648c6bfb.png">

## After

<img width="887" alt="Screenshot 2020-04-02 at 09 50 46" src="https://user-images.githubusercontent.com/30665/78229227-9b3cfa00-74c7-11ea-9be9-4f7d55a86d1a.png">
