### PR TITLE
Remove margin from right of tag in header

### DIFF
--- a/psd-web/app/assets/stylesheets/header.scss
+++ b/psd-web/app/assets/stylesheets/header.scss
@@ -16,3 +16,7 @@ $navbar-link-colour: #ffffff;
   @include govuk-link-common;
   padding: 0;
 }
+
+.psd-header .govuk-tag {
+  margin-right: 0;
+}


### PR DESCRIPTION
Removes unnecessary margin on the beta tag in our header - which currently makes the link larger than it needs to be.

Current:
<img width="635" alt="Screenshot 2020-04-24 at 15 10 22" src="https://user-images.githubusercontent.com/2204224/80221925-ec12bf00-863d-11ea-9e3c-33c55d077189.png">

Fixed:
<img width="681" alt="Screenshot 2020-04-24 at 15 10 11" src="https://user-images.githubusercontent.com/2204224/80221930-eddc8280-863d-11ea-8c1d-427c82e870a2.png">
