### PR TITLE
Reorganise page expectation helpers into a single support file

### DIFF
--- a/psd-web/spec/features/add_attachment_spec.rb
+++ b/psd-web/spec/features/add_attachment_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Adding an attachment to a case", :with_stubbed_elasticsearch, :wi
 
     fill_and_submit_attachment_details_page
 
-    expect_to_be_on_case_overview_page
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
 
     click_link "Attachments (1)"
 
@@ -64,23 +64,6 @@ RSpec.feature "Adding an attachment to a case", :with_stubbed_elasticsearch, :wi
     click_link "Activity"
 
     expect_case_activity_page_to_show_entered_information
-  end
-
-  def expect_to_be_on_add_attachment_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/upload")
-    expect(page).to have_selector("h1", text: "Add attachment")
-    expect(page).to have_link("Back", href: investigation_path(investigation))
-  end
-
-  def expect_to_be_on_enter_attachment_details_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
-    expect(page).to have_selector("h3", text: "Document details")
-    expect(page).to have_link("Back", href: investigation_path(investigation))
-  end
-
-  def expect_to_be_on_case_overview_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
-    expect(page).to have_selector("h1", text: "Overview")
   end
 
   def expect_case_attachments_page_to_show_entered_information

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
     click_on "Save business"
 
     expect_to_be_on_investigation_businesses_page
+    expect(page).not_to have_error_messages
 
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Trading name")
     expect(page).to have_css("dd.govuk-summary-list__value", text: trading_name)
@@ -62,11 +63,5 @@ RSpec.feature "Adding a business", :with_stubbed_mailer, :with_stubbed_elasticse
     expected_contact = [name, job_title, phone_number, email].join(", ")
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Contact")
     expect(page).to have_css("dd.govuk-summary-list__value", text: expected_contact)
-  end
-
-  def expect_to_be_on_investigation_businesses_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/businesses")
-    expect(page).to have_selector("h1", text: "Businesses")
-    expect(page).not_to have_error_messages
   end
 end

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -20,15 +20,20 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     scenario "shows inputted data on the confirmation page and on the case attachments and activity pages" do
       visit new_investigation_corrective_action_path(investigation)
 
-      expect_to_be_on_record_corrective_action_page
+      expect_to_be_on_record_corrective_action_for_case_page
+      expect(page).not_to have_error_messages
+
       fill_and_submit_form
 
       expect_to_be_on_confirmation_page
+      expect(page).not_to have_error_messages
+
       expect_confirmation_page_to_show_entered_data
 
       click_on "Continue"
 
-      expect_to_be_on_case_overview_page
+      expect_to_be_on_case_page(case_id: investigation.pretty_id)
+      expect(page).not_to have_error_messages
 
       click_on "Activity"
 
@@ -42,10 +47,14 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     scenario "going back to the form from the confirmation page shows inputted data" do
       visit new_investigation_corrective_action_path(investigation)
 
-      expect_to_be_on_record_corrective_action_page
+      expect_to_be_on_record_corrective_action_for_case_page
+      expect(page).not_to have_error_messages
+
       fill_and_submit_form
 
       expect_to_be_on_confirmation_page
+      expect(page).not_to have_error_messages
+
       expect_confirmation_page_to_show_entered_data
 
       click_link "Edit details"
@@ -60,29 +69,13 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     scenario "shows an error message" do
       visit new_investigation_corrective_action_path(investigation)
 
-      expect_to_be_on_record_corrective_action_page
+      expect_to_be_on_record_corrective_action_for_case_page
+      expect(page).not_to have_error_messages
+
       fill_and_submit_form
 
       expect(page).to have_error_messages
     end
-  end
-
-  def expect_to_be_on_record_corrective_action_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/corrective_actions/details")
-    expect(page).to have_selector("h1", text: "Record corrective action")
-    expect(page).not_to have_error_messages
-  end
-
-  def expect_to_be_on_confirmation_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/corrective_actions/confirmation")
-    expect(page).to have_selector("h1", text: "Confirm corrective action details")
-    expect(page).not_to have_error_messages
-  end
-
-  def expect_to_be_on_case_overview_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
-    expect(page).to have_selector("h1", text: "Overview")
-    expect(page).not_to have_error_messages
   end
 
   def expect_confirmation_page_to_show_entered_data

