### PR TITLE
Bugfix filtering cases assigned to me

### DIFF
--- a/.github/workflows/overrides/bugfix-filtering-cases-assigned-to-me.env
+++ b/.github/workflows/overrides/bugfix-filtering-cases-assigned-to-me.env
@@ -1,1 +1,1 @@
-DB_VERSION=filtering-cases-bugfix
+DB_NAME=filtering-cases-bugfix

--- a/.github/workflows/overrides/bugfix-filtering-cases-assigned-to-me.env
+++ b/.github/workflows/overrides/bugfix-filtering-cases-assigned-to-me.env
@@ -1,0 +1,1 @@
+DB_VERSION=filtering-cases-bugfix

--- a/psd-web/app/helpers/investigations_helper.rb
+++ b/psd-web/app/helpers/investigations_helper.rb
@@ -189,6 +189,7 @@ module InvestigationsHelper
 
   def set_default_assignee_filter
     params[:assigned_to_me] = "unchecked" if params[:assigned_to_me].blank?
+    params[:assigned_to_team_0] = "unchecked" if params[:assigned_to_team_0].blank?
     params[:assigned_to_someone_else] = "unchecked" if params[:assigned_to_someone_else].blank?
   end
 

--- a/psd-web/spec/features/filter_investigations_spec.rb
+++ b/psd-web/spec/features/filter_investigations_spec.rb
@@ -115,4 +115,15 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
     expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
     expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
   end
+
+  scenario "filtering cases assigned to me via homepage link" do
+    visit "/"
+    click_link "Your cases"
+
+    expect(page).to have_listed_case(investigation.pretty_id)
+
+    expect(page).not_to have_listed_case(other_user_investigation.pretty_id)
+    expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
+    expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
+  end
 end

--- a/psd-web/spec/features/investigations_spec.rb
+++ b/psd-web/spec/features/investigations_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Investigation listing", :with_elasticsearch, :with_stubbed_mailer
     {
       allegation: :unchecked,
       assigned_to_me: :unchecked,
+      assigned_to_team_0: :unchecked,
       assigned_to_someone_else: :unchecked,
       created_by_me: :unchecked,
       created_by_someone_else: :unchecked,


### PR DESCRIPTION
This fixes the bug whereby if you click the "Your cases" link on the homepage, you also see cases assigned to your team.

See https://trello.com/c/5LUydUFA/199-your-cases-link-filter-doesnt-filter-to-users-cases

This was caused because the filter builds the query by assuming that the team ID of your team should be added to the query unless the `assigned_to_team_0` param has the value of `unchecked`. But because the link from the homepage doesn't set this param (it just sets `/cases?assigned_to_me=checked`), the param had the value of nil instead of `unchecked`.

A private `set_default_assignee_filter` sets the params values to `unchecked` if they are missing, but the `assigned_to_team_0` was missing. Adding this fixes the bug.

I've added a feature spec which tests for this bug (if you checkout just this commit you can [see the test failing](https://github.com/UKGovernmentBEIS/beis-opss-psd/runs/641142391), with the second commit fixing the bug).

Also fixed the params in an unrelated spec which was relying upon the bug.

The code which builds the elasticsearch query is pretty hard to follow, and the resulting query is more complex than it often needs to be – however refactoring this is a task for the future. 😄 