### PR TITLE
Fix invitations

### DIFF
--- a/psd-web/app/controllers/users_controller.rb
+++ b/psd-web/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
     # this even once their account has been created. Hence redirecting them to the root page.
     return redirect_to(root_path) if signed_in_as?(@user) || @user.has_completed_registration?
     return render(:expired_invitation) if @user.invitation_expired?
-    return (render "errors/not_found", status: :not_found) if @user.invitation_token != params[:invitation]
+    return (render "errors/not_found", status: :not_found) if !params[:invitation] || (@user.invitation_token != params[:invitation])
 
     # Reset name and mobile number in case they’ve been remembered
     # from a previous registration that was abandoned before the mobile number

--- a/psd-web/app/jobs/send_user_invitation_job.rb
+++ b/psd-web/app/jobs/send_user_invitation_job.rb
@@ -17,6 +17,6 @@ class SendUserInvitationJob < ApplicationJob
     user_inviting = user_inviting_id ? User.find(user_inviting_id) : nil
 
     NotifyMailer.invitation_email(user, user_inviting).deliver_now
-    user.update!(has_been_sent_welcome_email: true, invited_at: user.invited_at || Time.current)
+    user.update!(has_been_sent_welcome_email: true)
   end
 end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -50,7 +50,8 @@ class User < ApplicationRecord
       id: SecureRandom.uuid,
       email: email_address,
       organisation: team.organisation,
-      invitation_token: SecureRandom.hex(15)
+      invitation_token: SecureRandom.hex(15),
+      invited_at: Time.now
     )
 
     # TODO: remove this once we’ve updated the application to no
@@ -143,7 +144,7 @@ class User < ApplicationRecord
   end
 
   def invitation_expired?
-    return false unless invited_at
+    return true unless invited_at
 
     invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
   end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -35,6 +35,8 @@ class User < ApplicationRecord
   end
 
   attribute :skip_password_validation, :boolean, default: false
+  attribute :invitation_token, :string, default: -> { SecureRandom.hex(15) }
+  attribute :invited_at, :datetime, default: -> { Time.current }
 
   def self.activated
     where(account_activated: true)
@@ -49,9 +51,7 @@ class User < ApplicationRecord
       skip_password_validation: true,
       id: SecureRandom.uuid,
       email: email_address,
-      organisation: team.organisation,
-      invitation_token: SecureRandom.hex(15),
-      invited_at: Time.now
+      organisation: team.organisation
     )
 
     # TODO: remove this once we’ve updated the application to no
@@ -144,8 +144,6 @@ class User < ApplicationRecord
   end
 
   def invitation_expired?
-    return true unless invited_at
-
     invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
   end
 

--- a/psd-web/app/services/create_organisation_with_team_and_admin_user.rb
+++ b/psd-web/app/services/create_organisation_with_team_and_admin_user.rb
@@ -12,8 +12,7 @@ class CreateOrganisationWithTeamAndAdminUser
       context.user = context.team.users.create!(
         email: context.admin_email,
         organisation: context.org,
-        skip_password_validation: true,
-        invitation_token: SecureRandom.hex(15)
+        skip_password_validation: true
       )
 
       context.user.user_roles.create!(name: "psd_user")

--- a/psd-web/db/migrate/20200402142659_init_schema.rb
+++ b/psd-web/db/migrate/20200402142659_init_schema.rb
@@ -1,334 +1,336 @@
 class InitSchema < ActiveRecord::Migration[5.2]
   def up
-    # These are extensions that must be enabled in order to support this database
-    enable_extension "pgcrypto"
-    enable_extension "plpgsql"
+    safety_assured do
+      # These are extensions that must be enabled in order to support this database
+      enable_extension "pgcrypto"
+      enable_extension "plpgsql"
 