--- a/psd-web/spec/features/add_product_spec.rb
+++ b/psd-web/spec/features/add_product_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     click_on "Save product"
 
     expect_to_be_on_investigation_products_page
+    expect(page).not_to have_error_messages
 
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Product name")
     expect(page).to have_css("dd.govuk-summary-list__value", text: product.name)
@@ -41,11 +42,5 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expect(page).to have_css("dd.govuk-summary-list__value", text: product.country_of_origin)
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Description")
     expect(page).to have_css("dd.govuk-summary-list__value", text: product.description)
-  end
-
-  def expect_to_be_on_investigation_products_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/products")
-    expect(page).to have_selector("h1", text: "Products")
-    expect(page).not_to have_error_messages
   end
 end

--- a/psd-web/spec/features/add_test_results_spec.rb
+++ b/psd-web/spec/features/add_test_results_spec.rb
@@ -63,14 +63,6 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     end
   end
 
-  def expect_to_be_on_new_activity_page
-    expect_page_to_have_h1("New activity")
-  end
-
-  def expect_to_be_on_record_test_result_page
-    expect_page_to_have_h1("Record test result")
-  end
-
   def fill_in_test_result_submit_form(legislation:, date:, test_result:, file:)
     select legislation, from: "test_legislation"
     fill_in "Day",   with: date.day if date

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -89,26 +89,6 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
 
 private
 
-  def expect_to_be_on_case_page(case_id:)
-    expect(page).to have_current_path("/cases/#{case_id}")
-    expect(page).to have_selector("h1", text: "Overview")
-  end
-
-  def expect_to_be_on_teams_page(case_id:)
-    expect(page).to have_current_path("/cases/#{case_id}/teams")
-    expect(page).to have_selector("h1", text: "Teams added to the case")
-  end
-
-  def expect_to_be_on_add_team_to_case_page(case_id:)
-    expect(page).to have_current_path("/cases/#{case_id}/teams/add")
-    expect(page).to have_selector("h1", text: "Add a team to the case")
-  end
-
-  def expect_to_be_on_case_activity_page(case_id:)
-    expect(page).to have_current_path("/cases/#{case_id}/activity")
-    expect(page).to have_selector("h1", text: "Activity")
-  end
-
   def expect_teams_tables_to_contain(expected_teams)
     teams_table = page.find(:table, "Teams added to the case")
 

--- a/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
@@ -51,11 +51,11 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       choose "Yes, it is (or could be)"
       click_button "Continue"
 
-      expect_to_be_on_complainant_page
+      expect_to_be_on_allegation_complainant_page
       choose "complainant_complainant_type_consumer"
       click_button "Continue"
 
-      expect_to_be_on_complainant_details_page
+      expect_to_be_on_allegation_complainant_details_page
       enter_contact_details(contact_details)
 
       expect_to_be_on_allegation_details_page
@@ -119,23 +119,6 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: webpage)
     expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: country_of_origin)
     expect(page.find("dt", text: "Description")).to have_sibling("dd", text: description)
-  end
-
-  def expect_to_be_on_complainant_page
-    expect(page).to have_current_path("/allegation/complainant")
-    expect_page_to_have_h1("New allegation")
-  end
-
-  def expect_to_be_on_complainant_details_page
-    expect(page).to have_current_path("/allegation/complainant_details")
-    expect_page_to_have_h1("New allegation")
-    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What are their contact details?")
-  end
-
-  def expect_to_be_on_allegation_details_page
-    expect(page).to have_current_path("/allegation/allegation_details")
-    expect_page_to_have_h1("New allegation")
-    expect(page).to have_css(".govuk-label--m", text: "What is being alleged?")
   end
 
   def expect_details_on_summary_page(contact_name:, contact_email:, contact_phone:)

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -97,28 +97,6 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     end
   end
 
