### PR TITLE
Use inset text style for assignment message

### DIFF
--- a/psd-web/app/models/audit_activity/investigation/update_assignee.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_assignee.rb
@@ -1,4 +1,6 @@
 class AuditActivity::Investigation::UpdateAssignee < AuditActivity::Investigation::Base
+  include NotifyHelper
+
   def self.from(investigation)
     title = investigation.assignee.id.to_s
     body = investigation.assignee_rationale
@@ -23,9 +25,13 @@ class AuditActivity::Investigation::UpdateAssignee < AuditActivity::Investigatio
   def email_update_text
     body = []
     body << "#{investigation.case_type.upcase_first} was assigned to #{investigation.assignee.display_name} by #{source&.show}."
-    body << "\nComment provided by #{source&.show}:" if investigation.visibility_rationale.present?
-    body << investigation.assignee_rationale if investigation.assignee_rationale.present?
-    body.join("\n")
+
+    if investigation.assignee_rationale.present?
+      body << "Message from #{source&.show}:"
+      body << inset_text_for_notify(investigation.assignee_rationale)
+    end
+
+    body.join("\n\n")
   end
 
   def email_subject_text


### PR DESCRIPTION
This makes the message more visually distinctive in the email.

Also fixed a bug whereby the lead-in line ("Message from {name}:") wasn't being included, and reworded that slightly.

See https://trello.com/c/sQHypNpr/351-use-inset-style-for-comments-included-with-email-notifications

## Example:
<img width="646" alt="Screenshot 2020-04-27 at 12 12 30" src="https://user-images.githubusercontent.com/2204224/80366007-6c286700-8880-11ea-9035-63f9cc02cca7.png">
