### PR TITLE
Fix invite

### DIFF
--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   def self.resend_invite(email_address, inviting_user)
     user = find_user_within_teams_with_email!(email: email_address, teams: inviting_user.teams)
 
-    user.update!(invitation_token: SecureRandom.hex(15)) unless user.invitation_token?
+    user.update! invitation_token: user.invitation_token || SecureRandom.hex(15), invited_at: Time.current
 
     SendUserInvitationJob.perform_later(user.id, inviting_user.id)
   end

--- a/psd-web/spec/features/invite_user_spec.rb
+++ b/psd-web/spec/features/invite_user_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.feature "Inviting a user", :with_stubbed_mailer, :with_stubbed_elasticsearch, type: :feature do
+  let(:team) { create(:team) }
+  let(:user) { create(:user, :activated, :team_admin, teams: [team], has_viewed_introduction: true) }
+
+  before do
+    sign_in(user)
+    visit invite_to_team_url(team)
+    expect_to_be_on_invite_a_team_member_page
+  end
+
+  context "when there is already a user with that email" do
+    scenario "shows an error message" do
+      fill_in "new_user_email_address", with: user.email
+      click_button "Send invitation email"
+      expect(page).to have_css(".govuk-error-summary__list", text: "You cannot invite this person to join your team because they are already a member of another team from a different organisation.")
+    end
+  end
+
+  def expect_to_be_on_invite_a_team_member_page
+    expect(page).to have_css("h1", text: "Invite a team member")
+  end
+end

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
   let(:user) { create(:user, :activated, :psd_user, teams: [team], has_viewed_introduction: true) }
 
   let!(:another_active_user) { create(:user, :activated, email: "active.sameteam@example.com", organisation: user.organisation, teams: [team], has_viewed_introduction: true) }
-  let!(:another_inactive_user) { create(:user, email: "inactive.sameteam@example.com", organisation: user.organisation, teams: [team]) }
+  let!(:another_inactive_user) { create(:user, email: "inactive.sameteam@example.com", invited_at: 1.year.ago, organisation: user.organisation, teams: [team]) }
   let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, teams: [create(:team)]) }
 
   before do
@@ -28,11 +28,22 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
 
   context "when the user is a team admin" do
     let(:user) { create(:user, :activated, :team_admin, teams: [team], has_viewed_introduction: true) }
+    let(:message_delivery_instance) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+    before do
+      allow(NotifyMailer).to receive(:invitation_email).with(another_inactive_user, user).and_return(message_delivery_instance)
+    end
 
     scenario "displays the invite a team member link and only displays the resend invite link for inactive users" do
       expect(page).to have_link("Invite a team member")
       expect(page).to have_resend_invite_link_for(another_inactive_user)
       expect(page).not_to have_resend_invite_link_for(another_active_user)
+    end
+
+    scenario "resending an invitation sends an email to the user and shows a confirmation message" do
+      click_link "Resend invitation to #{another_inactive_user.email}"
+      expect(message_delivery_instance).to have_received(:deliver_now)
+      expect_confirmation_banner "Invite sent to #{another_inactive_user.email}"
     end
   end
 

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
 
   before do
     sign_in(user)
-    visit team_path(team)
+    visit "/teams/#{team.id}"
     expect_to_be_on_team_page
   end
 
@@ -57,6 +57,6 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
   end
 
   def have_resend_invite_link_for(user)
-    have_link("Resend invitation", href: resend_invitation_team_path(team, email_address: user.email))
+    have_link("Resend invitation", href: "/teams/#{team.id}/resend_invitation?email_address=#{CGI.escape(user.email)}")
   end
 end

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -179,13 +179,11 @@ RSpec.describe User do
 
       before { allow(SendUserInvitationJob).to receive(:perform_later) }
 
-      # rubocop:disable RSpec/MultipleExpectations
-      it "raises an exception and does not send the invitation" do
+      it "raises an exception and does not send the invitation", :aggregate_failures do
         expect { described_class.create_and_send_invite!(email, team, inviting_user) }
           .to raise_exception(ActiveRecord::RecordInvalid)
         expect(SendUserInvitationJob).not_to have_received(:perform_later)
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 
@@ -198,28 +196,28 @@ RSpec.describe User do
       let!(:invitation_token) { SecureRandom.hex }
       let(:invited_user) { create(:user, teams: inviting_user.teams, organisation: inviting_user.organisation, invitation_token: invitation_token) }
 
