### PR TITLE
 Bugfix: Avoid sending 2FA code when not requesting 2FA

### DIFF
--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,7 @@ module Users
     skip_before_action :has_accepted_declaration
     skip_before_action :has_viewed_introduction
     # These methods trigger Warden authentication.
-    # We don't want this to happen until we explicitely attempt to authenticate the user.
+    # We don't want this to happen until we explicitly attempt to authenticate the user.
     skip_before_action :set_current_user, :set_raven_context, :authorize_user, only: :create
 
     def new

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,8 @@ module Users
   class SessionsController < Devise::SessionsController
     skip_before_action :has_accepted_declaration
     skip_before_action :has_viewed_introduction
+    # These methods trigger Warden authentication.
+    # We don't want this to happen until we explicitely attempt to authenticate the user.
     skip_before_action :set_current_user, :set_raven_context, :authorize_user, only: :create
 
     def new

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -51,7 +51,7 @@ module Users
 
       set_resource_as_new_user_from_params
       add_wrong_credentials_errors(resource)
-      return render :new
+      render :new
     end
 
     def handle_invalid_form(resource)

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -25,7 +25,7 @@ module Users
     # When the sign-in submission does not fall under any of these checks,
     # the user will be successfully set and signed in.
     def create
-      set_dummy_devise_resource_for_display_errors
+      set_resource_as_new_user_from_params
 
       # Checks against form attributes validations
       if sign_in_form.invalid?
@@ -52,7 +52,7 @@ module Users
         # User may have become locked
         return render "account_locked" if matching_user&.reload&.access_locked?
 
-        set_dummy_devise_resource_for_display_errors
+        set_resource_as_new_user_from_params
         add_wrong_credentials_errors
         return render :new
       end
@@ -82,7 +82,7 @@ module Users
       Rails.configuration.two_factor_authentication_enabled && user && !user.mobile_number_verified
     end
 
-    def set_dummy_devise_resource_for_display_errors
+    def set_resource_as_new_user_from_params
       self.resource = resource_class.new(sign_in_params).decorate
     end
   end

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -39,7 +39,7 @@ module Users
       # of their mobile number during account set up process.
       if user_missing_2fa_mobile_verification?(matching_user)
         sign_out
-        add_wrong_credentials_errors
+        add_wrong_credentials_errors(resource)
         return render :new
       end
 
@@ -68,16 +68,17 @@ module Users
       return render "account_locked" if user&.reload&.access_locked?
 
       set_resource_as_new_user_from_params
-      add_wrong_credentials_errors
+      add_wrong_credentials_errors(resource)
       return render :new
     end
-
 
     def sign_in_form
       @sign_in_form ||= SignInForm.new(sign_in_params)
     end
 
-    def add_wrong_credentials_errors
+    def add_wrong_credentials_errors(resource)
+      return unless resource
+
       resource.errors.add(:email, I18n.t(:wrong_email_or_password, scope: "sign_user_in.email"))
       resource.errors.add(:password, nil)
     end

--- a/psd-web/app/controllers/users/sessions_controller.rb
+++ b/psd-web/app/controllers/users/sessions_controller.rb
@@ -20,8 +20,8 @@ module Users
 
       matching_user = User.find_by(email: sign_in_form.email)
 
-      if missing_mobile_verification?(matching_user)
-        handle_missing_mobile_verification(resource)
+      if mobile_not_verified?(matching_user)
+        handle_mobile_not_verified(resource)
         return render :new
       end
 
@@ -58,7 +58,7 @@ module Users
       resource.errors.merge!(sign_in_form.errors)
     end
 
-    def handle_missing_mobile_verification(resource)
+    def handle_mobile_not_verified(resource)
       sign_out
       add_wrong_credentials_errors(resource)
     end
@@ -74,7 +74,7 @@ module Users
       resource.errors.add(:password, nil)
     end
 
-    def missing_mobile_verification?(user)
+    def mobile_not_verified?(user)
       Rails.configuration.two_factor_authentication_enabled && user && !user.mobile_number_verified
     end
 

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -25,9 +25,9 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     expect(page).not_to have_link("Cases")
   end
 
