### PR TITLE
Remove covid banner from question page

### DIFF
--- a/psd-web/app/views/investigations/_coronavirus.html.erb
+++ b/psd-web/app/views/investigations/_coronavirus.html.erb
@@ -2,13 +2,15 @@
 
 <%= page_title page_heading, errors: @coronavirus_related_form.errors.any? %>
 
-<%= form_with scope: scope, model: @coronavirus_related_form, url: wizard_path, method: :put, local: true do |form| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @coronavirus_related_form.errors  %>
-      <% if defined?(caption) %>
-        <span class="govuk-caption-l"><%= caption %></span>
-      <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= error_summary @coronavirus_related_form.errors  %>
+
+    <% if defined?(caption) %>
+      <span class="govuk-caption-l"><%= caption %></span>
+    <% end %>
+
+    <%= form_with scope: scope, model: @coronavirus_related_form, url: wizard_path, method: :put, local: true do |form| %>
       <%= form.hidden_field :coronavirus_related %>
       <%= render "form_components/govuk_radios", form: form, key: :coronavirus_related,
               fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
@@ -17,6 +19,6 @@
                       { text: "No, this is business as usual", value: "false" }] %>
 
       <%= govukButton(text: "Continue") %>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/psd-web/app/views/investigations/_coronavirus.html.erb
+++ b/psd-web/app/views/investigations/_coronavirus.html.erb
@@ -2,10 +2,6 @@
 
 <%= page_title page_heading, errors: @coronavirus_related_form.errors.any? %>
 
-<%= banner do %>
-  <p class="govuk-body">Coronavirus (COVID-19): OPSS is urging all market surveillance authorities to prioritise coronavirus-related cases above other work.</p>
-<% end %>
-
 <%= form_with scope: scope, model: @coronavirus_related_form, url: wizard_path, method: :put, local: true do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/psd-web/spec/support/feature_helpers.rb
+++ b/psd-web/spec/support/feature_helpers.rb
@@ -16,7 +16,6 @@ end
 def expect_to_be_on_coronavirus_page(path)
   expect(page).to have_current_path(path)
   expect(page).to have_selector("h1", text: "Is this case related to the coronavirus outbreak?")
-  expect(page).to have_selector(".app-banner", text: "Coronavirus")
 end
 
 def enter_contact_details(contact_name:, contact_email:, contact_phone:)


### PR DESCRIPTION
We've decided the covid banner on the covid question isn't needed
as we have it on the TS homepage.

## After changes
![Screenshot from 2020-04-16 17-14-00](https://user-images.githubusercontent.com/1227578/79480393-edbd0100-8005-11ea-9a1b-f3b7b3c0d627.png)
![Screenshot from 2020-04-16 17-14-07](https://user-images.githubusercontent.com/1227578/79480406-ef86c480-8005-11ea-8e5d-b152d657fe76.png)

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