-    create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
-      t.bigint "blob_id", null: false
-      t.datetime "created_at", null: false
-      t.string "name", null: false
-      t.bigint "record_id", null: false
-      t.string "record_type", null: false
-      t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-      t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+      create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
+        t.bigint "blob_id", null: false
+        t.datetime "created_at", null: false
+        t.string "name", null: false
+        t.bigint "record_id", null: false
+        t.string "record_type", null: false
+        t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+        t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+      end
+
+      create_table "active_storage_blobs", id: :serial, force: :cascade do |t|
+        t.bigint "byte_size", null: false
+        t.string "checksum", null: false
+        t.string "content_type"
+        t.datetime "created_at", null: false
+        t.string "filename", null: false
+        t.string "key", null: false
+        t.text "metadata"
+        t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+      end
+
+      create_table "activities", id: :serial, force: :cascade do |t|
+        t.text "body"
+        t.bigint "business_id"
+        t.bigint "correspondence_id"
+        t.datetime "created_at", null: false
+        t.integer "investigation_id"
+        t.bigint "product_id"
+        t.string "title"
+        t.string "type", default: "CommentActivity"
+        t.datetime "updated_at", null: false
+        t.index ["business_id"], name: "index_activities_on_business_id"
+        t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
+        t.index ["investigation_id"], name: "index_activities_on_investigation_id"
+        t.index ["product_id"], name: "index_activities_on_product_id"
+      end
+
+      create_table "alerts", id: :serial, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.text "description"
+        t.integer "investigation_id"
+        t.string "summary"
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id"], name: "index_alerts_on_investigation_id"
+      end
+
+      create_table "businesses", id: :serial, force: :cascade do |t|
+        t.string "company_number"
+        t.datetime "created_at", null: false
+        t.string "legal_name"
+        t.string "trading_name", null: false
+        t.datetime "updated_at", null: false
+      end
+
+      create_table "collaborators", force: :cascade do |t|
+        t.uuid "added_by_user_id", null: false
+        t.datetime "created_at", null: false
+        t.integer "investigation_id", null: false
+        t.text "message"
+        t.uuid "team_id", null: false
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id", "team_id"], name: "index_collaborators_on_investigation_id_and_team_id", unique: true
+      end
+
+      create_table "complainants", id: :serial, force: :cascade do |t|
+        t.string "complainant_type"
+        t.datetime "created_at", null: false
+        t.string "email_address"
+        t.integer "investigation_id"
+        t.string "name"
+        t.text "other_details"
+        t.string "phone_number"
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id"], name: "index_complainants_on_investigation_id"
+      end
+
+      create_table "contacts", force: :cascade do |t|
+        t.integer "business_id"
+        t.datetime "created_at", null: false
+        t.string "email"
+        t.string "job_title"
+        t.string "name"
+        t.string "phone_number"
+        t.datetime "updated_at", null: false
+        t.index ["business_id"], name: "index_contacts_on_business_id"
+      end
+
+      create_table "corrective_actions", id: :serial, force: :cascade do |t|
+        t.integer "business_id"
+        t.datetime "created_at", null: false
+        t.date "date_decided"
+        t.text "details"
+        t.string "duration"
+        t.string "geographic_scope"
+        t.integer "investigation_id"
+        t.string "legislation"
+        t.string "measure_type"
+        t.integer "product_id"
+        t.text "summary"
+        t.datetime "updated_at", null: false
+        t.index ["business_id"], name: "index_corrective_actions_on_business_id"
+        t.index ["investigation_id"], name: "index_corrective_actions_on_investigation_id"
+        t.index ["product_id"], name: "index_corrective_actions_on_product_id"
+      end
+
+      create_table "correspondences", force: :cascade do |t|
+        t.string "contact_method"
+        t.date "correspondence_date"
+        t.string "correspondent_name"
+        t.string "correspondent_type"
+        t.datetime "created_at", null: false
+        t.text "details"
+        t.string "email_address"
+        t.string "email_direction"
+        t.string "email_subject"
+        t.boolean "has_consumer_info", default: false, null: false
+        t.integer "investigation_id"
+        t.string "overview"
+        t.string "phone_number"
+        t.string "type"
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id"], name: "index_correspondences_on_investigation_id"
+      end
+
+      create_table "investigation_businesses", id: :serial, force: :cascade do |t|
+        t.integer "business_id"
+        t.datetime "created_at", null: false
+        t.integer "investigation_id"
+        t.string "relationship"
+        t.datetime "updated_at", null: false
+        t.index ["business_id"], name: "index_investigation_businesses_on_business_id"
+        t.index ["investigation_id", "business_id"], name: "index_on_investigation_id_and_business_id", unique: true
+        t.index ["investigation_id"], name: "index_investigation_businesses_on_investigation_id"
+      end
+
+      create_table "investigation_products", id: :serial, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.integer "investigation_id"
+        t.integer "product_id"
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id", "product_id"], name: "index_investigation_products_on_investigation_id_and_product_id", unique: true
+        t.index ["investigation_id"], name: "index_investigation_products_on_investigation_id"
+        t.index ["product_id"], name: "index_investigation_products_on_product_id"
+      end
+
+      create_table "investigations", id: :serial, force: :cascade do |t|
+        t.uuid "assignable_id"
+        t.string "assignable_type"
+        t.string "complainant_reference"
+        t.boolean "coronavirus_related", default: false
+        t.datetime "created_at", null: false
+        t.date "date_received"
+        t.text "description"
+        t.text "hazard_description"
+        t.string "hazard_type"
+        t.boolean "is_closed", default: false
+        t.boolean "is_private", default: false, null: false
+        t.text "non_compliant_reason"
+        t.string "pretty_id"
+        t.string "product_category"
+        t.string "received_type"
+        t.string "type", default: "Investigation::Allegation"
+        t.datetime "updated_at", null: false
+        t.string "user_title"
+        t.index ["assignable_type", "assignable_id"], name: "index_investigations_on_assignable_type_and_assignable_id"
+        t.index ["pretty_id"], name: "index_investigations_on_pretty_id"
+        t.index ["updated_at"], name: "index_investigations_on_updated_at"
+      end
+
+      create_table "locations", id: :serial, force: :cascade do |t|
+        t.string "address_line_1"
+        t.string "address_line_2"
+        t.integer "business_id"
+        t.string "city"
+        t.string "country"
+        t.string "county"
+        t.datetime "created_at", null: false
+        t.string "name", null: false
+        t.string "phone_number"
+        t.string "postal_code"
+        t.datetime "updated_at", null: false
+        t.index ["business_id"], name: "index_locations_on_business_id"
+      end
+
+      create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.string "name"
+        t.datetime "updated_at", null: false
+      end
+
+      create_table "products", id: :serial, force: :cascade do |t|
+        t.string "batch_number"
+        t.string "category"
+        t.string "country_of_origin"
+        t.datetime "created_at", null: false
+        t.text "description"
+        t.string "name"
+        t.string "product_code"
+        t.string "product_type"
+        t.datetime "updated_at", null: false
+        t.string "webpage"
+      end
+
+      create_table "rapex_imports", id: :serial, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.string "reference", null: false
+        t.datetime "updated_at", null: false
+      end
+
+      create_table "sources", id: :serial, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.string "name"
+        t.integer "sourceable_id"
+        t.string "sourceable_type"
+        t.string "type"
+        t.datetime "updated_at", null: false
+        t.uuid "user_id"
+        t.index ["sourceable_id", "sourceable_type"], name: "index_sources_on_sourceable_id_and_sourceable_type"
+        t.index ["user_id"], name: "index_sources_on_user_id"
+      end
+
+      create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.string "name"
+        t.uuid "organisation_id"
+        t.string "team_recipient_email"
+        t.datetime "updated_at", null: false
+        t.index ["name"], name: "index_teams_on_name"
+        t.index ["organisation_id"], name: "index_teams_on_organisation_id"
+      end
+
+      create_table "teams_users", force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.uuid "team_id"
+        t.datetime "updated_at", null: false
+        t.uuid "user_id"
+        t.index ["team_id"], name: "index_teams_users_on_team_id"
+        t.index ["user_id"], name: "index_teams_users_on_user_id"
+      end
+
+      create_table "tests", id: :serial, force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.date "date"
+        t.text "details"
+        t.integer "investigation_id"
+        t.string "legislation"
+        t.integer "product_id"
+        t.string "result"
+        t.string "type"
+        t.datetime "updated_at", null: false
+        t.index ["investigation_id"], name: "index_tests_on_investigation_id"
+        t.index ["product_id"], name: "index_tests_on_product_id"
+      end
+
+      create_table "user_roles", force: :cascade do |t|
+        t.datetime "created_at", null: false
+        t.string "name", null: false
+        t.datetime "updated_at", null: false
+        t.uuid "user_id"
+        t.index ["user_id", "name"], name: "index_user_roles_on_user_id_and_name", unique: true
+        t.index ["user_id"], name: "index_user_roles_on_user_id"
+      end
+
+      create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+        t.boolean "account_activated", default: false
+        t.datetime "created_at", null: false
+        t.string "credential_type"
+        t.datetime "current_sign_in_at"
+        t.inet "current_sign_in_ip"
+        t.string "direct_otp"
+        t.datetime "direct_otp_sent_at"
+        t.string "email"
+        t.string "encrypted_otp_secret_key"
+        t.string "encrypted_otp_secret_key_iv"
+        t.string "encrypted_otp_secret_key_salt"
+        t.string "encrypted_password", default: "", null: false
+        t.integer "failed_attempts", default: 0, null: false
+        t.boolean "has_accepted_declaration", default: false
+        t.boolean "has_been_sent_welcome_email", default: false
+        t.boolean "has_viewed_introduction", default: false
+        t.integer "hash_iterations", default: 27500
+        t.text "invitation_token"
+        t.datetime "invited_at"
+        t.datetime "keycloak_created_at"
+        t.datetime "last_sign_in_at"
+        t.inet "last_sign_in_ip"
+        t.datetime "locked_at"
+        t.text "mobile_number"
+        t.boolean "mobile_number_verified", default: false, null: false
+        t.string "name"
+        t.uuid "organisation_id"
+        t.binary "password_salt"
+        t.datetime "remember_created_at"
+        t.datetime "reset_password_sent_at"
+        t.string "reset_password_token"
+        t.integer "second_factor_attempts_count", default: 0
+        t.datetime "second_factor_attempts_locked_at"
+        t.integer "sign_in_count", default: 0, null: false
+        t.string "unlock_token"
+        t.datetime "updated_at", null: false
+        t.index ["account_activated"], name: "index_users_on_account_activated"
+        t.index ["email"], name: "index_users_on_email"
+        t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
+        t.index ["name"], name: "index_users_on_name"
+        t.index ["organisation_id"], name: "index_users_on_organisation_id"
+        t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+        t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+      end
+
+      add_foreign_key "activities", "businesses"
+      add_foreign_key "activities", "correspondences"
+      add_foreign_key "activities", "investigations"
+      add_foreign_key "activities", "products"
+      add_foreign_key "alerts", "investigations"
+      add_foreign_key "collaborators", "investigations"
+      add_foreign_key "collaborators", "teams"
+      add_foreign_key "collaborators", "users", column: "added_by_user_id"
+      add_foreign_key "complainants", "investigations"
+      add_foreign_key "corrective_actions", "businesses"
+      add_foreign_key "corrective_actions", "investigations"
+      add_foreign_key "corrective_actions", "products"
+      add_foreign_key "correspondences", "investigations"
+      add_foreign_key "locations", "businesses"
+      add_foreign_key "tests", "investigations"
+      add_foreign_key "tests", "products"
     end