-  context "when succeeeding signin in", :with_2fa do
+  context "when succeeding signin in", :with_2fa do
     context "when in two factor authentication page" do
-      it "allows user to sign in with correct two factor authentication code" do
+      scenario "allows user to sign in with correct two factor authentication code" do
         visit "/sign-in"
         fill_in_credentials
 
@@ -40,7 +40,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
         expect(page).to have_link("Sign out", href: destroy_user_session_path)
       end
 
-      it "allows user to sign out and be sent to the homepage" do
+      scenario "allows user to sign out and be sent to the homepage" do
         visit "/sign-in"
         fill_in_credentials
 
@@ -54,7 +54,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
         expect(page).to have_link("Sign in to your account")
       end
 
-      it "don't allow the user to sign in with a wrong two factor authentication code" do
+      scenario "don't allow the user to sign in with a wrong two factor authentication code" do
         visit "/sign-in"
         fill_in_credentials
 
@@ -152,7 +152,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
   end
 
   context "when signed in" do
-    it "times you out in due time" do
+    scenario "times you out in due time" do
       visit investigation_path(investigation)
       expect(page).not_to have_css("h2#error-summary-title", text: "You need to sign in or sign up before continuing.")
 
@@ -166,7 +166,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
   context "when the user hasn’t verified their mobile number", :with_2fa do
     let(:user) { create(:user, mobile_number_verified: false) }
 
-    it "doesn’t let them sign in" do
+    scenario "doesn’t let them sign in" do
       visit "/sign-in"
 
       fill_in "Email address", with: user.email
@@ -185,7 +185,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
   end
 
   context "when email address does not belong to any user", :with_2fa do
-    it "shows a generic error message" do
+    scenario "shows a generic error message" do
       visit "/sign-in"
 
       fill_in "Email address", with: "notarealuser@example.com"
@@ -200,7 +200,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
   end
 
   context "with credentials entered incorrectly" do
-    it "highlights email field" do
+    scenario "highlights email field" do
       visit "/sign-in"
 
       fill_in "Email address", with: user.email
@@ -213,7 +213,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       expect(page).to have_css("span#password-error", text: "")
     end
 
-    it "does not work with email no in database" do
+    scenario "does not work with email no in database" do
       visit "/sign-in"
 
       fill_in "Email address", with: "user.email@foo.bar"

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
+RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, type: :feature do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:investigation) { create(:project) }
@@ -25,56 +25,52 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     expect(page).not_to have_link("Cases")
   end
 
-  context "when succeeding signin in", :with_2fa do
-    context "when in two factor authentication page" do
-      scenario "allows user to sign in with correct two factor authentication code" do
-        visit "/sign-in"
-        fill_in_credentials
+  scenario "user signs in with correct two factor authentication code" do
+    visit "/sign-in"
+    fill_in_credentials
 
-        expect(page).to have_css("h1", text: "Check your phone")
+    expect(page).to have_css("h1", text: "Check your phone")
 
-        fill_in "Enter security code", with: user.reload.direct_otp
-        click_on "Continue"
+    fill_in "Enter security code", with: user.reload.direct_otp
+    click_on "Continue"
 
-        expect(page).to have_css("h2", text: "Your cases")
-        expect(page).to have_link("Sign out", href: destroy_user_session_path)
-      end
-
-      scenario "allows user to sign out and be sent to the homepage" do
-        visit "/sign-in"
-        fill_in_credentials
-
-        expect(page).to have_css("h1", text: "Check your phone")
-
-        within(".psd-header__secondary-navigation") do
-          click_link("Sign out")
-        end
-
-        expect(page).to have_css("h1", text: "Product safety database")
-        expect(page).to have_link("Sign in to your account")
-      end
-
-      scenario "don't allow the user to sign in with a wrong two factor authentication code" do
-        visit "/sign-in"
-        fill_in_credentials
-
-        expect(page).to have_css("h1", text: "Check your phone")
-
-        fill_in "Enter security code", with: user.reload.direct_otp.reverse
-        click_on "Continue"
-
-        expect(page).to have_css("h1", text: "Check your phone")
-        expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-        expect(page).to have_css("#otp_code-error", text: "Error: Incorrect security code")
-      end
-    end
+    expect(page).to have_css("h2", text: "Your cases")
+    expect(page).to have_link("Sign out", href: destroy_user_session_path)
   end
 
