### PR TITLE
Prevent default on hide cookie link

### DIFF
--- a/psd-web/app/assets/javascripts/cookie_banner.js
+++ b/psd-web/app/assets/javascripts/cookie_banner.js
@@ -9,7 +9,7 @@ function cookieBanner () {
     const expires = `expires=${date.toUTCString()}`
     document.cookie = `seen_cookie_message = true;${expires};path=/`
   }
-  function hideCookieBanner () {
+  function hideCookieBanner (event) {
     event.preventDefault()
     setCookie(365)
     document.getElementById('global-cookie-message').style.display = 'none'

--- a/psd-web/app/assets/javascripts/cookie_banner.js
+++ b/psd-web/app/assets/javascripts/cookie_banner.js
@@ -10,6 +10,7 @@ function cookieBanner () {
     document.cookie = `seen_cookie_message = true;${expires};path=/`
   }
   function hideCookieBanner () {
+    event.preventDefault()
     setCookie(365)
     document.getElementById('global-cookie-message').style.display = 'none'
   }


### PR DESCRIPTION
The link in our cookie banner is used to hide the message - however because the default href is `#`, this means the url is changed when the link is clicked. As the link is exclusively for js users and not for navigation, we can prevent the default link behaviour from happening.

Before, clicking `hide this message`:
<img width="932" alt="Screenshot 2020-04-22 at 14 51 06" src="https://user-images.githubusercontent.com/2204224/79990466-ffd8ec80-84a8-11ea-9c96-1c12acf2c1e2.png">
Would result in:
<img width="751" alt="Screenshot 2020-04-22 at 14 52 09" src="https://user-images.githubusercontent.com/2204224/79990473-036c7380-84a9-11ea-87c6-ec7b519549e0.png">

Now it looks like:
<img width="881" alt="Screenshot 2020-04-22 at 14 53 48" src="https://user-images.githubusercontent.com/2204224/79990545-17b07080-84a9-11ea-9d14-7fed41b4865f.png">