-
-    create_table "active_storage_blobs", id: :serial, force: :cascade do |t|
-      t.bigint "byte_size", null: false
-      t.string "checksum", null: false
-      t.string "content_type"
-      t.datetime "created_at", null: false
-      t.string "filename", null: false
-      t.string "key", null: false
-      t.text "metadata"
-      t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-    end
-
-    create_table "activities", id: :serial, force: :cascade do |t|
-      t.text "body"
-      t.bigint "business_id"
-      t.bigint "correspondence_id"
-      t.datetime "created_at", null: false
-      t.integer "investigation_id"
-      t.bigint "product_id"
-      t.string "title"
-      t.string "type", default: "CommentActivity"
-      t.datetime "updated_at", null: false
-      t.index ["business_id"], name: "index_activities_on_business_id"
-      t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
-      t.index ["investigation_id"], name: "index_activities_on_investigation_id"
-      t.index ["product_id"], name: "index_activities_on_product_id"
-    end
-
-    create_table "alerts", id: :serial, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.text "description"
-      t.integer "investigation_id"
-      t.string "summary"
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id"], name: "index_alerts_on_investigation_id"
-    end
-
-    create_table "businesses", id: :serial, force: :cascade do |t|
-      t.string "company_number"
-      t.datetime "created_at", null: false
-      t.string "legal_name"
-      t.string "trading_name", null: false
-      t.datetime "updated_at", null: false
-    end
-
-    create_table "collaborators", force: :cascade do |t|
-      t.uuid "added_by_user_id", null: false
-      t.datetime "created_at", null: false
-      t.integer "investigation_id", null: false
-      t.text "message"
-      t.uuid "team_id", null: false
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id", "team_id"], name: "index_collaborators_on_investigation_id_and_team_id", unique: true
-    end
-
-    create_table "complainants", id: :serial, force: :cascade do |t|
-      t.string "complainant_type"
-      t.datetime "created_at", null: false
-      t.string "email_address"
-      t.integer "investigation_id"
-      t.string "name"
-      t.text "other_details"
-      t.string "phone_number"
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id"], name: "index_complainants_on_investigation_id"
-    end
-
-    create_table "contacts", force: :cascade do |t|
-      t.integer "business_id"
-      t.datetime "created_at", null: false
-      t.string "email"
-      t.string "job_title"
-      t.string "name"
-      t.string "phone_number"
-      t.datetime "updated_at", null: false
-      t.index ["business_id"], name: "index_contacts_on_business_id"
-    end
-
-    create_table "corrective_actions", id: :serial, force: :cascade do |t|
-      t.integer "business_id"
-      t.datetime "created_at", null: false
-      t.date "date_decided"
-      t.text "details"
-      t.string "duration"
-      t.string "geographic_scope"
-      t.integer "investigation_id"
-      t.string "legislation"
-      t.string "measure_type"
-      t.integer "product_id"
-      t.text "summary"
-      t.datetime "updated_at", null: false
-      t.index ["business_id"], name: "index_corrective_actions_on_business_id"
-      t.index ["investigation_id"], name: "index_corrective_actions_on_investigation_id"
-      t.index ["product_id"], name: "index_corrective_actions_on_product_id"
-    end
-
-    create_table "correspondences", force: :cascade do |t|
-      t.string "contact_method"
-      t.date "correspondence_date"
-      t.string "correspondent_name"
-      t.string "correspondent_type"
-      t.datetime "created_at", null: false
-      t.text "details"
-      t.string "email_address"
-      t.string "email_direction"
-      t.string "email_subject"
-      t.boolean "has_consumer_info", default: false, null: false
-      t.integer "investigation_id"
-      t.string "overview"
-      t.string "phone_number"
-      t.string "type"
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id"], name: "index_correspondences_on_investigation_id"
-    end
-
-    create_table "investigation_businesses", id: :serial, force: :cascade do |t|
-      t.integer "business_id"
-      t.datetime "created_at", null: false
-      t.integer "investigation_id"
-      t.string "relationship"
-      t.datetime "updated_at", null: false
-      t.index ["business_id"], name: "index_investigation_businesses_on_business_id"
-      t.index ["investigation_id", "business_id"], name: "index_on_investigation_id_and_business_id", unique: true
-      t.index ["investigation_id"], name: "index_investigation_businesses_on_investigation_id"
-    end
-
-    create_table "investigation_products", id: :serial, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.integer "investigation_id"
-      t.integer "product_id"
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id", "product_id"], name: "index_investigation_products_on_investigation_id_and_product_id", unique: true
-      t.index ["investigation_id"], name: "index_investigation_products_on_investigation_id"
-      t.index ["product_id"], name: "index_investigation_products_on_product_id"
-    end
-
-    create_table "investigations", id: :serial, force: :cascade do |t|
-      t.uuid "assignable_id"
-      t.string "assignable_type"
-      t.string "complainant_reference"
-      t.boolean "coronavirus_related", default: false
-      t.datetime "created_at", null: false
-      t.date "date_received"
-      t.text "description"
-      t.text "hazard_description"
-      t.string "hazard_type"
-      t.boolean "is_closed", default: false
-      t.boolean "is_private", default: false, null: false
-      t.text "non_compliant_reason"
-      t.string "pretty_id"
-      t.string "product_category"
-      t.string "received_type"
-      t.string "type", default: "Investigation::Allegation"
-      t.datetime "updated_at", null: false
-      t.string "user_title"
-      t.index ["assignable_type", "assignable_id"], name: "index_investigations_on_assignable_type_and_assignable_id"
-      t.index ["pretty_id"], name: "index_investigations_on_pretty_id"
-      t.index ["updated_at"], name: "index_investigations_on_updated_at"
-    end
-
-    create_table "locations", id: :serial, force: :cascade do |t|
-      t.string "address_line_1"
-      t.string "address_line_2"
-      t.integer "business_id"
-      t.string "city"
-      t.string "country"
-      t.string "county"
-      t.datetime "created_at", null: false
-      t.string "name", null: false
-      t.string "phone_number"
-      t.string "postal_code"
-      t.datetime "updated_at", null: false
-      t.index ["business_id"], name: "index_locations_on_business_id"
-    end
-
-    create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.string "name"
-      t.datetime "updated_at", null: false
-    end
-
-    create_table "products", id: :serial, force: :cascade do |t|
-      t.string "batch_number"
-      t.string "category"
-      t.string "country_of_origin"
-      t.datetime "created_at", null: false
-      t.text "description"
-      t.string "name"
-      t.string "product_code"
-      t.string "product_type"
-      t.datetime "updated_at", null: false
-      t.string "webpage"
-    end
-
-    create_table "rapex_imports", id: :serial, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.string "reference", null: false
-      t.datetime "updated_at", null: false
-    end
-
-    create_table "sources", id: :serial, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.string "name"
-      t.integer "sourceable_id"
-      t.string "sourceable_type"
-      t.string "type"
-      t.datetime "updated_at", null: false
-      t.uuid "user_id"
-      t.index ["sourceable_id", "sourceable_type"], name: "index_sources_on_sourceable_id_and_sourceable_type"
-      t.index ["user_id"], name: "index_sources_on_user_id"
-    end
-
-    create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.string "name"
-      t.uuid "organisation_id"
-      t.string "team_recipient_email"
-      t.datetime "updated_at", null: false
-      t.index ["name"], name: "index_teams_on_name"
-      t.index ["organisation_id"], name: "index_teams_on_organisation_id"
-    end
-
-    create_table "teams_users", force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.uuid "team_id"
-      t.datetime "updated_at", null: false
-      t.uuid "user_id"
-      t.index ["team_id"], name: "index_teams_users_on_team_id"
-      t.index ["user_id"], name: "index_teams_users_on_user_id"
-    end
-
-    create_table "tests", id: :serial, force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.date "date"
-      t.text "details"
-      t.integer "investigation_id"
-      t.string "legislation"
-      t.integer "product_id"
-      t.string "result"
-      t.string "type"
-      t.datetime "updated_at", null: false
-      t.index ["investigation_id"], name: "index_tests_on_investigation_id"
-      t.index ["product_id"], name: "index_tests_on_product_id"
-    end
-
-    create_table "user_roles", force: :cascade do |t|
-      t.datetime "created_at", null: false
-      t.string "name", null: false
-      t.datetime "updated_at", null: false
-      t.uuid "user_id"
-      t.index ["user_id", "name"], name: "index_user_roles_on_user_id_and_name", unique: true
-      t.index ["user_id"], name: "index_user_roles_on_user_id"
-    end
-
-    create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-      t.boolean "account_activated", default: false
-      t.datetime "created_at", null: false
-      t.string "credential_type"
-      t.datetime "current_sign_in_at"
-      t.inet "current_sign_in_ip"
-      t.string "direct_otp"
-      t.datetime "direct_otp_sent_at"
-      t.string "email"
-      t.string "encrypted_otp_secret_key"
-      t.string "encrypted_otp_secret_key_iv"
-      t.string "encrypted_otp_secret_key_salt"
-      t.string "encrypted_password", default: "", null: false
-      t.integer "failed_attempts", default: 0, null: false
-      t.boolean "has_accepted_declaration", default: false
-      t.boolean "has_been_sent_welcome_email", default: false
-      t.boolean "has_viewed_introduction", default: false
-      t.integer "hash_iterations", default: 27500
-      t.text "invitation_token"
-      t.datetime "invited_at"
-      t.datetime "keycloak_created_at"
-      t.datetime "last_sign_in_at"
-      t.inet "last_sign_in_ip"
-      t.datetime "locked_at"
-      t.text "mobile_number"
-      t.boolean "mobile_number_verified", default: false, null: false
-      t.string "name"
-      t.uuid "organisation_id"
-      t.binary "password_salt"
-      t.datetime "remember_created_at"
-      t.datetime "reset_password_sent_at"
-      t.string "reset_password_token"
-      t.integer "second_factor_attempts_count", default: 0
-      t.datetime "second_factor_attempts_locked_at"
-      t.integer "sign_in_count", default: 0, null: false
-      t.string "unlock_token"
-      t.datetime "updated_at", null: false
-      t.index ["account_activated"], name: "index_users_on_account_activated"
-      t.index ["email"], name: "index_users_on_email"
-      t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
-      t.index ["name"], name: "index_users_on_name"
-      t.index ["organisation_id"], name: "index_users_on_organisation_id"
-      t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-      t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
-    end
-
-    add_foreign_key "activities", "businesses"
-    add_foreign_key "activities", "correspondences"
-    add_foreign_key "activities", "investigations"
-    add_foreign_key "activities", "products"
-    add_foreign_key "alerts", "investigations"
-    add_foreign_key "collaborators", "investigations"
-    add_foreign_key "collaborators", "teams"
-    add_foreign_key "collaborators", "users", column: "added_by_user_id"
-    add_foreign_key "complainants", "investigations"
-    add_foreign_key "corrective_actions", "businesses"
-    add_foreign_key "corrective_actions", "investigations"
-    add_foreign_key "corrective_actions", "products"
-    add_foreign_key "correspondences", "investigations"
-    add_foreign_key "locations", "businesses"
-    add_foreign_key "tests", "investigations"
-    add_foreign_key "tests", "products"
   end
 
   def down

