### PR TITLE
Fixes for review app deploy script

### DIFF
--- a/psd-web/.gitignore
+++ b/psd-web/.gitignore
@@ -2,6 +2,9 @@
 
 .env.development
 .env.test
+
+env/*
+
 *.swp
 *.swo
 ### Node ###

--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -16,12 +16,22 @@ if [ -z "$DB_NAME" ]
 then
   DB_NAME=psd-review-database
 fi
-cf7 create-service postgres small-10 $DB_NAME
+cf7 create-service postgres small-10 $DB_NAME -c '{"enable_extensions": ["pgcrypto"]}'
 
 # Wait until db is prepared, might take up to 10 minutes
 until cf7 service $DB_NAME > /tmp/db_exists && grep -E "create succeeded|update succeeded" /tmp/db_exists; do sleep 20; echo "Waiting for db"; done
 
 cp -a ${PWD-.}/infrastructure/env/. ${PWD-.}/psd-web/env/
+
+if [ -z "$WEB_MAX_THREADS" ]
+then
+  WEB_MAX_THREADS=5
+fi
+
+if [ -z "$WORKER_MAX_THREADS" ]
+then
+  WORKER_MAX_THREADS=10
+fi
 
 # Set the amount of time in minutes that the CLI will wait for all instances to start.
 # Because of the rolling deployment strategy, this should be set to at least the amount of


### PR DESCRIPTION
## Description
This fixes a few issues with the review-app deploy script:

* pgcrypto extension not enabled ([the PaaS docs](https://docs.cloud.service.gov.uk/deploying_services/postgresql/#add-or-remove-extensions-for-a-postgresql-service-instance) state this must be enabled at the time the service is created)
* The script copies files to `psd-web/env` when run, which could be accidentally committed
* Two new env vars `WEB_MAX_THREADS` and `WORKER_MAX_THREADS` introduced in https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/445 had no default value so the deployment would fail if ran outside of the GitHub Actions environment

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
