### PR TITLE
Extract css by defualt rather than rendering with javascript

### DIFF
--- a/psd-web/config/webpacker.yml
+++ b/psd-web/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg
@@ -86,7 +86,7 @@ production:
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
 
-  # Extract and emit a css file
+  # Extract and emit a css file - set explicitly to ensure prod always has it
   extract_css: true
 
   # Cache manifest.json for performance


### PR DESCRIPTION
This renders css by default rather than doing it client side with javascript.

This fixes an issue where we can't test on dev environment without js as it also stops CSS from rendering.

## Testing

Suggest testing this locally to check it works sensibly. Unlike master, if you disable javascript you should see a site with css.