-  context "when using wrong credentials over and over again", :with_2fa do
+  scenario "user signs out when required to fill two factor authentication code" do
+    visit "/sign-in"
+    fill_in_credentials
+
+    expect(page).to have_css("h1", text: "Check your phone")
+
+    within(".psd-header__secondary-navigation") do
+      click_link("Sign out")
+    end
+
+    expect(page).to have_css("h1", text: "Product safety database")
+    expect(page).to have_link("Sign in to your account")
+  end
+
+  scenario "user attempts to sign in with wrong two factor authentication code" do
+    visit "/sign-in"
+    fill_in_credentials
+
+    expect(page).to have_css("h1", text: "Check your phone")
+
+    fill_in "Enter security code", with: user.reload.direct_otp.reverse
+    click_on "Continue"
+
+    expect(page).to have_css("h1", text: "Check your phone")
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_css("#otp_code-error", text: "Error: Incorrect security code")
+  end
+
+  context "when using wrong credentials over and over again" do
     let(:unlock_email) { delivered_emails.last }
     let(:unlock_path) { unlock_email.personalization_path(:unlock_user_url_token) }
 
-    scenario "locks and sends email with unlock link" do
+    scenario "user gets locked and uses the unlock link received by email" do
       visit "/sign-in"
       fill_in_credentials
       fill_in "Enter security code", with: user.reload.direct_otp
@@ -104,34 +100,28 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       expect(page).to have_link("Sign out")
     end
 
-    context "when logged in as different user" do
-      let(:user2) { create(:user, :activated, has_viewed_introduction: true) }
+    scenario "user tries to use unlock link when logged in as different user" do
+      user2 = create(:user, :activated, has_viewed_introduction: true)
+      user2.lock_access!
 
-      before do
-        user2.lock_access!
-      end
+      visit "/sign-in"
+      fill_in_credentials
+      fill_in "Enter security code", with: user.reload.direct_otp
+      click_on "Continue"
 
-      scenario "logouts currently logged in user" do
-        visit "/sign-in"
-        fill_in_credentials
-        fill_in "Enter security code", with: user.reload.direct_otp
-        click_on "Continue"
+      expect(page).to have_css("h2", text: "Your cases")
 
-        expect(page).to have_css("h2", text: "Your cases")
-
-        visit unlock_path
-        expect(page).to have_css("h1", text: "Check your phone")
-      end
+      visit unlock_path
+      expect(page).to have_css("h1", text: "Check your phone")
     end
 
-    scenario "shows invalid link page for invalid link" do
+    scenario "user follows an invalid unlock link" do
       visit "/unlock?unlock_token=wrong-token"
       expect(page).to have_css("h1", text: "Invalid link")
       expect(page.status_code).to eq(404)
     end
 
-
-    scenario "sends email with reset password link", :with_2fa do
+    scenario "locked user receives email with reset password link" do
       Devise.maximum_attempts.times do
         visit "/sign-in"
         fill_in_credentials(password_override: "XXX")
@@ -151,103 +141,77 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     end
   end
 
-  context "when signed in" do
-    scenario "times you out in due time" do
+  scenario "user session expires" do
+    visit investigation_path(investigation)
+    expect(page).not_to have_css("h2#error-summary-title", text: "You need to sign in or sign up before continuing.")
+
+    travel_to 24.hours.from_now do
       visit investigation_path(investigation)
-      expect(page).not_to have_css("h2#error-summary-title", text: "You need to sign in or sign up before continuing.")
-
-      travel_to 24.hours.from_now do
-        visit investigation_path(investigation)
-        expect(page).not_to have_css("h2#error-summary-title", text: "Your session expired. Please sign in again to continue.")
-      end
+      expect(page).not_to have_css("h2#error-summary-title", text: "Your session expired. Please sign in again to continue.")
     end
   end
 
