### PR TITLE
Mark old migrations as safe

### DIFF
--- a/psd-web/db/migrate/20181101114717_add_audit_fields_for_activities.rb
+++ b/psd-web/db/migrate/20181101114717_add_audit_fields_for_activities.rb
@@ -1,6 +1,7 @@
 class AddAuditFieldsForActivities < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
+  # rubocop:disable Metrics/BlockLength
   def change
     safety_assured do
       add_column :activities, :title, :string
@@ -37,4 +38,5 @@ class AddAuditFieldsForActivities < ActiveRecord::Migration[5.2]
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/psd-web/db/migrate/20181101114717_add_audit_fields_for_activities.rb
+++ b/psd-web/db/migrate/20181101114717_add_audit_fields_for_activities.rb
@@ -2,13 +2,13 @@ class AddAuditFieldsForActivities < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    add_column :activities, :title, :string
-    add_reference :activities, :business, foreign_key: true, index: false
-    add_index :activities, :business_id, algorithm: :concurrently
-    add_reference :activities, :product, index: false, foreign_key: true
-    add_index :activities, :product_id, algorithm: :concurrently
-
     safety_assured do
+      add_column :activities, :title, :string
+      add_reference :activities, :business, foreign_key: true, index: false
+      add_index :activities, :business_id, algorithm: :concurrently
+      add_reference :activities, :product, index: false, foreign_key: true
+      add_index :activities, :product_id, algorithm: :concurrently
+
       reversible do |dir|
         dir.up do
           drop_table :versions

--- a/psd-web/db/migrate/20181105134010_add_correspondence_to_activities.rb
+++ b/psd-web/db/migrate/20181105134010_add_correspondence_to_activities.rb
@@ -2,7 +2,9 @@ class AddCorrespondenceToActivities < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    add_reference :activities, :correspondence, index: false, foreign_key: true
-    add_index :activities, :correspondence_id, algorithm: :concurrently
+    safety_assured do
+      add_reference :activities, :correspondence, index: false, foreign_key: true
+      add_index :activities, :correspondence_id, algorithm: :concurrently
+    end
   end
 end


### PR DESCRIPTION
Since running these migrations, we must have updated the `strong_migrations` gem, which now complains about these.  This blocks running a `rake db:migrate` locally.

By marking these as "safety assured" we can run the migrations locally. This won't impact production as the migrations have already run there.