-  def expect_to_be_on_about_enquiry_page
-    expect(page).to have_current_path("/enquiry/about_enquiry")
-    expect_page_to_have_h1("New enquiry")
-  end
-
-  def expect_to_be_on_complainant_page
-    expect(page).to have_current_path("/enquiry/complainant")
-    expect_page_to_have_h1("New enquiry")
-  end
-
-  def expect_to_be_on_complainant_details_page
-    expect(page).to have_current_path("/enquiry/complainant_details")
-    expect_page_to_have_h1("New enquiry")
-    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What are their contact details?")
-  end
-
-  def expect_to_be_on_enquiry_details_page
-    expect(page).to have_current_path("/enquiry/enquiry_details")
-    expect_page_to_have_h1("New enquiry")
-    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What is the enquiry?")
-  end
-
   def expect_details_on_summary_page(contact_name:, contact_email:, contact_phone:)
     expect(page.find("dt", text: "Source type")).to have_sibling("dd", text: "Consumer")
     expect(page).to have_css("p", text: contact_name)

--- a/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
+++ b/psd-web/spec/features/creating_an_account_from_an_invitation_spec.rb
@@ -105,34 +105,6 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_elasticsea
     end
   end
 
-  def expect_to_be_on_secondary_authentication_page
-    expect(page).to have_current_path(/\/two-factor/)
-
-    expect(page).to have_h1("Check your phone")
-  end
-
-  def expect_to_be_on_complete_registration_page
-    expect(page).to have_current_path(/\/complete-registration?.+$/)
-
-    expect(page).to have_h1("Create an account")
-
-    expect(page).to have_field("username", type: "email", with: invited_user.email, disabled: true)
-  end
-
-  def expect_to_be_on_signed_in_as_another_user_page
-    expect(page).to have_current_path(/\/complete-registration?.+$/)
-
-    expect(page).to have_h1("You are already signed in to the Product safety database")
-  end
-
-  def expect_to_be_on_declaration_page
-    expect(page).to have_current_path(/^\/declaration$/)
-  end
-
-  def expect_to_be_on_the_homepage
-    expect(page).to have_current_path("/")
-  end
-
   def expect_to_be_signed_in
     expect(page).to have_content("Sign out")
   end

--- a/psd-web/spec/features/delete_attachment_from_case_spec.rb
+++ b/psd-web/spec/features/delete_attachment_from_case_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Deleting an attachment from a case", :with_stubbed_elasticsearch,
 
     click_button "Delete attachment"
 
-    expect_to_be_on_case_overview_page
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
 
     click_link "Attachments"
 
@@ -28,24 +28,6 @@ RSpec.feature "Deleting an attachment from a case", :with_stubbed_elasticsearch,
     click_link "Activity"
 
     expect_case_activity_page_to_show_deleted_document
-  end
-
-  def expect_to_be_on_attachments_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/attachments")
-    expect(page).to have_selector("h1", text: "Attachments")
-    expect(page).to have_selector("h2", text: document.title)
-    expect(page).to have_selector("p",  text: document.description)
-  end
-
-  def expect_to_be_on_remove_attachment_confirmation_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.id}/remove")
-    expect(page).to have_selector("h2", text: "Remove attachment")
-    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
-  end
-
-  def expect_to_be_on_case_overview_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
-    expect(page).to have_selector("h1", text: "Overview")
   end
 
   def expect_remove_attachment_confirmation_page_to_show_attachment_information

--- a/psd-web/spec/features/delete_attachment_from_product_spec.rb
+++ b/psd-web/spec/features/delete_attachment_from_product_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Deleting an attachment from a product", :with_stubbed_elasticsear
 
     click_link "Remove document"
 
-    expect_to_be_on_remove_attachment_confirmation_page
+    expect_to_be_on_remove_attachment_from_product_confirmation_page
     expect_remove_attachment_confirmation_page_to_show_attachment_information
 
     click_button "Delete attachment"
@@ -28,23 +28,6 @@ RSpec.feature "Deleting an attachment from a product", :with_stubbed_elasticsear
     click_link "Attachments"
 
     expect_product_attachments_page_not_to_show_deleted_attachment