-  context "when the user hasn’t verified their mobile number", :with_2fa do
-    let(:user) { create(:user, mobile_number_verified: false) }
+  scenario "user tries to sign in without having verified its mobile number on registration" do
+    user.update_column(:mobile_number_verified, false)
 
-    scenario "doesn’t let them sign in and does not send them a 2FA code by sms" do
-      visit "/sign-in"
+    visit "/sign-in"
 
-      fill_in_credentials
-      expect_incorrect_email_or_password
-      expect(notify_stub).not_to have_received(:send_sms)
-    end
+    fill_in_credentials
+    expect_incorrect_email_or_password
+    expect(notify_stub).not_to have_received(:send_sms)
   end
 
-  context "when email address does not belong to any user", :with_2fa do
-    scenario "shows a generic error message" do
-      visit "/sign-in"
+  scenario "user tries to sign in with email address that does not belong to any user" do
+    visit "/sign-in"
 
-      fill_in "Email address", with: "notarealuser@example.com"
-      fill_in "Password", with: "notarealpassword"
-      click_on "Continue"
+    fill_in "Email address", with: "notarealuser@example.com"
+    fill_in "Password", with: "notarealpassword"
+    click_on "Continue"
 
-      expect_incorrect_email_or_password
-    end
+    expect_incorrect_email_or_password
   end
 
-  context "with credentials entered incorrectly" do
-    scenario "highlights email field" do
-      visit "/sign-in"
+  scenario "user introduces wrong password" do
+    visit "/sign-in"
 
-      fill_in "Email address", with: user.email
-      fill_in "Password", with: "passworD"
-      click_on "Continue"
+    fill_in "Email address", with: user.email
+    fill_in "Password", with: "passworD"
+    click_on "Continue"
 
-      expect_incorrect_email_or_password
-    end
+    expect_incorrect_email_or_password
+  end
 
-    scenario "does not work with email no in database" do
-      visit "/sign-in"
+  scenario "user introduces email address with incorrect format" do
+    visit "/sign-in"
 
-      fill_in "Email address", with: "user.email@foo.bar"
-      fill_in "Password", with: "passworD"
-      click_on "Continue"
-
-      expect_incorrect_email_or_password
-    end
-
-    context "when email address is not in correct format" do
-      scenario "shows an error message" do
-        visit "/sign-in"
-
-        fill_in "Email address", with: "test.email"
-        fill_in "Password", with: "password "
-        click_on "Continue"
+    fill_in "Email address", with: "test.email"
+    fill_in "Password", with: "password "
+    click_on "Continue"
 
 
-        expect(page).to have_css(".govuk-error-summary__list", text: "Enter your email address in the correct format, like name@example.com")
-        expect(page).to have_css(".govuk-error-message", text: "Enter your email address in the correct format, like name@example.com")
-      end
-    end
+    expect(page).to have_css(".govuk-error-summary__list", text: "Enter your email address in the correct format, like name@example.com")
+    expect(page).to have_css(".govuk-error-message", text: "Enter your email address in the correct format, like name@example.com")
+  end
 
-    context "when email and password fields left empty" do
-      scenario "shows error messages" do
-        visit "/sign-in"
+  scenario "user leaves email and password fields empty" do
+    visit "/sign-in"
 
-        fill_in "Email address", with: " "
-        fill_in "Password", with: " "
-        click_on "Continue"
+    fill_in "Email address", with: " "
+    fill_in "Password", with: " "
+    click_on "Continue"
 
-        expect(page).to have_css(".govuk-error-message", text: "Enter your email address")
-        expect(page).to have_css(".govuk-error-message", text: "Enter your password")
-      end
-    end
+    expect(page).to have_css(".govuk-error-message", text: "Enter your email address")
+    expect(page).to have_css(".govuk-error-message", text: "Enter your password")
+  end
 
+  scenario "user leaves password field empty" do
+    visit "/sign-in"
 
-    context "when password field is left empty" do
-      scenario "shows an error messages" do
-        visit "/sign-in"
+    fill_in "Email address", with: user.email
+    fill_in "Password", with: " "
+    click_on "Continue"
 
