### PR TITLE
Remove titleize from nearly everywhere

### DIFF
--- a/psd-web/app/controllers/investigations/assign_controller.rb
+++ b/psd-web/app/controllers/investigations/assign_controller.rb
@@ -28,7 +28,7 @@ class Investigations::AssignController < ApplicationController
     @investigation.assignee = potential_assignee
     @investigation.assignee_rationale = params[:investigation][:assignee_rationale]
     @investigation.save
-    redirect_to investigation_path(@investigation), notice: "#{@investigation.case_type.titleize} was successfully updated."
+    redirect_to investigation_path(@investigation), notice: "#{@investigation.case_type.upcase_first} was successfully updated."
   end
 
 private

--- a/psd-web/app/controllers/investigations/coronavirus_related_controller.rb
+++ b/psd-web/app/controllers/investigations/coronavirus_related_controller.rb
@@ -15,7 +15,7 @@ module Investigations
       if @investigation.coronavirus_related_changed?
         @investigation.save!
         AuditActivity::Investigation::UpdateCoronavirusStatus.from(@investigation)
-        flash[:success] = I18n.t(".success", scope: "investigations.coronavirus_related", case_title: @investigation.case_type.titleize)
+        flash[:success] = I18n.t(".success", scope: "investigations.coronavirus_related", case_title: @investigation.case_type.upcase_first)
       end
 
       redirect_to investigation_path(@investigation)

--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -84,7 +84,7 @@ private
       if @investigation.update(update_params)
         format.html {
           redirect_to investigation_path(@investigation), flash: {
-            success: "#{@investigation.case_type.titleize} was successfully updated."
+            success: "#{@investigation.case_type.upcase_first} was successfully updated."
           }
         }
         format.json { render :show, status: :ok, location: @investigation }

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -113,7 +113,7 @@ class InvestigationDecorator < ApplicationDecorator
   end
 
   def pretty_description
-    "#{case_type.titleize}: #{pretty_id}"
+    "#{case_type.upcase_first}: #{pretty_id}"
   end
 
   # rubocop:disable Rails/OutputSafety

--- a/psd-web/app/models/activity.rb
+++ b/psd-web/app/models/activity.rb
@@ -75,7 +75,7 @@ class Activity < ApplicationRecord
   def email_update_text; end
 
   def email_subject_text
-    "#{investigation.case_type.titleize} updated"
+    "#{investigation.case_type.upcase_first} updated"
   end
 
 private

--- a/psd-web/app/models/audit_activity/business/add.rb
+++ b/psd-web/app/models/audit_activity/business/add.rb
@@ -2,7 +2,7 @@ class AuditActivity::Business::Add < AuditActivity::Business::Base
   def self.from(business, investigation)
     title = business.trading_name
     relationship = investigation.investigation_businesses.find_by(business_id: business.id).relationship
-    body = "Role: **#{self.sanitize_text relationship.titleize}**"
+    body = "Role: **#{self.sanitize_text relationship}**"
     super(business, investigation, title, body)
   end
 
@@ -11,6 +11,6 @@ class AuditActivity::Business::Add < AuditActivity::Business::Base
   end
 
   def email_update_text
-    "Business was added to the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Business was added to the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/business/destroy.rb
+++ b/psd-web/app/models/audit_activity/business/destroy.rb
@@ -9,6 +9,6 @@ class AuditActivity::Business::Destroy < AuditActivity::Business::Base
   end
 
   def email_update_text
-    "Business was removed from the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Business was removed from the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/corrective_action/add.rb
+++ b/psd-web/app/models/audit_activity/corrective_action/add.rb
@@ -8,6 +8,6 @@ class AuditActivity::CorrectiveAction::Add < AuditActivity::CorrectiveAction::Ba
   end
 
   def email_update_text
-    "Corrective action was added to the #{investigation.case_type.titleize} by #{source&.show&.titleize}."
+    "Corrective action was added to the #{investigation.case_type.upcase_first} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/correspondence/add_email.rb
+++ b/psd-web/app/models/audit_activity/correspondence/add_email.rb
@@ -57,7 +57,7 @@ class AuditActivity::Correspondence::AddEmail < AuditActivity::Correspondence::B
   end
 
   def email_update_text