-      it "resends an invitation to the user" do
-        described_class.resend_invite(invited_user.email, inviting_user)
+      it "resends an invitation to the user", :aggregate_failures do
+        expect {
+          described_class.resend_invite(invited_user.email, inviting_user)
+        }.to(change { invited_user.reload.invited_at })
         expect(SendUserInvitationJob).to have_received(:perform_later).with(anything, inviting_user.id)
       end
 
-      context "when resending an invite" do
-        context "when the invitee has already been sent an invite but has not yet accepted it" do
-          it "does not change the existing invitation token" do
-            expect { described_class.resend_invite(invited_user.email, inviting_user) }
-              .not_to(change { invited_user.reload.invitation_token })
-          end
+      context "when the invitee has already been sent an invite but has not yet accepted it" do
+        it "does not change the existing invitation token" do
+          expect { described_class.resend_invite(invited_user.email, inviting_user) }
+            .not_to(change { invited_user.reload.invitation_token })
         end
+      end
 
-        context "when the invitee does not have an invitation token" do
-          before { invited_user.update!(invitation_token: nil) }
+      context "when the invitee does not have an invitation token" do
+        before { invited_user.update!(invitation_token: nil) }
 
-          it "re-regerates the token" do
-            allow(SecureRandom).to receive(:hex).with(15).and_return("new_token")
-            expect {
-              described_class.resend_invite(invited_user.email, inviting_user)
-            }.to change { invited_user.reload.invitation_token }.from(nil).to("new_token")
-          end
+        it "re-regerates the token" do
+          allow(SecureRandom).to receive(:hex).with(15).and_return("new_token")
+          expect {
+            described_class.resend_invite(invited_user.email, inviting_user)
+          }.to change { invited_user.reload.invitation_token }.from(nil).to("new_token")
         end
       end
     end
@@ -227,25 +225,21 @@ RSpec.describe User do
     context "when the given email does not match any user" do
       let(:email) { "inexistent@southampton.gov.uk" }
 
-      # rubocop:disable RSpec/MultipleExpectations
-      it "raises an exception and does not send the invitation" do
+      it "raises an exception and does not send the invitation", :aggregate_failures do
         expect { described_class.resend_invite(email, inviting_user) }
           .to raise_exception(ActiveRecord::RecordNotFound)
         expect(SendUserInvitationJob).not_to have_received(:perform_later)
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
 
     context "when inviting and invited users belong to different teams" do
       let(:invited_user) { create(:user_with_teams) }
 
-      # rubocop:disable RSpec/MultipleExpectations
-      it "raises an exception and does not send the invitation" do
+      it "raises an exception and does not send the invitation", :aggregate_failures do
         expect { described_class.resend_invite(invited_user.email, inviting_user) }
           .to raise_exception(ActiveRecord::RecordNotFound)
         expect(SendUserInvitationJob).not_to have_received(:perform_later)
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 

--- a/psd-web/test/controllers/teams_controller_test.rb
+++ b/psd-web/test/controllers/teams_controller_test.rb
@@ -13,11 +13,6 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     User.current = nil
   end
 
-  test "Team pages are visible to members" do
-    get team_url(teams(:southampton))
-    assert_response :success
-  end
-
   test "Team pages are not visible to non-members" do
     assert_raises Pundit::NotAuthorizedError do
       get team_url(teams(:luton))
@@ -28,14 +23,6 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_raises Pundit::NotAuthorizedError do
       get invite_to_team_url(teams(:luton))
     end
-  end
-
-  test "Team pages don’t include invite links for non-team-admins" do
-    sign_out(:user)
-    sign_in users(:southampton_bob)
-
-    get team_url(teams(:southampton))
-    assert_not_includes(response.body, "Invite a team member")
   end
 
   test "Team invite pages are visible to users with team_admin role only" do


### PR DESCRIPTION
https://trello.com/c/RwQ63f7o/520-bugs-with-invitations-for-users-invited-prior-to-keycloak-migration

## Description
Due to a lack of tests around resending user invitations, https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/531 introduced a bug whereby a user whose invitation was expired could not have their invitation resent. They would instead receive the "invitation expired" email.

The fix is to reset their `invited_at` timestamp when the team admin resends their invitation. This means the job will send the correct invitation email.

I've taken the opportunity to add a spec around this scenario and refactor some of the existing tests, and removed a few redundant Minitest tests.

Thanks to @nasirkhanbeis for spotting this bug.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