-  end
-
-  def expect_to_be_on_product_attachments_page
-    expect(page).to have_selector("h2", text: "Attachments")
-    expect(page).to have_selector("h2", text: document.title)
-    expect(page).to have_selector("p",  text: document.description)
-  end
-
-  def expect_to_be_on_remove_attachment_confirmation_page
-    expect(page).to have_current_path("/products/#{product.id}/documents/#{document.id}/remove")
-    expect(page).to have_selector("h2", text: "Remove attachment")
-    expect(page).to have_link("Back", href: "/products/#{product.id}")
-  end
-
-  def expect_to_be_on_product_page
-    expect(page).to have_current_path("/products/#{product.id}")
-    expect(page).to have_selector("h1", text: product.name)
   end
 
   def expect_remove_attachment_confirmation_page_to_show_attachment_information

--- a/psd-web/spec/features/edit_attachment_spec.rb
+++ b/psd-web/spec/features/edit_attachment_spec.rb
@@ -27,12 +27,6 @@ RSpec.feature "Editing an attachment on a case", :with_stubbed_elasticsearch, :w
     expect_case_activity_page_to_show_entered_information
   end
 
-  def expect_to_be_on_edit_attachment_page
-    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.to_param}/edit")
-    expect(page).to have_selector("h2", text: "Edit document details")
-    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
-  end
-
   def expect_case_attachments_page_to_show_entered_information
     expect(page).to have_selector("h2", text: new_title)
     expect(page).to have_selector("p",  text: new_description)

--- a/psd-web/spec/features/invite_user_spec.rb
+++ b/psd-web/spec/features/invite_user_spec.rb
@@ -27,8 +27,4 @@ RSpec.feature "Inviting a user", :with_stubbed_mailer, :with_stubbed_elasticsear
       expect(page).to have_css(".govuk-error-summary__list", text: "Email address belongs to a user that has been deleted. Email OPSS if you would like their account restored.")
     end
   end
-
-  def expect_to_be_on_invite_a_team_member_page
-    expect(page).to have_css("h1", text: "Invite a team member")
-  end
 end

--- a/psd-web/spec/features/password_reset_spec.rb
+++ b/psd-web/spec/features/password_reset_spec.rb
@@ -207,31 +207,6 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
     click_on "Continue"
   end
 
-  def expect_to_be_on_secondary_authentication_page
-    expect(page).to have_current_path(/\/two-factor/)
-  end
-
-  def expect_to_be_on_reset_password_page
-    expect(page).to have_current_path("/password/new")
-  end
-
-  def expect_to_be_on_signed_in_as_another_user_page
-    expect(page).to have_css("h1", text: "You are already signed in to the Product safety database")
-  end
-
-  def expect_to_be_on_edit_user_password_page
-    expect(page).to have_current_path("/password/edit", ignore_query: true)
-  end
-
-  def expect_to_be_on_check_your_email_page
-    expect(page).to have_css("h1", text: "Check your email")
-  end
-
-  def expect_to_be_on_password_changed_page
-    expect(page).to have_current_path("/password-changed")
-    expect(page).to have_css("h1", text: "You have changed your password successfully")
-  end
-
   def last_user_otp(user)
     user.reload.direct_otp
   end

--- a/psd-web/spec/features/registration_spec.rb
+++ b/psd-web/spec/features/registration_spec.rb
@@ -61,17 +61,9 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
     click_on "Continue"
   end
 
-  def expect_to_be_on_secondary_authentication_page
-    expect(page).to have_title("Check your phone")
-  end
-
   def enter_secondary_authentication_code(otp_code)
     fill_in "Enter security code", with: otp_code
     click_on "Continue"
-  end
-
-  def expect_to_be_on_declaration_page
-    expect(page).to have_title("Declaration - Product safety database - GOV.UK")
   end
 
   def otp_code

--- a/psd-web/spec/features/report_product_spec.rb
+++ b/psd-web/spec/features/report_product_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         expect_to_be_on_coronavirus_page("/ts_investigation/coronavirus")
         fill_in_coronavirus_page(coronavirus)
 
-        expect_to_be_on_product_page
+        expect_to_be_on_what_product_are_you_reporting_page
         fill_in_product_page(with: product_details)
 
         expect_to_be_on_why_reporting_page
@@ -167,7 +167,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
         click_link "View case"
 