-    "Email details added to the #{investigation.case_type.titleize} by #{source&.show&.titleize}."
+    "Email details added to the #{investigation.case_type.upcase_first} by #{source&.show}."
   end
 
   def activity_type

--- a/psd-web/app/models/audit_activity/correspondence/add_meeting.rb
+++ b/psd-web/app/models/audit_activity/correspondence/add_meeting.rb
@@ -24,7 +24,7 @@ class AuditActivity::Correspondence::AddMeeting < AuditActivity::Correspondence:
   end
 
   def email_update_text
-    "Meeting details added to the #{investigation.case_type.titleize} by #{source&.show&.titleize}."
+    "Meeting details added to the #{investigation.case_type.upcase_first} by #{source&.show}."
   end
 
   def activity_type

--- a/psd-web/app/models/audit_activity/correspondence/add_phone_call.rb
+++ b/psd-web/app/models/audit_activity/correspondence/add_phone_call.rb
@@ -48,7 +48,7 @@ class AuditActivity::Correspondence::AddPhoneCall < AuditActivity::Correspondenc
   end
 
   def email_update_text
-    "Phone call details added to the #{investigation.case_type.titleize} by #{source&.show&.titleize}."
+    "Phone call details added to the #{investigation.case_type.upcase_first} by #{source&.show}."
   end
 
   def activity_type

--- a/psd-web/app/models/audit_activity/document/add.rb
+++ b/psd-web/app/models/audit_activity/document/add.rb
@@ -9,7 +9,7 @@ class AuditActivity::Document::Add < AuditActivity::Document::Base
   end
 
   def email_update_text
-    "Document was attached to the #{investigation.case_type.titleize} by #{source&.show&.titleize}."
+    "Document was attached to the #{investigation.case_type.upcase_first} by #{source&.show}."
   end
 
   def restricted_title

--- a/psd-web/app/models/audit_activity/document/destroy.rb
+++ b/psd-web/app/models/audit_activity/document/destroy.rb
@@ -9,7 +9,7 @@ class AuditActivity::Document::Destroy < AuditActivity::Document::Base
   end
 
   def email_update_text
-    "Document attached to the #{investigation.case_type.titleize} was removed by #{source&.show&.titleize}."
+    "Document attached to the #{investigation.case_type.upcase_first} was removed by #{source&.show}."
   end
 
   def restricted_title

--- a/psd-web/app/models/audit_activity/document/update.rb
+++ b/psd-web/app/models/audit_activity/document/update.rb
@@ -27,7 +27,7 @@ class AuditActivity::Document::Update < AuditActivity::Document::Base
   end
 
   def email_update_text
-    "Document attached to the #{investigation.case_type.titleize} was updated by #{source&.show&.titleize}."
+    "Document attached to the #{investigation.case_type.upcase_first} was updated by #{source&.show}."
   end
 
   def restricted_title

--- a/psd-web/app/models/audit_activity/investigation/update_assignee.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_assignee.rb
@@ -22,14 +22,14 @@ class AuditActivity::Investigation::UpdateAssignee < AuditActivity::Investigatio
 
   def email_update_text
     body = []
-    body << "#{investigation.case_type.titleize} was assigned to #{investigation.assignee.display_name} by #{source&.show&.titleize}."
-    body << "\nComment provided by #{source&.show&.titleize}:" if investigation.visibility_rationale.present?
+    body << "#{investigation.case_type.upcase_first} was assigned to #{investigation.assignee.display_name} by #{source&.show}."
+    body << "\nComment provided by #{source&.show}:" if investigation.visibility_rationale.present?
     body << investigation.assignee_rationale if investigation.assignee_rationale.present?
     body.join("\n")
   end
 
   def email_subject_text
-    "#{investigation.case_type.titleize} was reassigned"
+    "#{investigation.case_type.upcase_first} was reassigned"
   end
 
   def users_to_notify

