### PR TITLE
Don't output team and org names if they're the same

### DIFF
--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -104,10 +104,10 @@ module Investigations::DisplayTextHelper
 
   # rubocop:disable Rails/OutputSafety
   def investigation_assignee(investigation, classes = "")
-    out = [investigation.assignable ? investigation.assignable.name.to_s : tag.div("Unassigned", class: classes)]
-    out << investigation.assignable.organisation.name if investigation.assignable&.organisation.present?
-    out.uniq!
-    out.compact!
+    out = [investigation.assignable ? h(investigation.assignable.name.to_s) : h("Unassigned")]
+    if investigation&.assignable&.organisation&.name != investigation&.assignable&.name
+      out << h(investigation.assignable.organisation.name)
+    end
     out.join("<br />").html_safe
   end
   # rubocop:enable Rails/OutputSafety

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -105,8 +105,10 @@ module Investigations::DisplayTextHelper
   # rubocop:disable Rails/OutputSafety
   def investigation_assignee(investigation, classes = "")
     out = [investigation.assignable ? investigation.assignable.name.to_s : tag.div("Unassigned", class: classes)]
-    out << tag.div(investigation.assignable.organisation.name, class: classes) if investigation.assignable&.organisation.present?
-    out.join.html_safe
+    out << investigation.assignable.organisation.name if investigation.assignable&.organisation.present?
+    out.uniq!
+    out.compact!
+    out.join("<br />").html_safe
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -104,11 +104,11 @@ module Investigations::DisplayTextHelper
 
   # rubocop:disable Rails/OutputSafety
   def investigation_assignee(investigation)
-    out = [investigation.assignable ? h(investigation.assignable.name.to_s) : "Unassigned"]
+    out = [investigation.assignable ? h(investigation.assignable.name.to_s) : "Unassigned".html_safe]
     if investigation&.assignable&.organisation&.name != investigation&.assignable&.name
       out << h(investigation.assignable.organisation.name)
     end
-    out.join("<br>").html_safe
+    safe_join(out, "<br>".html_safe)
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -102,7 +102,6 @@ module Investigations::DisplayTextHelper
     true
   end
 
-  # rubocop:disable Rails/OutputSafety
   def investigation_assignee(investigation)
     out = [investigation.assignable ? h(investigation.assignable.name.to_s) : "Unassigned".html_safe]
     if investigation&.assignable&.organisation&.name != investigation&.assignable&.name
@@ -110,8 +109,8 @@ module Investigations::DisplayTextHelper
     end
     safe_join(out, "<br>".html_safe)
   end
-  # rubocop:enable Rails/OutputSafety
 
+  # rubocop:enable Rails/OutputSafety
   def business_summary_list(business)
     rows = [
       { key: { text: "Trading name" }, value: { text: business.trading_name } },

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -104,7 +104,7 @@ module Investigations::DisplayTextHelper
 
   # rubocop:disable Rails/OutputSafety
   def investigation_assignee(investigation)
-    out = [investigation.assignable ? h(investigation.assignable.name.to_s) : h("Unassigned")]
+    out = [investigation.assignable ? h(investigation.assignable.name.to_s) : "Unassigned"]
     if investigation&.assignable&.organisation&.name != investigation&.assignable&.name
       out << h(investigation.assignable.organisation.name)
     end

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -103,12 +103,12 @@ module Investigations::DisplayTextHelper
   end
 
   # rubocop:disable Rails/OutputSafety
-  def investigation_assignee(investigation, classes = "")
+  def investigation_assignee(investigation)
     out = [investigation.assignable ? h(investigation.assignable.name.to_s) : h("Unassigned")]
     if investigation&.assignable&.organisation&.name != investigation&.assignable&.name
       out << h(investigation.assignable.organisation.name)
     end
-    out.join("<br />").html_safe
+    out.join("<br>").html_safe
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -110,7 +110,6 @@ module Investigations::DisplayTextHelper
     safe_join(out, "<br>".html_safe)
   end
 
-  # rubocop:enable Rails/OutputSafety
   def business_summary_list(business)
     rows = [
       { key: { text: "Trading name" }, value: { text: business.trading_name } },

--- a/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
+++ b/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Investigations::DisplayTextHelper, type: :helper do
+  describe "#investigation_assignee", :with_stubbed_mailer, :with_stubbed_notify, :with_stubbed_elasticsearch do
+    context "when assignee has a team name that matches the organisation name" do
+      let(:organisation) { create(:organisation, name: "Southampton Council") }
+      let(:team) { create(:team, name: "Southampton Council", organisation: organisation) }
+      let(:investigation) { create(:investigation, assignable: team) }
+
+      it "displays just the team name" do
+        result = helper.investigation_assignee(investigation)
+        expect(result).to eq("Southampton Council")
+      end
+    end
+
+    context "when assignee has a team name differs from the organisation name" do
+      let(:organisation) { create(:organisation, name: "Office for Product Safety and Standards") }
+      let(:team) { create(:team, name: "OPSS Processing", organisation: organisation) }
+      let(:investigation) { create(:investigation, assignable: team) }
+
+      it "displays the team name and the organisation name" do
+        result = helper.investigation_assignee(investigation)
+        expect(result).to eq("OPSS Processing<br>Office for Product Safety and Standards")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our assignee section currently shows the assignee and their org. For many users, the org name is the same as the team name.

Where the team is the assignee, this means we show the same text twice.

This pr cleans up the markup a little (no unnecessary divs) and uniques the names.

Before:
![Screenshot 2020-04-29 at 18 19 01](https://user-images.githubusercontent.com/2204224/80626283-1e5d5b80-8a46-11ea-8f21-ee27e172a1cd.png)

After:
![Screenshot 2020-04-29 at 18 18 52](https://user-images.githubusercontent.com/2204224/80626290-20bfb580-8a46-11ea-87a3-349e4ff3eea6.png)

Because I'm uniquing the names this means that for opss we'll still show the team name and the org - the same for other orgs where they've got multiple teams.

![Screenshot 2020-04-29 at 18 21 18](https://user-images.githubusercontent.com/2204224/80626371-3cc35700-8a46-11ea-8d85-22eefaa8e5a7.png)
