### PR TITLE
Increase memory on staging and review apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         SPACE: staging
         APP_NAME: psd-web
         DOMAIN: staging.product-safety-database.service.gov.uk
-        WEB_MEMORY: 1G
+        WEB_MEMORY: 2G
         WORKER_MEMORY: 1G
         WEB_INSTANCES: 1
         WORKER_INSTANCES: 1

--- a/psd-web/manifest.review.yml
+++ b/psd-web/manifest.review.yml
@@ -37,7 +37,7 @@ applications:
         RAILS_MAX_THREADS: ((web-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s ES_NAMESPACE=((app-name)) bin/rake cf:on_first_instance db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
-      memory: 1G
+      memory: 2G
     - type: worker
       env:
         RAILS_MAX_THREADS: ((worker-max-threads))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Background: we've seen a number of `Exit status 223 (out of memory)` errors when deploying review apps and to staging.

This change increases the available memory to 2GB which matches production. It's the next available increment above 1GB.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