--- a/psd-web/app/models/audit_activity/investigation/update_coronavirus_status.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_coronavirus_status.rb
@@ -11,8 +11,8 @@ class AuditActivity::Investigation::UpdateCoronavirusStatus < AuditActivity::Inv
     I18n.t(
       ".email_update_text.#{investigation.coronavirus_related?}",
       scope: self.class.i18n_scope,
-      case_type: investigation.case_type.titleize,
-      name: source&.show&.titleize,
+      case_type: investigation.case_type.upcase_first,
+      name: source&.show,
       pretty_id: investigation.pretty_id
     )
   end

--- a/psd-web/app/models/audit_activity/investigation/update_status.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_status.rb
@@ -1,15 +1,15 @@
 class AuditActivity::Investigation::UpdateStatus < AuditActivity::Investigation::Base
   def self.from(investigation)
-    title = "#{investigation.case_type.titleize} #{investigation.is_closed? ? 'closed' : 'reopened'}"
+    title = "#{investigation.case_type.upcase_first} #{investigation.is_closed? ? 'closed' : 'reopened'}"
     super(investigation, title, self.sanitize_text(investigation.status_rationale))
   end
 
   def email_update_text
-    "#{email_subject_text} by #{source&.show&.titleize}."
+    "#{email_subject_text} by #{source&.show}."
   end
 
   def email_subject_text
-    "#{investigation.case_type.titleize} was #{investigation.is_closed? ? 'closed' : 'reopened'}"
+    "#{investigation.case_type.upcase_first} was #{investigation.is_closed? ? 'closed' : 'reopened'}"
   end
 
   def users_to_notify

--- a/psd-web/app/models/audit_activity/investigation/update_summary.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_summary.rb
@@ -1,10 +1,10 @@
 class AuditActivity::Investigation::UpdateSummary < AuditActivity::Investigation::Base
   def self.from(investigation)
-    title = "#{investigation.case_type.titleize} summary updated"
+    title = "#{investigation.case_type.upcase_first} summary updated"
     super(investigation, title, investigation.description)
   end
 
   def email_update_text
-    "#{investigation.case_type.titleize} summary was updated by #{source&.show&.titleize}."
+    "#{investigation.case_type.upcase_first} summary was updated by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/investigation/update_visibility.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_visibility.rb
@@ -1,11 +1,11 @@
 class AuditActivity::Investigation::UpdateVisibility < AuditActivity::Investigation::Base
   def self.from(investigation)
-    title = "#{investigation.case_type.titleize} visibility
+    title = "#{investigation.case_type.upcase_first} visibility
             #{investigation.is_private ? 'Restricted' : 'Unrestricted'}"
     super(investigation, title, self.sanitize_text(investigation.visibility_rationale))
   end
 
   def email_update_text
-    "#{investigation.case_type.titleize} visibility was #{investigation.is_private ? 'restricted' : 'unrestricted'} by #{source&.show&.titleize}."
+    "#{investigation.case_type.upcase_first} visibility was #{investigation.is_private ? 'restricted' : 'unrestricted'} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/product/add.rb
+++ b/psd-web/app/models/audit_activity/product/add.rb
@@ -9,6 +9,6 @@ class AuditActivity::Product::Add < AuditActivity::Product::Base
   end
 
   def email_update_text
-    "Product was added to the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Product was added to the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/product/destroy.rb
+++ b/psd-web/app/models/audit_activity/product/destroy.rb
@@ -9,6 +9,6 @@ class AuditActivity::Product::Destroy < AuditActivity::Product::Base
   end
 
   def email_update_text
-    "Product was removed from the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Product was removed from the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/test/request.rb
+++ b/psd-web/app/models/audit_activity/test/request.rb
@@ -13,6 +13,6 @@ class AuditActivity::Test::Request < AuditActivity::Test::Base
   end
 
   def email_update_text
-    "Test request was added to the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Test request was added to the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/audit_activity/test/result.rb
+++ b/psd-web/app/models/audit_activity/test/result.rb
@@ -14,6 +14,6 @@ class AuditActivity::Test::Result < AuditActivity::Test::Base
   end
 
   def email_update_text
-    "Test result was added to the #{investigation.case_type} by #{source&.show&.titleize}."
+    "Test result was added to the #{investigation.case_type} by #{source&.show}."
   end
 end