-        expect_to_be_on_case_details_page
+        expect_to_be_on_case_page
         expect_case_details_page_to_show_entered_information
         expect_product_reported_unsafe_and_non_compliant
 
@@ -224,10 +224,10 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
         fill_in_coronavirus_page(coronavirus)
 
-        expect_to_be_on_product_page
+        expect_to_be_on_what_product_are_you_reporting_page
         click_button "Continue"
 
-        expect_to_be_on_product_page
+        expect_to_be_on_what_product_are_you_reporting_page
         expect(page).to have_error_summary "Name cannot be blank", "Product type cannot be blank", "Category cannot be blank"
 
         fill_in_product_page(with: product_details)
@@ -283,7 +283,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
         click_link "View case"
 
-        expect_to_be_on_case_details_page
+        expect_to_be_on_case_page
         expect(page).to have_text("#{product_details[:name]}, #{product_details[:type]}")
         expect(page).to have_text("Product reported because it is non-compliant.")
         expect(page.find("dt", text: "Coronavirus related")).to have_sibling("dd", text: "Coronavirus related case")
@@ -300,74 +300,6 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         expect_case_activity_page_to_show_product_added
       end
     end
-  end
-
-  def expect_to_be_on_product_page
-    expect(page).to have_current_path("/ts_investigation/product")
-    expect(page).to have_selector("h1", text: "What product are you reporting?")
-  end
-
-  def expect_to_be_on_why_reporting_page
-    expect(page).to have_current_path("/ts_investigation/why_reporting")
-    expect(page).to have_selector("h1", text: "Why are you reporting this product?")
-  end
-
-  def expect_to_be_on_supply_chain_page
-    expect(page).to have_current_path("/ts_investigation/which_businesses")
-    expect(page).to have_selector("h1", text: "Supply chain information")
-  end
-
-  def expect_to_be_on_business_details_page(title)
-    expect(page).to have_current_path("/ts_investigation/business")
-    expect(page).to have_selector("h1", text: "#{title} details")
-  end
-
-  def expect_to_be_on_corrective_action_taken_page
-    expect(page).to have_current_path("/ts_investigation/has_corrective_action")
-    expect(page).to have_selector("h1", text: "Has any corrective action been agreed or taken?")
-  end
-
-  def expect_to_be_on_record_corrective_action_page
-    expect(page).to have_current_path("/ts_investigation/corrective_action")
-    expect(page).to have_selector("h1", text: "Record corrective action")
-  end
-
-  def expect_to_be_on_other_information_page
-    expect(page).to have_current_path("/ts_investigation/other_information")
-    expect(page).to have_selector("h1", text: "Other information and files")
-  end
-
-  def expect_to_be_on_test_result_details_page
-    expect(page).to have_current_path("/ts_investigation/test_results")
-    expect(page).to have_selector("h1", text: "Test result details")
-  end
-
-  def expect_to_be_on_risk_assessment_details_page
-    expect(page).to have_current_path("/ts_investigation/risk_assessments")
-    expect(page).to have_selector("h1", text: "Risk assessment details")
-  end
-
-  def expect_to_be_on_reference_number_page
-    expect(page).to have_current_path("/ts_investigation/reference_number")
-    expect(page).to have_selector("h1", text: "Add your own reference number")
-  end
-
-  def expect_to_be_on_case_created_page
-    expect(page).to have_current_path(/\/cases\/([\d-]+)\/created/)
-    expect(page).to have_selector("h1", text: "Case created")
-    expect(page).to have_text(/Case ID: ([\d-]+)/)
-  end
-
-  def expect_to_be_on_case_details_page
-    expect(page).to have_selector("h1", text: "Overview")
-  end
-
-  def expect_to_be_on_case_products_page
-    expect(page).to have_selector("h1", text: "Products")
-  end
-
-  def expect_to_be_on_case_activity_page
-    expect(page).to have_selector("h1", text: "Activity")
   end
 
   def expect_case_details_page_to_show_entered_information

--- a/psd-web/spec/features/team_spec.rb
+++ b/psd-web/spec/features/team_spec.rb
@@ -48,10 +48,6 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
     end
   end
 
