### PR TITLE
Strip whitespace from security code that user enters

### DIFF
--- a/psd-web/app/controllers/users/two_factor_authentication_controller.rb
+++ b/psd-web/app/controllers/users/two_factor_authentication_controller.rb
@@ -46,7 +46,7 @@ module Users
   private
 
     def otp_code_param
-      @otp_code_param ||= resource_params.permit(:otp_code)[:otp_code]
+      @otp_code_param ||= resource_params.permit(:otp_code)[:otp_code].strip
     end
 
     # Suppress unwanted Devise alert.

--- a/psd-web/spec/features/sign_in_spec.rb
+++ b/psd-web/spec/features/sign_in_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
 
     expect(page).to have_css("h1", text: "Check your phone")
 
-    fill_in "Enter security code", with: user.reload.direct_otp
+    fill_in "Enter security code", with: " #{user.reload.direct_otp} "
     click_on "Continue"
 
     expect(page).to have_css("h2", text: "Your cases")


### PR DESCRIPTION
This is helpful, as some users may accidentally add a space after the security code (eg from a mobile keyboard).

See https://trello.com/c/RWJ7pENv/492-1-strip-whitespace-on-2fa-codes-before-validating