### PR TITLE
New implementation of service interface, get rid of using context nam…

### DIFF
--- a/psd-web/app/services/add_team_to_an_investigation.rb
+++ b/psd-web/app/services/add_team_to_an_investigation.rb
@@ -1,27 +1,59 @@
+module PsdServiceInterface
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def new(args)
+      this = super()
+      args.keys.each do |key|
+        self.attr_accessor key.to_sym
+        this.send("#{key}=".to_sym, args[key])
+      end
+      this.instance_variable_set(:@success, true)
+      this
+    end
+
+    def call(args)
+      obj = new(args)
+      obj.call
+      obj
+    end
+  end
+
+  def success?
+    @success
+  end
+
+  def fail!
+    @success = false
+  end
+end
+
 class AddTeamToAnInvestigation
-  include Interactor
+  include PsdServiceInterface
+
+  attr_accessor :collaborator
 
   # rubocop:disable Lint/SuppressedException
   def call
-    context.collaborator = context.investigation.collaborators.new(
-      team_id: context.team_id,
-      include_message: context.include_message,
-      added_by_user: context.current_user,
-      message: context.message
+    self.collaborator = investigation.collaborators.new(
+      team_id: team_id,
+      include_message: include_message,
+      added_by_user: current_user,
+      message: message
       )
 
     begin
-      if context.collaborator.save
-        NotifyTeamAddedToCaseJob.perform_later(context.collaborator)
+      if collaborator.save
+        NotifyTeamAddedToCaseJob.perform_later(collaborator)
 
         AuditActivity::Investigation::TeamAdded.create!(
-          source: UserSource.new(user: context.current_user),
-          investigation: context.investigation,
-          title: "#{context.collaborator.team.name} added to #{context.investigation.case_type.downcase}",
-          body: context.collaborator.message.to_s
+          source: UserSource.new(user: current_user),
+          investigation: investigation,
+          title: "#{collaborator.team.name} added to #{investigation.case_type.downcase}",
+          body: collaborator.message.to_s
         )
       else
-        context.fail!
+        self.fail!
       end
     rescue ActiveRecord::RecordNotUnique
       # Collaborator already added, so return successful but without notfiying the team


### PR DESCRIPTION
If we want to use common services interface, we could use implementation which does not enforce us to prepend each variable with `context`.