-  def expect_to_be_on_team_page
-    expect(page).to have_css("h1", text: "test organisation")
-  end
-
   def have_user(user)
     have_css(".teams--user .teams--user-email:contains(\"#{user.email}\")")
   end

--- a/psd-web/spec/features/your_account_spec.rb
+++ b/psd-web/spec/features/your_account_spec.rb
@@ -38,16 +38,4 @@ RSpec.feature "Your Account", :with_stubbed_elasticsearch, :with_stubbed_mailer,
     expect_to_be_on_your_account_page
     expect(page).to have_summary_item(key: "Name", value: "Joe Smith")
   end
-
-private
-
-  def expect_to_be_on_your_account_page
-    expect(page).to have_current_path("/account")
-    expect(page).to have_selector("h1", text: "Your account")
-  end
-
-  def expect_to_be_on_change_name_page
-    expect(page).to have_current_path("/account/name")
-    expect(page).to have_selector("h1", text: "Change your name")
-  end
 end

--- a/psd-web/spec/rails_helper.rb
+++ b/psd-web/spec/rails_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
 
   config.include ActiveSupport::Testing::TimeHelpers
 
+  config.include PageExpectations, type: :feature
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/psd-web/spec/support/feature_helpers.rb
+++ b/psd-web/spec/support/feature_helpers.rb
@@ -13,11 +13,6 @@ def expect_page_to_have_h1(header)
   expect(page).to have_css("h1", text: header)
 end
 