--- a/psd-web/db/migrate/20200402142659_init_schema.rb
+++ b/psd-web/db/migrate/20200402142659_init_schema.rb
@@ -59,16 +59,6 @@ class InitSchema < ActiveRecord::Migration[5.2]
         t.datetime "updated_at", null: false
       end
 
-      create_table "collaborators", force: :cascade do |t|
-        t.uuid "added_by_user_id", null: false
-        t.datetime "created_at", null: false
-        t.integer "investigation_id", null: false
-        t.text "message"
-        t.uuid "team_id", null: false
-        t.datetime "updated_at", null: false
-        t.index ["investigation_id", "team_id"], name: "index_collaborators_on_investigation_id_and_team_id", unique: true
-      end
-
       create_table "complainants", id: :serial, force: :cascade do |t|
         t.string "complainant_type"
         t.datetime "created_at", null: false
@@ -319,9 +309,6 @@ class InitSchema < ActiveRecord::Migration[5.2]
       add_foreign_key "activities", "investigations"
       add_foreign_key "activities", "products"
       add_foreign_key "alerts", "investigations"
-      add_foreign_key "collaborators", "investigations"
-      add_foreign_key "collaborators", "teams"
-      add_foreign_key "collaborators", "users", column: "added_by_user_id"
       add_foreign_key "complainants", "investigations"
       add_foreign_key "corrective_actions", "businesses"
       add_foreign_key "corrective_actions", "investigations"