--- a/psd-web/app/models/comment_activity.rb
+++ b/psd-web/app/models/comment_activity.rb
@@ -5,7 +5,7 @@ class CommentActivity < Activity
   validates_length_of :body, maximum: 10000
 
   def title
-    "Comment: #{source&.show&.titleize}"
+    "Comment: #{source&.show}"
   end
 
   def subtitle
@@ -17,6 +17,6 @@ class CommentActivity < Activity
   end
 
   def email_update_text
-    "#{source&.show&.titleize} commented on the #{investigation.case_type}."
+    "#{source&.show} commented on the #{investigation.case_type}."
   end
 end

--- a/psd-web/app/views/documents/_metadata_form.html.slim
+++ b/psd-web/app/views/documents/_metadata_form.html.slim
@@ -7,7 +7,7 @@
     .govuk-grid-column-two-thirds-from-desktop
       = render "documents/document_preview", document: document, dimensions: "480x320"
       hr [class = "govuk-section-break govuk-section-break--m govuk-section-break--visible"]
-      h3.govuk-heading-m = "#{image_document_text(document).titleize} details"
+      h3.govuk-heading-m = "#{image_document_text(document).upcase_first} details"
       = form.fields_for :file do |subform|
         = render "form_components/govuk_input", key: :title, form: subform, classes: "govuk-!-width-two-thirds",
                 value: document.metadata["title"],

--- a/psd-web/app/views/investigations/show.pdf.slim
+++ b/psd-web/app/views/investigations/show.pdf.slim
@@ -50,7 +50,7 @@ table[style="width:100%; text-align:left"]
         td
           = activity.created_at.to_s :db
         td
-          = activity.type.titleize
+          = activity.type.upcase_first
         td
           = activity.source.show
         td

--- a/psd-web/app/views/investigations/status.html.slim
+++ b/psd-web/app/views/investigations/status.html.slim
@@ -7,7 +7,7 @@
       = render "form_components/govuk_error_summary", form: form
       = render "minimal_investigation_heading", investigation: @investigation, title: "Status information"
       h2.govuk-heading-m
-        = "#{@investigation.case_type.titleize} status"
+        = "#{@investigation.case_type.upcase_first} status"
       = render "form_components/govuk_radios", form: form, key: :is_closed,
               fieldset: { legend: { text: "Status" } },
               items: [{ text: "Open", value: "false" }, { text: "Closed", value: "true" }]

--- a/psd-web/app/views/investigations/tabs/_businesses.html.slim
+++ b/psd-web/app/views/investigations/tabs/_businesses.html.slim
@@ -17,7 +17,7 @@
   .govuk-grid-column-two-thirds-from-desktop
     - @investigation.investigation_businesses.each do |ib|
       h2.govuk-heading-m
-        = ib.relationship.titleize
+        = ib.relationship.upcase_first
       = business_summary_list ib.business
       = link_with_hidden_text_to "View business", ib.business.trading_name,
         ib.business, class: "govuk-link app-block-link govuk-!-margin-right-3"

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -17,13 +17,13 @@
 
     <% if @investigation.display_product_summary_list? %>
       <%= govuk_hr %>
-      <h2 class="govuk-heading-m"><%= "product".pluralize(products_count).titleize %></h2>
+      <h2 class="govuk-heading-m"><%= "product".pluralize(products_count).upcase_first %></h2>
       <%= @investigation.product_summary_list %>
     <% end %>
 
     <% if @investigation.complainant %>
       <%= govuk_hr %>
-      <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.titleize %></h2>
+      <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.upcase_first %></h2>
       <%= @investigation.source_details_summary_list %>
     <% end %>
 

--- a/psd-web/app/views/investigations/tests/confirmation.html.slim
+++ b/psd-web/app/views/investigations/tests/confirmation.html.slim
@@ -21,7 +21,7 @@ h1.govuk-heading-l
         - if @test.result
           tr.govuk-table__row
             th.govuk-table__header scope="row" Test result
-            td.govuk-table__cell = @test.result.titleize
+            td.govuk-table__cell = @test.result.upcase_first
         - if @test.details.present?
           tr.govuk-table__row
             th.govuk-table__header scope="row" Details

