### PR TITLE
Don't re-index models in Elasticsearch on deployment

### DIFF
--- a/psd-web/config/environments/production.rb
+++ b/psd-web/config/environments/production.rb
@@ -85,15 +85,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  config.after_initialize do
-    unless Sidekiq.server?
-      ActiveRecord::Base.descendants.each do |model|
-        if model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
-          model.import force: true
-        end
-      end
-    end
-  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
https://trello.com/c/n4bJKN2i/486-spike-investigate-intermittent-elastic-search-issues-causing-missing-cases

## Description
During a rolling deployment we have noticed a recurring issue with 'no cases' shown in the front end. This also manifests an exception - examples at https://sentry.io/organizations/beis/issues/1615248225/?project=1329381&query=is%3Aunresolved&statsPeriod=14d. It eventually resolves itself after a few minutes when the deployment is complete.

I think this is due to the application re-indexing the models on startup. In our scenario where we presently have scaled to four web instances, this will happen four times. The use of `force: true` causes it to [delete the index first](https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/lib/elasticsearch/model/importing.rb#L94-L96). This happens asynchronously, four times on every deployment, which I think is causing the missing document issues.

This change will mean we will have to manually re-index if we change any of the indexing code, but this is better than doing it four times (or however many instances we have). In future we could create a Rake task which executes on the first instance only.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