-def expect_to_be_on_coronavirus_page(path)
-  expect(page).to have_current_path(path)
-  expect(page).to have_selector("h1", text: "Is this case related to the coronavirus outbreak?")
-end
-
 def enter_contact_details(contact_name:, contact_email:, contact_phone:)
   fill_in "complainant[name]", with: contact_name
   fill_in "complainant_email_address", with: contact_email

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -1,0 +1,275 @@
+module PageExpectations
+  def expect_to_be_on_the_homepage
+    expect(page).to have_current_path("/")
+  end
+
+  # Cases pages
+  def expect_to_be_on_case_page(case_id: nil)
+    if case_id
+      expect(page).to have_current_path("/cases/#{case_id}")
+    else
+      expect(page).to have_current_path(/\/cases\/[\d\-]+$/)
+    end
+    expect(page).to have_selector("h1", text: "Overview")
+  end
+
+  def expect_to_be_on_investigation_businesses_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/businesses")
+    expect(page).to have_selector("h1", text: "Businesses")
+  end
+
+  def expect_to_be_on_add_attachment_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/upload")
+    expect(page).to have_selector("h1", text: "Add attachment")
+    expect(page).to have_link("Back", href: investigation_path(investigation))
+  end
+
+  def expect_to_be_on_enter_attachment_details_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
+    expect(page).to have_selector("h3", text: "Document details")
+    expect(page).to have_link("Back", href: investigation_path(investigation))
+  end
+
+  def expect_to_be_on_record_corrective_action_for_case_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/corrective_actions/details")
+    expect(page).to have_selector("h1", text: "Record corrective action")
+  end
+
+  def expect_to_be_on_confirmation_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/corrective_actions/confirmation")
+    expect(page).to have_selector("h1", text: "Confirm corrective action details")
+  end
+
+  def expect_to_be_on_investigation_products_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/products")
+    expect(page).to have_selector("h1", text: "Products")
+  end
+
+  def expect_to_be_on_case_products_page
+    expect(page).to have_selector("h1", text: "Products")
+  end
+
+  def expect_to_be_on_teams_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/teams")
+    expect(page).to have_selector("h1", text: "Teams added to the case")
+  end
+
+  def expect_to_be_on_add_team_to_case_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/teams/add")
+    expect(page).to have_selector("h1", text: "Add a team to the case")
+  end
+
+  def expect_to_be_on_attachments_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/attachments")
+    expect(page).to have_selector("h1", text: "Attachments")
+    expect(page).to have_selector("h2", text: document.title)
+    expect(page).to have_selector("p",  text: document.description)
+  end
+
+  def expect_to_be_on_product_attachments_page
+    expect(page).to have_selector("h2", text: "Attachments")
+    expect(page).to have_selector("h2", text: document.title)
+    expect(page).to have_selector("p",  text: document.description)
+  end
+
+  def expect_to_be_on_edit_attachment_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.to_param}/edit")
+    expect(page).to have_selector("h2", text: "Edit document details")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
+  end
+
+  def expect_to_be_on_remove_attachment_confirmation_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/#{document.id}/remove")
+    expect(page).to have_selector("h2", text: "Remove attachment")
+    expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}")
+  end
+
+  def expect_to_be_on_case_created_page
+    expect(page).to have_current_path(/\/cases\/([\d-]+)\/created/)
+    expect(page).to have_selector("h1", text: "Case created")
+    expect(page).to have_text(/Case ID: ([\d-]+)/)
+  end
+
+  def expect_to_be_on_new_activity_page
+    expect_page_to_have_h1("New activity")
+  end
+
+  def expect_to_be_on_record_test_result_page
+    expect_page_to_have_h1("Record test result")
+  end
+
+  def expect_to_be_on_case_activity_page(case_id: nil)
+    if case_id
+      expect(page).to have_current_path("/cases/#{case_id}/activity")
+    else
+      expect(page).to have_current_path(/\/cases\/[\d\-]+\/activity/)
+    end
+    expect(page).to have_selector("h1", text: "Activity")
+  end
+
+  # Add an allegation flow
+  def expect_to_be_on_allegation_complainant_page
+    expect(page).to have_current_path("/allegation/complainant")
+    expect_page_to_have_h1("New allegation")
+  end
+
+  def expect_to_be_on_allegation_complainant_details_page
+    expect(page).to have_current_path("/allegation/complainant_details")
+    expect_page_to_have_h1("New allegation")
+    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What are their contact details?")
+  end
+
+  def expect_to_be_on_allegation_details_page
+    expect(page).to have_current_path("/allegation/allegation_details")
+    expect_page_to_have_h1("New allegation")
+    expect(page).to have_css(".govuk-label--m", text: "What is being alleged?")
+  end
+
+  # Add an enquiry flow
+  def expect_to_be_on_about_enquiry_page
+    expect(page).to have_current_path("/enquiry/about_enquiry")
+    expect_page_to_have_h1("New enquiry")
+  end
+
+  def expect_to_be_on_complainant_page
+    expect(page).to have_current_path("/enquiry/complainant")
+    expect_page_to_have_h1("New enquiry")
+  end
+
+  def expect_to_be_on_complainant_details_page
+    expect(page).to have_current_path("/enquiry/complainant_details")
+    expect_page_to_have_h1("New enquiry")
+    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What are their contact details?")
+  end
+
+  def expect_to_be_on_enquiry_details_page
+    expect(page).to have_current_path("/enquiry/enquiry_details")
+    expect_page_to_have_h1("New enquiry")
+    expect(page).to have_css(".govuk-fieldset__legend--m", text: "What is the enquiry?")
+  end
+
+  # Trading Standards add investigation flow
+  def expect_to_be_on_risk_assessment_details_page
+    expect(page).to have_current_path("/ts_investigation/risk_assessments")
+    expect(page).to have_selector("h1", text: "Risk assessment details")
+  end
+
+  def expect_to_be_on_reference_number_page
+    expect(page).to have_current_path("/ts_investigation/reference_number")
+    expect(page).to have_selector("h1", text: "Add your own reference number")
+  end
+
+  def expect_to_be_on_what_product_are_you_reporting_page
+    expect(page).to have_current_path("/ts_investigation/product")
+    expect(page).to have_selector("h1", text: "What product are you reporting?")
+  end
+
+  def expect_to_be_on_why_reporting_page
+    expect(page).to have_current_path("/ts_investigation/why_reporting")
+    expect(page).to have_selector("h1", text: "Why are you reporting this product?")
+  end
+
+  def expect_to_be_on_supply_chain_page
+    expect(page).to have_current_path("/ts_investigation/which_businesses")
+    expect(page).to have_selector("h1", text: "Supply chain information")
+  end
+
+  def expect_to_be_on_business_details_page(title)
+    expect(page).to have_current_path("/ts_investigation/business")
+    expect(page).to have_selector("h1", text: "#{title} details")
+  end
+
+  def expect_to_be_on_corrective_action_taken_page
+    expect(page).to have_current_path("/ts_investigation/has_corrective_action")
+    expect(page).to have_selector("h1", text: "Has any corrective action been agreed or taken?")
+  end
+
+  def expect_to_be_on_record_corrective_action_page
+    expect(page).to have_current_path("/ts_investigation/corrective_action")
+    expect(page).to have_selector("h1", text: "Record corrective action")
+  end
+
+  def expect_to_be_on_other_information_page
+    expect(page).to have_current_path("/ts_investigation/other_information")
+    expect(page).to have_selector("h1", text: "Other information and files")
+  end
+
+  def expect_to_be_on_test_result_details_page
+    expect(page).to have_current_path("/ts_investigation/test_results")
+    expect(page).to have_selector("h1", text: "Test result details")
+  end
+
+  # Product pages
+  def expect_to_be_on_remove_attachment_from_product_confirmation_page
+    expect(page).to have_current_path("/products/#{product.id}/documents/#{document.id}/remove")
+    expect(page).to have_selector("h2", text: "Remove attachment")
+    expect(page).to have_link("Back", href: "/products/#{product.id}")
+  end
+
+  def expect_to_be_on_product_page
+    expect(page).to have_current_path("/products/#{product.id}")
+    expect(page).to have_selector("h1", text: product.name)
+  end
+
+  # Shared pages across different flows
+  def expect_to_be_on_coronavirus_page(path)
+    expect(page).to have_current_path(path)
+    expect(page).to have_selector("h1", text: "Is this case related to the coronavirus outbreak?")
+  end
+
+  # Login and account management pages
+  def expect_to_be_on_secondary_authentication_page
+    expect(page).to have_current_path(/\/two-factor/)
+    expect(page).to have_h1("Check your phone")
+  end
+
+  def expect_to_be_on_complete_registration_page
+    expect(page).to have_current_path(/\/complete-registration?.+$/)
+    expect(page).to have_h1("Create an account")
+    expect(page).to have_field("username", type: "email", with: invited_user.email, disabled: true)
+  end
+
+  def expect_to_be_on_signed_in_as_another_user_page
+    expect(page).to have_h1("You are already signed in to the Product safety database")
+  end
+
+  def expect_to_be_on_declaration_page
+    expect(page).to have_current_path(/^\/declaration$/)
+    expect(page).to have_title("Declaration - Product safety database - GOV.UK")
+  end
+
+  def expect_to_be_on_reset_password_page
+    expect(page).to have_current_path("/password/new")
+  end
+
+  def expect_to_be_on_edit_user_password_page
+    expect(page).to have_current_path("/password/edit", ignore_query: true)
+  end
+
+  def expect_to_be_on_check_your_email_page
+    expect(page).to have_css("h1", text: "Check your email")
+  end
+
+  def expect_to_be_on_password_changed_page
+    expect(page).to have_current_path("/password-changed")
+    expect(page).to have_css("h1", text: "You have changed your password successfully")
+  end
+
+  def expect_to_be_on_your_account_page
+    expect(page).to have_current_path("/account")
+    expect(page).to have_selector("h1", text: "Your account")
+  end
+
+  def expect_to_be_on_change_name_page
+    expect(page).to have_current_path("/account/name")
+    expect(page).to have_selector("h1", text: "Change your name")
+  end
+
+  def expect_to_be_on_team_page
+    expect(page).to have_css("h1", text: "test organisation")
+  end
+
+  def expect_to_be_on_invite_a_team_member_page
+    expect(page).to have_css("h1", text: "Invite a team member")
+  end
+end


### PR DESCRIPTION
This should help us to avoid duplication of the helper methods across different feature specs.

As part of this, I spotted that we had some identical helper methods, some slight variants, and some which were named the same thing but were asserting different pages (in which case I renamed one of them).

A few of the page expectations are used both within an edit scenario, where the ID of the thing is know as it is set up before the test using a factory, and a creation scenario, where the ID is generated as part of the flow. Rather than having 2 different helpers, I've merged them together and made the ID optional. If missing then the expectations uses a regex for the ID instead.