--- a/psd-web/app/views/investigations/visibility.html.slim
+++ b/psd-web/app/views/investigations/visibility.html.slim
@@ -1,4 +1,4 @@
-= page_title "#{@investigation.case_type.titleize} visibility", errors: @investigation.errors.any?
+= page_title "#{@investigation.case_type.upcase_first} visibility", errors: @investigation.errors.any?
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", investigation_path(@investigation), class: "govuk-back-link"
 = form_with(scope: :investigation, model: @investigation, url: visibility_investigation_path(@investigation)) do |form|

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
   describe "#pretty_description" do
     it {
       expect(decorated_investigation.pretty_description)
-        .to eq("#{investigation.case_type.titleize}: #{investigation.pretty_id}")
+        .to eq("#{investigation.case_type.upcase_first}: #{investigation.pretty_id}")
     }
   end
 

--- a/psd-web/spec/models/audit_activity/investigation/update_coronavirus_status_spec.rb
+++ b/psd-web/spec/models/audit_activity/investigation/update_coronavirus_status_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AuditActivity::Investigation::UpdateCoronavirusStatus, :with_stub
     it "creates an audit activity", :aggregate_failures do
       expect(audit_activity.title).to eq("Status updated: not coronavirus related")
       expect(audit_activity.body).to eq("The case is not related to the coronavirus outbreak.")
-      expect(audit_activity.email_update_text).to eq("#{investigation.case_type.capitalize} #{investigation.pretty_id} is not related to the coronavirus outbreak. This status was updated by #{user.display_name.titleize}.")
+      expect(audit_activity.email_update_text).to eq("#{investigation.case_type.capitalize} #{investigation.pretty_id} is not related to the coronavirus outbreak. This status was updated by #{user.display_name}.")
       expect(audit_activity.email_subject_text).to eq("Coronavirus status updated on #{investigation.case_type.downcase}")
     end
   end

--- a/psd-web/spec/requests/investigations/coronavirus_related_spec.rb
+++ b/psd-web/spec/requests/investigations/coronavirus_related_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Managing a case’s coronavirus status", :with_stubbed_elasticse
         patch investigation_coronavirus_related_path(investigation), params: { investigation: { coronavirus_related: !investigation.coronavirus_related } }
       }.to(change { investigation.reload.activities.where(type: "AuditActivity::Investigation::UpdateCoronavirusStatus").count }.by(1))
       expect(response).to redirect_to(investigation_path(investigation))
-      expect(flash[:success]).to eq("#{investigation.case_type.titleize} was successfully updated.")
+      expect(flash[:success]).to eq("#{investigation.case_type.upcase_first} was successfully updated.")
     end
   end
 end


### PR DESCRIPTION
The app was using titleize all over the place - mostly incorrectly.

I've removed titelize:
* Where we should not be recasing user input (eg people's names or team names)
* And replaced with `upcase_first` where what we actually want to do is just uppercase the first letter.

Previously we'd have things like this, where the use of `titleize` has incorrectly changed the case of the team names.
<img width="661" alt="Screenshot 2020-04-22 at 12 31 24" src="https://user-images.githubusercontent.com/2204224/79980578-36a80600-849b-11ea-9cd5-a3a5ded162e4.png">

It will now look like this:
![Screenshot 2020-04-22 at 13 16 12](https://user-images.githubusercontent.com/2204224/79980729-7838b100-849b-11ea-8260-5f1641412232.png)

I searched across the whole app, so this should be removed from all places we use it - including emails.

---

Where we simply want the first letter to be uppercase, I've swapped for `upcase_first`. If those cases eventually have multiword strings, we would not want to uppercase each word. A good example would be business relationship - where we accept a user provided string, and should not be recasing things (though it probably won't go wrong).

## Downsides

A downside of this is that some user's names might now be lowercase / poorly cased - this will be because they originally typed the name like that.

## One remaining `titleize`

There's one remaining `titleize` [here](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/helpers/application_helper.rb#L19). I wasn't sure what it was doing. If a dev can explain, we can decide what to do with it.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [?] Has the CHANGELOG been updated? (If change is worth telling users about.)
