### PR TITLE
Fix mailer stub

### DIFF
--- a/psd-web/spec/support/mailer.rb
+++ b/psd-web/spec/support/mailer.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 class TestNotifyEmail
-  def initialize(recipient, personalization)
+  attr_reader :recipient, :reference, :template, :personalization, :action_name
+
+  def initialize(recipient:, reference:, template:, personalization:, action_name:)
     @recipient = recipient
+    @reference = reference
+    @template = template
     @personalization = personalization
-  end
-
-  attr_reader :personalization
-
-  def recipient
-    @recipient.second
+    @action_name = action_name
   end
 
   def personalization_path(param)
@@ -22,8 +21,12 @@ RSpec.shared_context "with stubbed mailer", shared_context: :metadata do
   let!(:delivered_emails) { [] }
   # rubocop:disable RSpec/AnyInstance
   before do
-    allow_any_instance_of(NotifyMailer).to receive(:mail).and_wrap_original do |m, *args|
-      delivered_emails << TestNotifyEmail.new(*args.first, m.receiver.govuk_notify_personalisation)
+    allow_any_instance_of(NotifyMailer).to receive(:mail) do |m, *args|
+      delivered_emails << TestNotifyEmail.new(recipient: args.first[:to],
+                                              reference: m.govuk_notify_reference,
+                                              template: m.govuk_notify_template,
+                                              personalization: m.govuk_notify_personalisation,
+                                              action_name: m.action_name)
     end
   end
   # rubocop:enable RSpec/AnyInstance

--- a/psd-web/spec/support/user.rb
+++ b/psd-web/spec/support/user.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.after do
+    User.current = nil
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes a number of flaky tests (example: https://github.com/UKGovernmentBEIS/beis-opss-psd/runs/622461339?check_suite_focus=true) caused by an [ActiveRecord callback](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/models/investigation.rb#L233-L242) sending an email if `User.current` is set. Tests were not cleaning up `User.current` - a regression introduced by the Keycloak replacement work - so depending on the test order this would sometimes attempt to send an email unexpectedly. This change makes sure `User.current` is cleared after each test.

Also improved the mailer stub so that it does not call the original implementation, which could result in a call to the live Notify API, and added some extra properties to the `delivered_emails` objects so we can identify which email was sent (some borrowed from @scruti 's [PR](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/532)).

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