-
-        fill_in "Email address", with: user.email
-        fill_in "Password", with: " "
-        click_on "Continue"
-
-        expect(page).to have_css(".govuk-error-message", text: "Enter your password")
-        expect(page).to have_css(".govuk-error-summary__list", text: "Enter your password")
-      end
-    end
+    expect(page).to have_css(".govuk-error-message", text: "Enter your password")
+    expect(page).to have_css(".govuk-error-summary__list", text: "Enter your password")
   end
 end

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
     expect(page).to have_link("Enter correct email address and password", href: "#email")
     expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
+    expect(page).to have_css("span#password-error", text: "")
 
     expect(page).not_to have_link("Cases")
   end
@@ -182,10 +183,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       fill_in "Password", with: "notarealpassword"
       click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter correct email address and password", href: "#email")
-      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
-      expect(page).to have_css("span#password-error", text: "")
+      expect_incorrect_email_or_password
     end
   end
 
@@ -197,10 +195,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       fill_in "Password", with: "passworD"
       click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter correct email address and password", href: "#email")
-      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
-      expect(page).to have_css("span#password-error", text: "")
+      expect_incorrect_email_or_password
     end
 
     scenario "does not work with email no in database" do
@@ -210,10 +205,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
       fill_in "Password", with: "passworD"
       click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter correct email address and password", href: "#email")
-      expect(page).to have_css("span#email-error", text: "Error: Enter correct email address and password")
-      expect(page).to have_css("span#password-error", text: "")
+      expect_incorrect_email_or_password
     end
 
     context "when email address is not in correct format" do


### PR DESCRIPTION
Trello Card: https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/458

# Short? description

We don't allow to login into the service users who didn't complete the 2FA validation for their mobile phone when completing their registration.
But when they attempt to use their credentials, on top of the login error page, they get a 2FA code in their mobile phone.

This happens because the code send 2FA codes is hooked to warden authentication method. And this method is being called by Devise user helpers that are being invoked by our service in `before_action` `ApplicationController` declarations.

The solution consists in delaying these calls until we effectively want to authorise the user.

# Detailed description

We only want to send sms with 2FA code for users that are going to be
redirected to 2FA page in order to fil the form with the received code.

Our sign in business logic dictates some cases where we don't want
the sign in submission to reach 2FA, like when the user didn't verified
its phone during the registration from an invitation email link.

The ruby gem used for 2FA adds a hook to successful Warden
authentication calls, so whenever a Warden authentication happens, a
2FA code gets send to the user (if the user is marked as requiring 2FA).

Devise helpers like "current_user" and "user_signed_in?" internally
do a "warden.authenticate", triggering the 2FA code being sent.

Our application controller has multiple before filters calling those
Devise methods. So, when submitting a Sign in form, the filters where
being triggered and the 2FA code was being sent even before we could
run our business logic to dictate if an user gets directed to 2FA page
or not.

This was causing users not being directed to 2FA page and being shown
a login error (as the business logic dictates) but still getting an
SMS with a 2FA code for each login submission.

The solution consists in suppressing those calls to Devise methods
based in existing user until the point where we actually want to sign
in an user. In that point we set up those variables/invoke those calls.

This way the 2FA code will be sent only when we explicitly authenticate
the user, instead of being an uncontrolled side effect.


## Refactor session creation method

The method in charge of handling user sign-in submissions has become
complex with multiple branching for dealing with edge cases and
different ways to redirect after specific failures.

As a result of all this mixed logic, I found the method hard to follow and
change.

As an attempt to improve its maintainability:

- Re-shaped it so the different edge cases and errors provoke an early
  return one by one, while defaulting at the end to the happy path with
  a successful sign in. This is done to allow the reader to follow a
  linear process of the checks that would cause a sign-in failure.

- Documented all these checks in the method declaration, so future
  maintainers can understand better how our Sign-in process work.

- Extracted a couple private methods encapsulating checks/logic to
  show the intention of the code bit through the naming of the method.

- Added comments where considered necessary.