--- a/psd-web/db/migrate/20200427131227_user_invited_at_not_null.rb
+++ b/psd-web/db/migrate/20200427131227_user_invited_at_not_null.rb
@@ -1,10 +1,14 @@
 class UserInvitedAtNotNull < ActiveRecord::Migration[5.2]
   def up
-    User.where(invited_at: nil).update_all("invited_at=created_at")
-    change_column :users, :invited_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    safety_assured do
+      User.where(invited_at: nil).update_all("invited_at=created_at")
+      change_column :users, :invited_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
   end
 
   def down
-    change_column :users, :invited_at, :datetime, null: true, default: nil
+    safety_assured do
+      change_column :users, :invited_at, :datetime, null: true, default: nil
+    end
   end
 end

--- a/psd-web/db/migrate/20200427131227_user_invited_at_not_null.rb
+++ b/psd-web/db/migrate/20200427131227_user_invited_at_not_null.rb
@@ -1,0 +1,10 @@
+class UserInvitedAtNotNull < ActiveRecord::Migration[5.2]
+  def up
+    User.where(invited_at: nil).update_all("invited_at=created_at")
+    change_column :users, :invited_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+  end
+
+  def down
+    change_column :users, :invited_at, :datetime, null: true, default: nil
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_17_130015) do
+ActiveRecord::Schema.define(version: 2020_04_27_131227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -298,7 +298,7 @@ ActiveRecord::Schema.define(version: 2020_04_17_130015) do
     t.boolean "has_viewed_introduction", default: false
     t.integer "hash_iterations", default: 27500
     t.text "invitation_token"
-    t.datetime "invited_at"
+    t.datetime "invited_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "keycloak_created_at"
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"

--- a/psd-web/db/seeds.rb
+++ b/psd-web/db/seeds.rb
@@ -461,7 +461,7 @@ if run_seeds
       organisation: organisation,
       mobile_number_verified: true,
       teams: [processing],
-      mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER"),
+      mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
 
     %i[opss_user psd_user user].each do |role|

--- a/psd-web/spec/factories/users.rb
+++ b/psd-web/spec/factories/users.rb
@@ -43,8 +43,6 @@ FactoryBot.define do
 
     trait :invited do
       skip_password_validation { true }
-      invitation_token { SecureRandom.hex(15) }
-      invited_at { Time.zone.now }
       account_activated { false }
       password { nil }
       password_confirmation { nil }

--- a/psd-web/spec/jobs/send_user_invitation_job_spec.rb
+++ b/psd-web/spec/jobs/send_user_invitation_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SendUserInvitationJob do
       let(:user_id) { SecureRandom.uuid }
       let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
       let!(:user) { create(:user, id: user_id, invitation_token: SecureRandom.hex(10), invited_at: invited_at, has_been_sent_welcome_email: false) }
-      let(:invited_at) { Time.now }
+      let(:invited_at) { 1.hour.ago }
 
       context "with a user inviting id" do
         before do
@@ -21,10 +21,6 @@ RSpec.describe SendUserInvitationJob do
 
         it "sends an email via the NotifyMailer" do
           expect(message_delivery_instance).to have_received(:deliver_now)
-        end
-
-        it "adds the time that the user was invited" do
-          expect(user.reload.invited_at).to be_within(1.second).of(Time.zone.now)
         end
 
         it "sets the user flag for having been sent the welcome email" do
@@ -47,10 +43,6 @@ RSpec.describe SendUserInvitationJob do
           it "re-sends the invitation email via the NotifyMailer" do
             expect(message_delivery_instance).to have_received(:deliver_now)
           end
-
-          it "does not change the the time that the user was invited at" do
-            expect(user.reload.invited_at).to be_within(1.second).of(invited_at)
-          end
         end
 
         context "with user whose invitation has expired" do
@@ -64,10 +56,6 @@ RSpec.describe SendUserInvitationJob do
           it "sends an email about the expired notification via the NotifyMailer" do
             expect(message_delivery_instance).to have_received(:deliver_now)
           end
-
-          it "does not change the the time that the user was invited at" do
-            expect(user.reload.invited_at).to be_within(1.second).of(invited_at)
-          end
         end
 
         context "with user who has not been invited before" do
@@ -78,10 +66,6 @@ RSpec.describe SendUserInvitationJob do
 
           it "sends an email via the NotifyMailer" do
             expect(message_delivery_instance).to have_received(:deliver_now)
-          end
-
-          it "adds the time that the user was invited" do
-            expect(user.reload.invited_at).to be_within(1.second).of(Time.zone.now)
           end
 
           it "sets the user flag for having been sent the welcome email" do

--- a/psd-web/spec/jobs/send_user_invitation_job_spec.rb
+++ b/psd-web/spec/jobs/send_user_invitation_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SendUserInvitationJob do
       let(:user_id) { SecureRandom.uuid }
       let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
       let!(:user) { create(:user, id: user_id, invitation_token: SecureRandom.hex(10), invited_at: invited_at, has_been_sent_welcome_email: false) }
-      let(:invited_at) { nil }
+      let(:invited_at) { Time.now }
 
       context "with a user inviting id" do
         before do

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe User do
   include ActiveSupport::Testing::TimeHelpers
 
   describe "attributes" do
-    let(:user) { User.new }
+    let(:user) { described_class.new }
 
     describe "invitation_token" do
       before { allow(SecureRandom).to receive(:hex).with(15).and_return(expected_token) }
+
       let(:expected_token) { "abcd1234" }
 
       it "is generated on instantiation" do

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe User do
         expect(created_user.invitation_token).not_to be_nil
       end
 
+      it "adds an invited_at timestamp to the created user" do
+        expect(created_user.invited_at).not_to be_nil
+      end
+
       it "associates the created user with the given team's organisation" do
         expect(created_user.organisation).to eq team.organisation
       end
@@ -376,9 +380,9 @@ RSpec.describe User do
   end
 
   describe "#invitation_expired?" do
-    it "returns false when the user has not been invited" do
+    it "returns true when the user has no invited_at" do
       user = build_stubbed(:user, invited_at: nil)
-      expect(user.invitation_expired?).to be false
+      expect(user.invitation_expired?).to be true
     end
 
     it "returns false when user was invited less than 14 days ago" do

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -3,6 +3,25 @@ require "rails_helper"
 RSpec.describe User do
   include ActiveSupport::Testing::TimeHelpers
 
+  describe "attributes" do
+    let(:user) { User.new }
+
+    describe "invitation_token" do
+      before { allow(SecureRandom).to receive(:hex).with(15).and_return(expected_token) }
+      let(:expected_token) { "abcd1234" }
+
+      it "is generated on instantiation" do
+        expect(user.invitation_token).to eq(expected_token)
+      end
+    end
+
+    describe "invited_at" do
+      it "is generated on instantiation" do
+        expect(user.invited_at).to be_within(1.second).of(Time.current)
+      end
+    end
+  end
+
   describe "validations" do
     before { user.validate(:registration_completion) }
 
@@ -109,14 +128,6 @@ RSpec.describe User do
 
       it "creates an user with the given email address" do
         expect(created_user).not_to be_nil
-      end
-
-      it "adds a invitation token to the created user" do
-        expect(created_user.invitation_token).not_to be_nil
-      end
-
-      it "adds an invited_at timestamp to the created user" do
-        expect(created_user.invited_at).not_to be_nil
       end
 
       it "associates the created user with the given team's organisation" do
@@ -380,11 +391,6 @@ RSpec.describe User do
   end
 
   describe "#invitation_expired?" do
-    it "returns true when the user has no invited_at" do
-      user = build_stubbed(:user, invited_at: nil)
-      expect(user.invitation_expired?).to be true
-    end
-
     it "returns false when user was invited less than 14 days ago" do
       user = build_stubbed(:user, invited_at: 13.days.ago)
       expect(user.invitation_expired?).to be false

--- a/psd-web/spec/requests/user_completes_registration_spec.rb
+++ b/psd-web/spec/requests/user_completes_registration_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe "User completes registration", type: :request, with_stubbed_notif
       end
     end
 
+    context "when the user has no invitation token" do
+      let(:user) { create(:user, :invited, invitation_token: nil) }
+
+      it "sends visitor to not found page" do
+        get complete_registration_user_path(user.id)
+        expect(response).to have_http_status :not_found
+      end
+    end
+
     context "when the user invitation has expired" do
       let(:user) { create(:user, :invited, account_activated: false, invited_at: 15.days.ago) }
 

--- a/psd-web/test/fixtures/users.yml
+++ b/psd-web/test/fixtures/users.yml
@@ -6,6 +6,8 @@ southampton:
   organisation: southampton
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 southampton_steve:
   email: southampton.steve@example.com
@@ -15,6 +17,8 @@ southampton_steve:
   organisation: southampton
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 southampton_bob:
   email: southampton.bob@example.com
@@ -24,6 +28,8 @@ southampton_bob:
   organisation: southampton
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 southampton_frankie:
   email: southampton.frankie@example.com
@@ -33,6 +39,8 @@ southampton_frankie:
   organisation: southampton
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 opss:
   email: opss@example.com
@@ -42,6 +50,8 @@ opss:
   organisation: opss
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 opss_yann:
   email: opss.yann@example.com
@@ -51,6 +61,8 @@ opss_yann:
   organisation: opss
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>
 
 luton:
   email: luton@example.com
@@ -60,3 +72,5 @@ luton:
   organisation: luton
   password_salt: 123
   encrypted_password: <%= Devise::Encryptable::Encryptors::PBKDF2.digest("2538fhdkvuULE36f", 27500, "123", nil) %>
+  invitation_token: <%= SecureRandom.hex(15) %>
+  invited_at: <%= Time.current %>


### PR DESCRIPTION
https://trello.com/c/RwQ63f7o/520-bugs-with-invitations-for-users-invited-prior-to-keycloak-migration

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Also includes fixes for https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/527 - I've included them here because it's affecting the deployment due to a new migration being added, and in anticipation of it being merged fairly quickly.

This fixes some bugs around the invitation/registration process, particularly for legacy users invited prior to the removal of Keycloak, but not yet registered.

These users were able to attempt to reset their password, and would then receive the invitation email with no `invitation` param in the link in the email. This was because they have no `invitation_token` set. And the form would render because there was no check for this combination of conditions, but would show an error message only after filling in the form.

We would instead expect that when this type of user attempts to reset their password they would see an invitation expired error message. This was not happening because the `invited_at` timestamp was also `nil`, and our code treated this as _not expired_ and therefore send the invitation email again.

It appears we wanted to delay setting the `invited_at` until the email was actually sent, presumably in the event of a delay in email delivery. But I think given the problem it has introduced and the threshold for expiry, we can remove this, and I think this more accurately captures the time of the event.

To combat this I have set the users `invited_at` column to be `NOT NULL` and migrated any existing data to set this to the `created_at` time (this has already been done in production). In order to keep things DRY and to avoid forgetting to set this on user creation I've added default values to the database and the model. The reason for doing so in the model as well was because database defaults would only be accessible to the app after `reload` which wasn't convenient.

This should not introduce any issues because even when we create a new organisation and team admin they will receive an invitation email.

I have not set the `invitation_token` column to be `NOT NULL` because we agreed not to change this for existing users. When their team admin resends their invite the token will be reset. But I have made the default behaviour of the model to generate the token so that we don't have to remember to keep doing this.

I've also added the edge case scenario to the request spec.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
