### PR TITLE
Bugfix: optional message should be blank, not nil

### DIFF
--- a/psd-web/app/mailers/notify_mailer.rb
+++ b/psd-web/app/mailers/notify_mailer.rb
@@ -131,6 +131,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
                            ),
                            inset_text_for_notify(collaborator.message)
                          ].join("\n\n")
+                       else
+                        ""
                        end
 
     set_personalisation(

--- a/psd-web/app/mailers/notify_mailer.rb
+++ b/psd-web/app/mailers/notify_mailer.rb
@@ -132,7 +132,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
                            inset_text_for_notify(collaborator.message)
                          ].join("\n\n")
                        else
-                        ""
+                         ""
                        end
 
     set_personalisation(

--- a/psd-web/spec/mailers/notify_mailer_spec.rb
+++ b/psd-web/spec/mailers/notify_mailer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe NotifyMailer, :with_stubbed_elasticsearch do
       it "sets the personalisation" do
         expect(mail.govuk_notify_personalisation).to eql(
           updater_name: "Bob Jones",
-          optional_message: nil,
+          optional_message: "",
           investigation_url: investigation_url(collaborator.investigation)
         )
       end


### PR DESCRIPTION
Bugfix for https://sentry.io/organizations/beis/issues/1463173953/

Seems that the Notify API requires all personalisation keys to have a value, eg a blank string, rather than being null.

