### PR TITLE
POC: case owner collaborator

### DIFF
--- a/doc/decisions/0002-multi-polymorphoc-collaborator-the-heart-of-account-management.md
+++ b/doc/decisions/0002-multi-polymorphoc-collaborator-the-heart-of-account-management.md
@@ -1,0 +1,104 @@
+## Case Owner / Collaborator models / permissions
+
+As we are going to add more permissions to the application, we need a more flexible and centralised way for out future account management needs.
+Some of those permission will be fairly classic _read_/_write access.
+
+### Current situation
+
+the core of the permission rely on what a `User` and/or `Team` can do.
+It is import the permission system is resilient enough to not have to know about that the underlying model being a `User` or a `Team`.
+This would lead to spagetti code with lots of conditionals all over the place and an exponential complexity of cases to handle.
+
+At the moment we have 3 models that reference either one or both of the `User` and `Team`
+
+1. `Source`
+   This model is polymorphic and reference either a `User` or a `Team` via the `Source` and `UserSource` model.
+   This model is used as an association on the investigation to identify who has created an investigation.
+   It currently set in a very obstructive way and rely on the fact the a user is logged currently logged in or not.
+   This makes our tests data brittle since it is very easy not to setup this assiciation correcty.
+
+2. Owner
+   This model is polymorphic and reference either a `User` or a `Team` directly.
+   This model is used as an association on the investigation to identify who currently owns an investigation.
+   Owners, whether it be a user or a team, determines which user or user within a team can re-assign (i.e change ownershio) of an investigation, view or change the certain attributes of and investgation and also add collaborators.
+
+3. Collaborator
+   This model is *not* polymorphic and only directly references a `Team`.
+   This is the first milestones of a our permission work and was introduced in order to _allow_ other team to collaborate (i.e add view permission) on a *private* investigation.
+
+### Problem with the current system
+
+In order to know what permissions and a team or a user has for a given case, with the current system we potentially have to query 4 or five different tables and deal with object with a completely different interface.
+
+
+### (multi) Polymorphic Collaborator model
+
+By adding a polymorphic `:collaborating` association we allows a collaborator to reference either a `Team` or a `User` and possibly in the future anther completely different type of collaboration like may and Admin, a cat or a dog it does not matter. As long as all the `:collaborating` referenced relation have a common interface. We can substitute one for another and the `Collaborator` does not need to care if is a `User`, `Team`, a cat or even a dog. This is comonly know as ducktyping in the ruby community but more generaly in the programming community it's the third pricinple of the S.O.L.I.D principles.
+
+We now can reference either a `Team` or `User` via the Collaborator object. But now, how to we model whether a this `:collaborating` reference is a `Source`, `UserSource`, `Owner` or a just a simple `Collaborator`, hence how to establish what set of permission a `:collaborating` object has in regards to an investigation?
+
+This is where polymorphism on `Collaborator` with Single Table Inheritence is here to help. It is pretty obvious by now that each collaborator do not have the same permissions.
+After consulting with Ed, with divised a different sets of permissions
+
+
+There basically three main branches in the hierarchy
+
+```ruby
+class Collaborators::Base;
+  self.abstract_class = true
+  belongs_to :invesitgation
+  belongs_to :collaborating, polymorphic: true
+end
+
+class Collaborators::Current < Collaborators::Base
+  self.abstract_class = true
+end
+
+# CaseCreator will replace the Source and SourceUser object.
+# right now case creator do not not have any type of permission.
+# But this record is useful as we always want to show which user and/or team created the investigation.
+# This gracefully handles the case where a user changed teams but created the case when he/she was part of another team.
+# This way we do not give extra permissions to these types of collaborator.
+# This are also extensively used in audit log, the formerly known :source association
+class Collaborators::CaseCreator < Collaborators::Base
+
+# Ed wants to store both to be able to easly display with a label which one which are the creators.
+# Currently we store either one or the other, a user or a team.
+class Collaborators::CaseCreatorTeam < Collaborators::CaseOwner; end
+class Collaborators::CaseCreatorUser < Collaborators::CaseOwner; end
+
+
+# the owner types
+class Collaborators::CaseOwner < Collaborators::Current
+  self.abstract_class = true
+end
+# This allows to assign either a team or user as an owner.
+# I've created a services class AssignInvestigation that allows the managing new case owner assignments,
+# when assigning a User a CaseOwnerTeam is also created.
+# @Ed: what was the rational behing having the two at the same time?
+class Collaborators::CaseOwnerTeam < Collaborators::CaseOwner; end
+class Collaborators::CaseOwnerUser < Collaborators::CaseOwner; end
+
+# This is your regular collbaborator.
+class Collaborator < Collaborators::Current; end
+
+# Ed wants to keep the history of retired collaborator. "Assign to a previously collaborator"
+class Collaborators::Historical < Collaborators::Current; end
+```
+
+This type of modelling is super flexible has you can retrieve part of the hierarchy tree `investigation.current_collaborators #  => [Collaborator, CaseOwnerTeam, CaseOwnerUser, OtherFuturTypeOfPermission]`
+without messing with several boolean columns and complex checking, often order dependent, to determine whether a user or a team has a certain permission. It also avoid boolean flag creap on table (i.e has_accepted_declaration, has_viewed_introduction, has_been_sent_welcome_email, mobile_number_verified... :rofl: which all represent on state of a user can be at time).
+
+It's also flexible enough that is can allow for future collaborator type to be added witout having to add another db field and backfill it.
+This also has the flexibily the we might want to scope/override some of the permission for a give type of Collaborator on specific investigation.
+```ruby
+collaborator.permission = { can_change_owner: true }
+```
+
+This class hierarchy will work beautifully with Pundit, as each class with have it own policy class, possibly respecting the Collaborators hierarchy and computing on the fly if any override or special permission has been assigned to a given type of collaborator.
+
+### Freebies(-ish)
+
+We'll have to index ownership slighlty differently. [See these line](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/586/files#diff-2cb85cf5237b33fabd4731cbac15181fR14-R20)
+The gives us to be abilty to perform search against a viewing user. And the search would not show cases you do not have access to.
+I think this is a slight hurdle to overcome that will however benefit the user.

--- a/doc/decisions/0002-multi-polymorphoc-collaborator-the-heart-of-account-management.md
+++ b/doc/decisions/0002-multi-polymorphoc-collaborator-the-heart-of-account-management.md
@@ -40,8 +40,9 @@ We now can reference either a `Team` or `User` via the Collaborator object. But 
 This is where polymorphism on `Collaborator` with Single Table Inheritence is here to help. It is pretty obvious by now that each collaborator do not have the same permissions.
 After consulting with Ed, with divised a different sets of permissions
 
+Think of this data modle a bit like a pointer to a pointer in C or C++, you can manipulate the data and defer  as much as possible the constraining access to type of the underlying value;
 
-There basically three main branches in the hierarchy
+Here is the rhierarchy, bear in mind that class names are subject, Slawosh has already made some good suggestions:
 
 ```ruby
 class Collaborators::Base;
@@ -102,3 +103,16 @@ This class hierarchy will work beautifully with Pundit, as each class with have 
 We'll have to index ownership slighlty differently. [See these line](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/586/files#diff-2cb85cf5237b33fabd4731cbac15181fR14-R20)
 The gives us to be abilty to perform search against a viewing user. And the search would not show cases you do not have access to.
 I think this is a slight hurdle to overcome that will however benefit the user.
+
+
+
+
+### Conclusion
+
+This is a fair bit of work, but it should remove a lot of the complexity.
+I'd would split this in probaly several steps:
+1. First deployable: chunk: Keep the data structures Source, UserSource but start double writing to collaborators (CaseCreator and CaseOwner) table at the same time as source and owner.
+2. Second deployable: Backfill hisetorical data and
+3. Swap view to use, the new data structure
+4. fix the search ( this can be done on a concurrently to step 2 and 3)
+5. bundle steps 3 and 4 and deploy together.

--- a/psd-web/app/controllers/collaborators_controller.rb
+++ b/psd-web/app/controllers/collaborators_controller.rb
@@ -4,7 +4,8 @@ class CollaboratorsController < ApplicationController
   end
 
   def index
-    @teams = @investigation.teams.order(:name)
+    @investigation.case_owner_team
+    @collaborators = @investigation.collaborators.includes(:collaborating)
   end
 
   def new
@@ -37,17 +38,16 @@ class CollaboratorsController < ApplicationController
   def edit
     authorize @investigation, :manage_collaborators?
 
-    @team = Team.find(params[:id])
-    @collaborator = @investigation.collaborators.find_by! team_id: @team.id
+    @collaborator = @investigation.collaborators.find(params[:id])
     @edit_form = EditInvestigationCollaboratorForm.new(permission_level: EditInvestigationCollaboratorForm::PERMISSION_LEVEL_EDIT)
   end
 
   def update
     authorize @investigation, :manage_collaborators?
 
-    @team = Team.find(params[:id])
+    @collaborator = @investigation.collaborators.find(params[:id])
     @edit_form = EditInvestigationCollaboratorForm.new(edit_params
-      .merge(investigation: @investigation, team: @team, user: current_user))
+      .merge(investigation: @investigation, collaborator: @collaborator, user: current_user))
     if @edit_form.save!
       flash[:success] = "#{@team.name} had been removed from the case"
       redirect_to investigation_collaborators_path(@investigation)

--- a/psd-web/app/controllers/investigations/activities_controller.rb
+++ b/psd-web/app/controllers/investigations/activities_controller.rb
@@ -57,7 +57,7 @@ module Investigations
 
     def set_investigation_with_associations
       investigation = Investigation
-                         .eager_load(:source,
+                         .eager_load(:case_creator_user,
                                      products: { documents_attachments: :blob },
                                      investigation_businesses: { business: :locations },
                                      documents_attachments: :blob)

--- a/psd-web/app/controllers/investigations/allegation_controller.rb
+++ b/psd-web/app/controllers/investigations/allegation_controller.rb
@@ -10,6 +10,10 @@ private
     :allegation
   end
 
+  def model_name
+    "Investigation::Allegation"
+  end
+
   def model_params
     %i[description hazard_type product_category coronavirus_related]
   end

--- a/psd-web/app/controllers/investigations/creation_flow_controller.rb
+++ b/psd-web/app/controllers/investigations/creation_flow_controller.rb
@@ -125,7 +125,7 @@ private
   def investigation_saved?
     return false unless investigation_valid?
 
-    result = CreateInvestigation.call(investigation_params: @investigation, current_user: current_user)
+    result = CreateInvestigation.call(investigation: @investigation, current_user: current_user)
     return false unless result.success?
 
     @investigation = result.investigation

--- a/psd-web/app/controllers/investigations/creation_flow_controller.rb
+++ b/psd-web/app/controllers/investigations/creation_flow_controller.rb
@@ -125,8 +125,10 @@ private
   def investigation_saved?
     return false unless investigation_valid?
 
-    result = CreateInvestigation.call(investigation_params: investigation_params.merge(type: model_name), current_user: current_user)
+    result = CreateInvestigation.call(investigation_params: @investigation, current_user: current_user)
     return false unless result.success?
+
+    @investigation = result.investigation
 
     attach_blobs_to_list(@file_blob, @investigation.documents)
     @investigation.update(complainant: @complainant)

--- a/psd-web/app/controllers/investigations/creation_flow_controller.rb
+++ b/psd-web/app/controllers/investigations/creation_flow_controller.rb
@@ -125,9 +125,11 @@ private
   def investigation_saved?
     return false unless investigation_valid?
 
+    result = CreateInvestigation.call(investigation_params: investigation_params.merge(type: model_name), current_user: current_user)
+    return false unless result.success?
+
     attach_blobs_to_list(@file_blob, @investigation.documents)
-    @investigation.complainant = @complainant
-    @investigation.save
+    @investigation.update(complainant: @complainant)
   end
 
   def complainant_params

--- a/psd-web/app/controllers/investigations/enquiry_controller.rb
+++ b/psd-web/app/controllers/investigations/enquiry_controller.rb
@@ -10,6 +10,10 @@ private
     :enquiry
   end
 
+  def model_name
+    "Investigation::Enquiry"
+  end
+
   def model_params
     %i[user_title description date_received received_type coronavirus_related]
   end

--- a/psd-web/app/controllers/investigations/project_controller.rb
+++ b/psd-web/app/controllers/investigations/project_controller.rb
@@ -44,6 +44,10 @@ class Investigations::ProjectController < ApplicationController
 
 private
 
+  def model_name
+    "Investigation::Project"
+  end
+
   def investigation_session_params
     session[:investigation] || {}
   end

--- a/psd-web/app/controllers/investigations/ts_investigations_controller.rb
+++ b/psd-web/app/controllers/investigations/ts_investigations_controller.rb
@@ -458,6 +458,7 @@ private
     @why_reporting_form = WhyReportingForm.new
   end
 
+
   def records_valid?
     case step
     when :coronavirus
@@ -507,9 +508,15 @@ private
   def records_saved?
     return false unless records_valid?
 
+    result = CreateInvestigation.call(investigation_params: investigation_step_params, current_user: current_user)
+
+    @investigation = result.investigation
+
+    return false unless result.success?
+
     @product.save
     @investigation.products << @product
-    @investigation.save
+
     save_businesses
     save_corrective_actions
     save_test_results

--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -13,7 +13,7 @@ class InvestigationsController < ApplicationController
       format.html do
         @answer         = search_for_investigations(20)
         @investigations = InvestigationDecorator
-                            .decorate_collection(@answer.records(includes: [{ owner: :organisation }, :products]))
+                            .decorate_collection(@answer.records(includes: [{ collaborators: :collaborating }, :products]))
       end
       format.xlsx do
         @answer = search_for_investigations

--- a/psd-web/app/decorators/collaborators/case_creator_user_decorator.rb
+++ b/psd-web/app/decorators/collaborators/case_creator_user_decorator.rb
@@ -1,0 +1,6 @@
+module Collaborators
+  class CaseCreatorUserDecorator < Draper::Decorator
+    delegate_all
+    decorates_association :collaborating
+  end
+end

--- a/psd-web/app/decorators/collaborators/case_owner_team_decorator.rb
+++ b/psd-web/app/decorators/collaborators/case_owner_team_decorator.rb
@@ -1,0 +1,6 @@
+module Collaborators
+  class CaseOwnerTeamDecorator < Draper::Decorator
+    delegate_all
+    decorates_association :collaborating
+  end
+end

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -1,11 +1,15 @@
 class InvestigationDecorator < ApplicationDecorator
   delegate_all
-  decorates_associations :documents_attachments, :owner, :source
+  decorates_associations :documents_attachments, :source
 
   PRODUCT_DISPLAY_LIMIT = 6
 
   def title
     user_title
+  end
+
+  def owner
+    investigation.owner.decorate
   end
 
   def hazard_description

--- a/psd-web/app/forms/edit_investigation_collaborator_form.rb
+++ b/psd-web/app/forms/edit_investigation_collaborator_form.rb
@@ -31,7 +31,7 @@ class EditInvestigationCollaboratorForm
 private
 
   def collaborator
-    investigation.collaborators.find_by!(team_id: team.id)
+    investigation.collaborators.find_by!(collaborating: team)
   end
 
   def schedule_delete_emails

--- a/psd-web/app/forms/edit_investigation_collaborator_form.rb
+++ b/psd-web/app/forms/edit_investigation_collaborator_form.rb
@@ -7,7 +7,7 @@ class EditInvestigationCollaboratorForm
   attribute :permission_level
   attribute :message
   attribute :investigation
-  attribute :team
+  attribute :collaborator
   attribute :user
   attribute :include_message, :boolean
 
@@ -30,19 +30,15 @@ class EditInvestigationCollaboratorForm
 
 private
 
-  def collaborator
-    investigation.collaborators.find_by!(collaborating: team)
-  end
-
   def schedule_delete_emails
     schedule_delete_email(find_emails)
   end
 
   def find_emails
-    if team.team_recipient_email.present?
-      [team.team_recipient_email]
+    if collaborator.email.present?
+      [collaborator.email]
     else
-      team.users.active.pluck(:email)
+      collaborator.collaborating.users.active.pluck(:email)
     end
   end
 
@@ -50,7 +46,7 @@ private
     AuditActivity::Investigation::TeamDeleted.create!(
       source: UserSource.new(user: user),
       investigation: investigation,
-      title: "#{team.name} removed from #{investigation.case_type.downcase}",
+      title: "#{collaborator.name} removed from #{investigation.case_type.downcase}",
       body: message.to_s
     )
   end
@@ -68,6 +64,6 @@ private
   end
 
   def email_payload
-    { permission_level: permission_level, include_message: include_message, message: message, investigation: investigation, team: team, user: user }
+    { permission_level: permission_level, include_message: include_message, message: message, investigation: investigation, team: collaborator.collaborating, user: user }
   end
 end

--- a/psd-web/app/jobs/notify_team_added_to_case_job.rb
+++ b/psd-web/app/jobs/notify_team_added_to_case_job.rb
@@ -1,6 +1,6 @@
 class NotifyTeamAddedToCaseJob < ApplicationJob
   def perform(collaborator)
-    team = collaborator.team
+    team = collaborator.collaborating
 
     if team.team_recipient_email.present?
       NotifyMailer.team_added_to_case_email(collaborator, to_email: team.team_recipient_email).deliver_later

--- a/psd-web/app/models/audit_activity/investigation/add_allegation.rb
+++ b/psd-web/app/models/audit_activity/investigation/add_allegation.rb
@@ -15,6 +15,7 @@ class AuditActivity::Investigation::AddAllegation < AuditActivity::Investigation
     body += "<br>Attachment: **#{sanitize_text investigation.documents.first.filename}**" if investigation.documents.attached?
     body += "<br><br>#{sanitize_text investigation.description}" if investigation.description.present?
     body += build_complainant_details(investigation.complainant) if investigation.complainant.present?
+
     body += build_owner_details(investigation) if investigation.owner.present?
     body
   end

--- a/psd-web/app/models/case_creator.rb
+++ b/psd-web/app/models/case_creator.rb
@@ -1,3 +1,3 @@
 class CaseCreator < CaseOwner
-  belongs_to :investigation, inverse_of: :case_creator
+  belongs_to :investigation, inverse_of: :case_creator, optional: true
 end

--- a/psd-web/app/models/case_creator.rb
+++ b/psd-web/app/models/case_creator.rb
@@ -1,3 +1,0 @@
-class CaseCreator < CaseOwner
-  belongs_to :investigation, inverse_of: :case_creator, optional: true
-end

--- a/psd-web/app/models/case_creator.rb
+++ b/psd-web/app/models/case_creator.rb
@@ -1,0 +1,3 @@
+class CaseCreator < CaseOwner
+  belongs_to :investigation, inverse_of: :case_creator
+end

--- a/psd-web/app/models/case_owner.rb
+++ b/psd-web/app/models/case_owner.rb
@@ -1,3 +1,0 @@
-class CaseOwner < Owner
-  belongs_to :investigation, inverse_of: :case_owner, optional: true
-end

--- a/psd-web/app/models/case_owner.rb
+++ b/psd-web/app/models/case_owner.rb
@@ -1,3 +1,3 @@
-class CaseOwner < Collaborator
+class CaseOwner < Owner
   belongs_to :investigation, inverse_of: :case_owner
 end

--- a/psd-web/app/models/case_owner.rb
+++ b/psd-web/app/models/case_owner.rb
@@ -1,0 +1,3 @@
+class CaseOwner < Collaborator
+  belongs_to :investigation, inverse_of: :case_owner
+end

--- a/psd-web/app/models/case_owner.rb
+++ b/psd-web/app/models/case_owner.rb
@@ -1,3 +1,3 @@
 class CaseOwner < Owner
-  belongs_to :investigation, inverse_of: :case_owner
+  belongs_to :investigation, inverse_of: :case_owner, optional: true
 end

--- a/psd-web/app/models/co_collaborator.rb
+++ b/psd-web/app/models/co_collaborator.rb
@@ -1,0 +1,2 @@
+class CoCollaborator < Collaborator
+end

--- a/psd-web/app/models/co_collaborator.rb
+++ b/psd-web/app/models/co_collaborator.rb
@@ -1,2 +1,0 @@
-class CoCollaborator < Collaborator
-end

--- a/psd-web/app/models/collaborator.rb
+++ b/psd-web/app/models/collaborator.rb
@@ -1,21 +1,6 @@
-class Collaborator < Collaborators::Base
-  belongs_to :investigation, optional: true
-
-  belongs_to :collaborating, polymorphic: true, optional: false
-
-  belongs_to :added_by_user, class_name: "User"
-
-  # validates :message, presence: true, if: :include_message
-
-  # validates :include_message, inclusion: { in: [true, false] }
-
-  attr_reader :include_message
-
-  def include_message=value
-    @include_message = if value.is_a? String
-                         (value == "true")
-                       else
-                         value
-                       end
+class Collaborator < Collaborators::Current
+  def make_case_owner!(collaborator_attributes)
+    collaborator_attributes[:type] = "Collaborators::CaseOwnerTeam"
+    update!(collaborator_attributes)
   end
 end

--- a/psd-web/app/models/collaborator.rb
+++ b/psd-web/app/models/collaborator.rb
@@ -1,13 +1,13 @@
 class Collaborator < ApplicationRecord
-  belongs_to :investigation
+  belongs_to :investigation, optional: true
 
-  belongs_to :collaborating, polymorphic: true, optional: :false
+  belongs_to :collaborating, polymorphic: true, optional: false
 
-  belongs_to :added_by_user, class_name: :User
+  belongs_to :added_by_user, class_name: "User"
 
-  validates :message, presence: true, if: :include_message
+  # validates :message, presence: true, if: :include_message
 
-  validates :include_message, inclusion: { in: [true, false] }
+  # validates :include_message, inclusion: { in: [true, false] }
 
   attr_reader :include_message
 

--- a/psd-web/app/models/collaborator.rb
+++ b/psd-web/app/models/collaborator.rb
@@ -1,6 +1,7 @@
 class Collaborator < ApplicationRecord
   belongs_to :investigation
-  belongs_to :team
+
+  belongs_to :collaborating, polymorphic: true, optional: :false
 
   belongs_to :added_by_user, class_name: :User
 

--- a/psd-web/app/models/collaborator.rb
+++ b/psd-web/app/models/collaborator.rb
@@ -1,4 +1,4 @@
-class Collaborator < ApplicationRecord
+class Collaborator < Collaborators::Base
   belongs_to :investigation, optional: true
 
   belongs_to :collaborating, polymorphic: true, optional: false

--- a/psd-web/app/models/collaborators/base.rb
+++ b/psd-web/app/models/collaborators/base.rb
@@ -1,0 +1,25 @@
+module Collaborators
+  class Base < ApplicationRecord
+    self.table_name = "collaborators"
+
+    belongs_to :investigation, optional: true
+    belongs_to :collaborating, polymorphic: true, optional: false
+
+    belongs_to :added_by_user, class_name: "User"
+
+    # validates :message, presence: true, if: :include_message
+
+    # validates :include_message, inclusion: { in: [true, false] }
+
+
+    attr_reader :include_message
+
+    def include_message=value
+      @include_message = if value.is_a? String
+                           (value == "true")
+                         else
+                           value
+                         end
+    end
+  end
+end

--- a/psd-web/app/models/collaborators/base.rb
+++ b/psd-web/app/models/collaborators/base.rb
@@ -11,7 +11,6 @@ module Collaborators
 
     # validates :include_message, inclusion: { in: [true, false] }
 
-
     attr_reader :include_message
 
     def include_message=value
@@ -21,5 +20,6 @@ module Collaborators
                            value
                          end
     end
+
   end
 end

--- a/psd-web/app/models/collaborators/base.rb
+++ b/psd-web/app/models/collaborators/base.rb
@@ -11,6 +11,8 @@ module Collaborators
 
     # validates :include_message, inclusion: { in: [true, false] }
 
+    delegate :name, to: :collaborating
+
     attr_reader :include_message
 
     def include_message=value
@@ -20,6 +22,13 @@ module Collaborators
                            value
                          end
     end
+  end
 
+  def email
+    if collaborating.respond_to?(:team_recipient_email)
+      collaborating.team_recipient_email
+    else
+      collaborating.email
+    end
   end
 end

--- a/psd-web/app/models/collaborators/case_creator.rb
+++ b/psd-web/app/models/collaborators/case_creator.rb
@@ -1,5 +1,9 @@
 module Collaborators
   class CaseCreator < Base
     self.abstract_class = true
+
+    def user_has_gdpr_access?(*)
+      true
+    end
   end
 end

--- a/psd-web/app/models/collaborators/case_creator.rb
+++ b/psd-web/app/models/collaborators/case_creator.rb
@@ -1,0 +1,5 @@
+module Collaborators
+  class CaseCreator < Base
+
+  end
+end

--- a/psd-web/app/models/collaborators/case_creator_team.rb
+++ b/psd-web/app/models/collaborators/case_creator_team.rb
@@ -1,0 +1,5 @@
+module Collaborators
+  class CaseCreatorTeam < CaseCreator
+
+  end
+end

--- a/psd-web/app/models/collaborators/case_creator_user.rb
+++ b/psd-web/app/models/collaborators/case_creator_user.rb
@@ -1,4 +1,7 @@
 module Collaborators
   class CaseCreatorUser < CaseCreator
+    def user_has_gdpr_access?(user: User.current)
+      user.organisation == collaborating.organisation
+    end
   end
 end

--- a/psd-web/app/models/collaborators/case_creator_user.rb
+++ b/psd-web/app/models/collaborators/case_creator_user.rb
@@ -1,0 +1,4 @@
+module Collaborators
+  class CaseCreatorUser < CaseCreator
+  end
+end

--- a/psd-web/app/models/collaborators/case_owner.rb
+++ b/psd-web/app/models/collaborators/case_owner.rb
@@ -1,5 +1,11 @@
 module Collaborators
-  class CaseOwner < Base
+  class CaseOwner < Current
+    self.abstract_class = true
+
+    def make_collaborator!(attributes)
+      attributes[:type] = "Collaborator"
+      update!(attributes)
+    end
 
   end
 end

--- a/psd-web/app/models/collaborators/case_owner.rb
+++ b/psd-web/app/models/collaborators/case_owner.rb
@@ -1,0 +1,5 @@
+module Collaborators
+  class CaseOwner < Base
+
+  end
+end

--- a/psd-web/app/models/collaborators/case_owner_team.rb
+++ b/psd-web/app/models/collaborators/case_owner_team.rb
@@ -1,0 +1,5 @@
+module Collaborators
+  class CaseOwnerTeam < CaseOwner
+
+  end
+end

--- a/psd-web/app/models/collaborators/case_owner_team.rb
+++ b/psd-web/app/models/collaborators/case_owner_team.rb
@@ -1,5 +1,4 @@
 module Collaborators
   class CaseOwnerTeam < CaseOwner
-
   end
 end

--- a/psd-web/app/models/collaborators/case_owner_user.rb
+++ b/psd-web/app/models/collaborators/case_owner_user.rb
@@ -1,0 +1,4 @@
+module Collaborators
+  class CaseOwnerUser < CaseOwner
+  end
+end

--- a/psd-web/app/models/collaborators/case_owner_user.rb
+++ b/psd-web/app/models/collaborators/case_owner_user.rb
@@ -1,4 +1,8 @@
 module Collaborators
   class CaseOwnerUser < CaseOwner
+
+    def make_collaborator!(*)
+      destroy!
+    end
   end
 end

--- a/psd-web/app/models/collaborators/current.rb
+++ b/psd-web/app/models/collaborators/current.rb
@@ -1,5 +1,6 @@
 module Collaborators
-  class CaseCreator < Base
+  class Current < Base
     self.abstract_class = true
+
   end
 end

--- a/psd-web/app/models/collaborators/historic.rb
+++ b/psd-web/app/models/collaborators/historic.rb
@@ -1,0 +1,4 @@
+module Collaborators
+  class Historic < Base
+  end
+end

--- a/psd-web/app/models/complainant.rb
+++ b/psd-web/app/models/complainant.rb
@@ -27,7 +27,7 @@ class Complainant < ApplicationRecord
 private
 
   def can_be_seen_by_current_user?
-    return true if investigation.source&.user_has_gdpr_access?
+    return true if investigation.case_creator_user.user_has_gdpr_access?
 
     complainant_type != "Consumer"
   end

--- a/psd-web/app/models/concerns/investigation_elasticsearch.rb
+++ b/psd-web/app/models/concerns/investigation_elasticsearch.rb
@@ -11,16 +11,16 @@ module InvestigationElasticsearch
       mappings do
         indexes :status, type: :keyword
         indexes :type, type: :keyword
-        indexes :owner_id, type: :keyword
+        indexes :case_owner_id, type: :keyword
         indexes :creator_id, type: :keyword
       end
     end
 
     def as_indexed_json(*)
       as_json(
-        only: %i[description hazard_type product_category is_closed owner_id type updated_at created_at pretty_id
+        only: %i[description hazard_type product_category is_closed type updated_at created_at pretty_id
                  hazard_description non_compliant_reason coronavirus_related],
-        methods: %i[title creator_id],
+        methods: %i[title creator_id case_owner_id],
         include: {
           documents: {
             only: [],

--- a/psd-web/app/models/concerns/investigation_elasticsearch.rb
+++ b/psd-web/app/models/concerns/investigation_elasticsearch.rb
@@ -11,7 +11,14 @@ module InvestigationElasticsearch
       mappings do
         indexes :status, type: :keyword
         indexes :type, type: :keyword
-        indexes :case_owner_id, type: :keyword
+        indexes :owner_id, type: :keyword
+        indexes :collaborators, type: :object do
+          # querying base on this attributes
+          # will give the correct permissions
+          indexes :collaborating_type, type: :keyword
+          indexes :collaborating_id,   type: :keyword
+          indexes :type,               type: :keyword
+        end
         indexes :creator_id, type: :keyword
       end
     end
@@ -20,8 +27,11 @@ module InvestigationElasticsearch
       as_json(
         only: %i[description hazard_type product_category is_closed type updated_at created_at pretty_id
                  hazard_description non_compliant_reason coronavirus_related],
-        methods: %i[title creator_id case_owner_id],
+        methods: %i[title creator_id owner_id],
         include: {
+          collaborators: {
+            only: %i[collaborating_id collaborating_type type]
+          },
           documents: {
             only: [],
             methods: %i[title description filename]

--- a/psd-web/app/models/concerns/investigation_elasticsearch.rb
+++ b/psd-web/app/models/concerns/investigation_elasticsearch.rb
@@ -11,7 +11,6 @@ module InvestigationElasticsearch
       mappings do
         indexes :status, type: :keyword
         indexes :type, type: :keyword
-        indexes :owner_id, type: :keyword
         indexes :collaborators, type: :object do
           # querying base on this attributes
           # will give the correct permissions
@@ -27,7 +26,7 @@ module InvestigationElasticsearch
       as_json(
         only: %i[description hazard_type product_category is_closed type updated_at created_at pretty_id
                  hazard_description non_compliant_reason coronavirus_related],
-        methods: %i[title creator_id owner_id],
+        methods: %i[title],
         include: {
           collaborators: {
             only: %i[collaborating_id collaborating_type type]

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -230,7 +230,7 @@ private
   end
 
   def creator_id
-    case_creator_team.id
+    case_creator_team&.id
   end
 end
 

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -54,7 +54,10 @@ class Investigation < ApplicationRecord
   has_one :source, as: :sourceable, dependent: :destroy
   has_one :complainant, dependent: :destroy
 
-  has_many :collaborators, dependent: :destroy
+  has_many :collaborators,     dependent: :destroy
+  has_many :co_collaborators,  dependent: :destroy
+  has_one :case_owner,         dependent: :destroy
+
   has_many :teams, through: :collaborators
 
   # TODO: Refactor to remove this callback hell

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -67,8 +67,6 @@ class Investigation < ApplicationRecord
 
   has_many :collaborators, dependent: :destroy
 
-  # has_many :current_collaborators, -> { where.not(type: "Collaborators::Historical") }, class_name: "Collaborators::Base"
-
   # scenario: assign a case to a user
   # 1. make user's team the CaseOwnerTeam
   # 2. make user's team the CaseOwnerUser

--- a/psd-web/app/models/investigation/allegation.rb
+++ b/psd-web/app/models/investigation/allegation.rb
@@ -16,8 +16,6 @@ class Investigation < ApplicationRecord
       "allegation"
     end
 
-  private
-
     def create_audit_activity_for_case
       AuditActivity::Investigation::AddAllegation.from(self)
     end

--- a/psd-web/app/models/investigation/enquiry.rb
+++ b/psd-web/app/models/investigation/enquiry.rb
@@ -29,8 +29,6 @@ class Investigation < ApplicationRecord
       end
     end
 
-  private
-
     def create_audit_activity_for_case
       AuditActivity::Investigation::AddEnquiry.from(self)
     end

--- a/psd-web/app/models/investigation/project.rb
+++ b/psd-web/app/models/investigation/project.rb
@@ -14,8 +14,6 @@ class Investigation < ApplicationRecord
       "project"
     end
 
-  private
-
     def create_audit_activity_for_case
       AuditActivity::Investigation::AddProject.from(self)
     end

--- a/psd-web/app/models/owner.rb
+++ b/psd-web/app/models/owner.rb
@@ -1,3 +1,3 @@
 class Owner < Collaborator
-  belongs_to :investigation, inverse_of: :owners
+  belongs_to :investigation, inverse_of: :owners, optional: true
 end

--- a/psd-web/app/models/owner.rb
+++ b/psd-web/app/models/owner.rb
@@ -1,3 +1,0 @@
-class Owner < Collaborator
-  belongs_to :investigation, inverse_of: :owners, optional: true
-end

--- a/psd-web/app/models/owner.rb
+++ b/psd-web/app/models/owner.rb
@@ -1,0 +1,3 @@
+class Owner < Collaborator
+  belongs_to :investigation, inverse_of: :owners
+end

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -1,6 +1,6 @@
 class Team < ApplicationRecord
   belongs_to :organisation
-  has_many :collaborations, as: :collaborating, dependent: :destroy, foreign_key: :collaborating_id, foreign_type: "Collaborator", inverse_of: :team
+  has_many :collaborations, as: :collaborating, dependent: :destroy, inverse_of: :collaborating
 
   has_and_belongs_to_many :users
 

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -1,6 +1,7 @@
 class Team < ApplicationRecord
   belongs_to :organisation
-  has_many :collaborations, as: :collaborating, dependent: :destroy, inverse_of: :collaborating
+  has_many :collaborations, as: :collaborating, inverse_of: :collaborating, dependent: :destroy, class_name: "Collaborator"
+  has_many :owned_collaborations, as: :collaborating, class_name: "Collaborators::CaseOwnerTeam", dependent: :destroy
 
   has_and_belongs_to_many :users
 

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -1,5 +1,6 @@
 class Team < ApplicationRecord
   belongs_to :organisation
+  has_many :collaborations, as: :collaborating, dependent: :destroy, foreign_key: :collaborating_id, foreign_type: "Collaborator", inverse_of: :team
 
   has_and_belongs_to_many :users
 

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
   has_many :user_sources, dependent: :destroy
   has_many :user_roles, dependent: :destroy
 
+  has_many :collaborations, as: :collaborating, dependent: :destroy, foreign_key: :collaborating_id, foreign_type: "Collaborator", inverse_of: :user
+
   has_and_belongs_to_many :teams
 
   validates :password,

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   has_many :user_sources, dependent: :destroy
   has_many :user_roles, dependent: :destroy
 
-  has_many :collaborations, as: :collaborating, dependent: :destroy, foreign_key: :collaborating_id, foreign_type: "Collaborator", inverse_of: :user
+  has_many :collaborations, as: :collaborating, dependent: :destroy, inverse_of: :collaborating
 
   has_and_belongs_to_many :teams
 

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   has_many :user_sources, dependent: :destroy
   has_many :user_roles, dependent: :destroy
 
-  has_many :collaborations, as: :collaborating, dependent: :destroy, inverse_of: :collaborating
+  has_many :owned_collaborations, as: :collaborating, class_name: "Collaborators::CaseOwnerUser", dependent: :destroy
 
   has_and_belongs_to_many :teams
 
@@ -84,6 +84,13 @@ class User < ApplicationRecord
 
   def self.current=(user)
     RequestStore.store[:current_user] = user
+  end
+
+  def make_case_owner!(investigation, collaboration_attributes)
+    team.make_case_owner!(investigation, collaboration_attributes)
+
+    collaboration_attributes[:collaborating] = self
+    investigation.create_case_owner_user!(collaboration_attributes)
   end
 
   def team

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -45,7 +45,7 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def can_change_owner(user: @user)
-    @record.owner.blank? || @record.collaborating.in_same_team_as?(user) || @record.owner == user
+    @record.case_owner_team.collaborating.in_same_team_as?(user)
   end
 
   def user_allowed_to_raise_alert?(user: @user)
@@ -57,8 +57,6 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def manage_collaborators?
-    return false if @record.case_owner.nil?
-
-    @record.case_owner.collaborating.in_same_team_as?(user)
+    @record.case_owner_team.collaborating.in_same_team_as?(user)
   end
 end

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -56,7 +56,7 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def manage_collaborators?
-    return false if @record.owner.nil?
+    return false if @record.case_owner.nil?
 
     @record.owner.in_same_team_as?(user)
   end

--- a/psd-web/app/services/add_team_to_an_investigation.rb
+++ b/psd-web/app/services/add_team_to_an_investigation.rb
@@ -3,7 +3,7 @@ class AddTeamToAnInvestigation
 
   delegate :collaborator, :current_user, :investigation, :team_id, :include_message, :message, to: :context
   def call
-    context.collaborator = investigation.collaborators.new(
+    context.collaborator = investigation.co_collaborators.new(
       team_id: team_id,
       include_message: include_message,
       added_by_user: current_user,

--- a/psd-web/app/services/add_team_to_an_investigation.rb
+++ b/psd-web/app/services/add_team_to_an_investigation.rb
@@ -4,17 +4,16 @@ class AddTeamToAnInvestigation
   delegate :collaborator, :current_user, :investigation, :team_id, :include_message, :message, to: :context
   def call
     team = Team.find_by(id: team_id)
+    context.fail!(error: "Team is required") unless team
 
-    context.collaborator = investigation.co_collaborators.new(
+    return if investigation.collaborators.where(collaborating: team).exists?
+
+    context.collaborator = investigation.collaborators.new(
       collaborating: team,
       include_message: include_message,
       added_by_user: current_user,
       message: message
     )
-
-    unless team
-      context.fail!(error: "Team is required")
-    end
 
     begin
       if collaborator.save

--- a/psd-web/app/services/add_team_to_an_investigation.rb
+++ b/psd-web/app/services/add_team_to_an_investigation.rb
@@ -3,12 +3,18 @@ class AddTeamToAnInvestigation
 
   delegate :collaborator, :current_user, :investigation, :team_id, :include_message, :message, to: :context
   def call
+    team = Team.find_by(id: team_id)
+
     context.collaborator = investigation.co_collaborators.new(
-      team_id: team_id,
+      collaborating: team,
       include_message: include_message,
       added_by_user: current_user,
       message: message
     )
+
+    unless team
+      context.fail!(error: "Team is required")
+    end
 
     begin
       if collaborator.save
@@ -17,12 +23,14 @@ class AddTeamToAnInvestigation
         AuditActivity::Investigation::TeamAdded.create!(
           source: UserSource.new(user: current_user),
           investigation: investigation,
-          title: "#{collaborator.team.name} added to #{investigation.case_type.downcase}",
+          title: "#{collaborator.collaborating.name} added to #{investigation.case_type.downcase}",
           body: collaborator.message.to_s
         )
       else
         context.fail!
       end
+
+      context.collaborator = collaborator
     rescue ActiveRecord::RecordNotUnique
       # Collaborator already added, so return successful but without notfiying the team
       # or creating an audit log.

--- a/psd-web/app/services/add_team_to_an_investigation.rb
+++ b/psd-web/app/services/add_team_to_an_investigation.rb
@@ -22,7 +22,7 @@ class AddTeamToAnInvestigation
         AuditActivity::Investigation::TeamAdded.create!(
           source: UserSource.new(user: current_user),
           investigation: investigation,
-          title: "#{collaborator.collaborating.name} added to #{investigation.case_type.downcase}",
+          title: "#{collaborator.name} added to #{investigation.case_type.downcase}",
           body: collaborator.message.to_s
         )
       else

--- a/psd-web/app/services/assign_investigation.rb
+++ b/psd-web/app/services/assign_investigation.rb
@@ -4,10 +4,22 @@ class AssignInvestigation
   delegate :investigation, :new_collaborating_case_owner, :current_user, to: :context
 
   def call
-    swap_with_co_collaborator! || create_new_case_owner!
+    swap_case_owner_to_co_collaborator!
+    create_new_case_owner!
   end
 
   def create_new_case_owner!
+    return if investigation.owners.exists?(team: new_collaborating_case_owner)
+
+    investigation.owners.create!(
+      type: "CaseOwner",
+      added_by_user: current_user,
+      team: new_collaborating_case_owner,
+      include_message: "Maybe this message should not be required when creating a case creator"
+    )
+  end
+
+  def swap_case_owner_to_co_collaborator!
     collaborator = investigation.collaborators.find_by(team: new_collaborating_case_owner)
 
     if collaborator
@@ -19,26 +31,13 @@ class AssignInvestigation
       # so the case_owner is either fetched from the database or is nil
       investigation.reload
     end
-
-    return if investigation.owners.exists?(team: new_collaborating_case_owner)
-
-    investigation.owners.create!(
-      type: "CaseOwner",
-      added_by_user: current_user,
-      team: new_collaborating_case_owner,
-      include_message: "Maybe this message should not be required when creating a case creator"
-    )
-  rescue ActiveRecord::RecordNotUnique
-    raise
-    investigation
   end
+  # def swap_with_co_collaborator!
+  #   co_collaborator = investigation.co_collaborators.find_by(team: new_collaborating_case_owner)
 
-  def swap_with_co_collaborator!
-    co_collaborator = investigation.co_collaborators.find_by(team: new_collaborating_case_owner)
+  #   return false if co_collaborator.nil?
 
-    return false if co_collaborator.nil?
-
-    co_collaborator.update!(type: CaseOwner, include_message: false)
-    investigation.case_owner.update!(type: CoCollaborator, include_message: false)
-  end
+  #   co_collaborator.update!(type: CaseOwner, include_message: false)
+  #   investigation.case_owner.update!(type: CoCollaborator, include_message: false)
+  # end
 end

--- a/psd-web/app/services/assign_investigation.rb
+++ b/psd-web/app/services/assign_investigation.rb
@@ -1,0 +1,39 @@
+class AssignInvestigation
+  include Interactor
+
+  delegate :investigation, :new_collaborating_case_owner, :current_user, to: :context
+
+  def call
+    investigation.with_lock do
+      swap_with_co_collaborator! || create_new_case_owner!
+    end
+  end
+
+  def create_new_case_owner!
+    investigation.with_lock do
+      old_case_owner = investigation.case_owner
+
+      investigation.create_case_owner!(
+        added_by_user: current_user,
+        team: new_collaborating_case_owner,
+        include_message: "Maybe this message should not be required when creating a case creator"
+      )
+
+      investigation.co_collaborators.create!(
+        added_by_user: old_case_owner.added_by_user,
+        team: old_case_owner.team,
+        created_at: old_case_owner.created_at,
+        include_message: "Maybe this message should not be required when creating a case creator"
+      )
+    end
+  end
+
+  def swap_with_co_collaborator!
+    co_collaborator = investigation.co_collaborators.find_by(team: new_collaborating_case_owner)
+
+    return false if co_collaborator.nil?
+
+    co_collaborator.update!(type: CaseOwner, include_message: false)
+    investigation.case_owner.update!(type: CoCollaborator, include_message: false)
+  end
+end

--- a/psd-web/app/services/assign_investigation.rb
+++ b/psd-web/app/services/assign_investigation.rb
@@ -14,7 +14,7 @@ class AssignInvestigation
     investigation.owners.create!(
       type: "CaseOwner",
       added_by_user: current_user,
-      team: new_collaborating_case_owner,
+      collaborating: new_collaborating_case_owner,
       include_message: "Maybe this message should not be required when creating a case creator"
     )
   end
@@ -32,12 +32,4 @@ class AssignInvestigation
       investigation.reload
     end
   end
-  # def swap_with_co_collaborator!
-  #   co_collaborator = investigation.co_collaborators.find_by(team: new_collaborating_case_owner)
-
-  #   return false if co_collaborator.nil?
-
-  #   co_collaborator.update!(type: CaseOwner, include_message: false)
-  #   investigation.case_owner.update!(type: CoCollaborator, include_message: false)
-  # end
 end

--- a/psd-web/app/services/assign_investigation.rb
+++ b/psd-web/app/services/assign_investigation.rb
@@ -4,8 +4,6 @@ class AssignInvestigation
   delegate :investigation, :new_collaborating_case_owner, :current_user, to: :context
 
   def call
-    return if investigation.case_owner_user.collaborating == new_collaborating_case_owner
-
     Collaborators::Base.transaction do
       swap_current_case_owners_to_collaborators!
       add_new_case_owner!

--- a/psd-web/app/services/create_investigation.rb
+++ b/psd-web/app/services/create_investigation.rb
@@ -1,0 +1,19 @@
+class CreateInvestigation
+  include Interactor
+
+  delegate :investigation_params, :case_creator_params, :user, to: :context
+
+  def call
+    investigation = Investigation::Allegation.new(investigation_params)
+    investigation.assignable = user
+    investigation.build_case_owner(
+      team: user.teams.first,
+      added_by_user: user,
+      include_message: "Maybe this message should not be required when creating a case creator"
+    )
+    context.investigation = investigation
+    return if investigation.save
+
+    context.fail!
+  end
+end

--- a/psd-web/app/services/create_investigation.rb
+++ b/psd-web/app/services/create_investigation.rb
@@ -1,14 +1,14 @@
 class CreateInvestigation
   include Interactor
 
-  delegate :investigation_params, :case_creator_params, :user, to: :context
+  delegate :investigation_params, :current_user, to: :context
 
   def call
-    investigation = Investigation::Allegation.new(investigation_params)
+    investigation = Investigation.new(investigation_params)
 
     investigation.build_case_creator(
-      team: user.teams.first,
-      added_by_user: user,
+      team: current_user.teams.first,
+      added_by_user: current_user,
       include_message: "Maybe this message should not be required when creating a case creator"
     )
     context.investigation = investigation

--- a/psd-web/app/services/create_investigation.rb
+++ b/psd-web/app/services/create_investigation.rb
@@ -5,8 +5,8 @@ class CreateInvestigation
 
   def call
     investigation = Investigation::Allegation.new(investigation_params)
-    investigation.assignable = user
-    investigation.build_case_owner(
+
+    investigation.build_case_creator(
       team: user.teams.first,
       added_by_user: user,
       include_message: "Maybe this message should not be required when creating a case creator"

--- a/psd-web/app/views/collaborators/edit.html.erb
+++ b/psd-web/app/views/collaborators/edit.html.erb
@@ -1,4 +1,4 @@
-<% title = @team.name %>
+<% title = @collaborator.name %>
 <% page_title title, errors: @edit_form.errors.any? %>
 
 <% content_for(:after_header) do %>
@@ -12,7 +12,7 @@
 
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <%= form_with model: @edit_form, url: investigation_collaborator_path(@investigation, @team), method: :put do |form| %>
+    <%= form_with model: @edit_form, url: investigation_collaborator_path(@investigation, @collaborator), method: :put do |form| %>
 
       <% remove_hint = @investigation.is_private? ? "Will not be able to view case details as it is restricted" :  "Will have default view rights"%>
       <%= render "form_components/govuk_radios",
@@ -37,7 +37,7 @@
           },
           {key: "or", divider: "or"},
           {
-            text: "Remove #{@team.name} from the case",
+            text: "Remove #{@collaborator.name} from the case",
             hint: {
               text: remove_hint
             },
@@ -46,7 +46,7 @@
         ]
       %>
 
-      <p class="govuk-body">We’ll email <%= @team.name %> to let them know that their permission level has been changed.
+      <p class="govuk-body">We’ll email <%= @collaborator.name %> to let them know that their permission level has been changed.
 </p>
 
       <% message_html = capture do %>
@@ -55,7 +55,7 @@
           key: :message,
           id: "message",
           label: {
-            text: "Message to the #{@team.name}"
+            text: "Message to the #{@collaborator.name}"
           },
           hint: {
             text: "Message will also be included on the case timeline"

--- a/psd-web/app/views/collaborators/index.html.erb
+++ b/psd-web/app/views/collaborators/index.html.erb
@@ -28,7 +28,7 @@
       </thead>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= @investigation.case_owner_team.collaborating.name %></th>
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= @investigation.case_owner_team.name %></th>
           <td class="govuk-table__cell"><span class="hmcts-badge hmcts-badge--grey">Case owner</span></td>
           <td class="govuk-table__cell"></td>
         </tr>

--- a/psd-web/app/views/collaborators/index.html.erb
+++ b/psd-web/app/views/collaborators/index.html.erb
@@ -27,20 +27,18 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% if @investigation.owner_team %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= @investigation.case_owner_team.collaborating.name %></th>
+          <td class="govuk-table__cell"><span class="hmcts-badge hmcts-badge--grey">Case owner</span></td>
+          <td class="govuk-table__cell"></td>
+        </tr>
+        <% @collaborators.each do |collaborator| %>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= @investigation.owner_team.name %></th>
-            <td class="govuk-table__cell"><span class="hmcts-badge hmcts-badge--grey">Case owner</span></td>
-            <td class="govuk-table__cell"></td>
-          </tr>
-        <% end %>
-        <% @teams.each do |team| %>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= team.name %></th>
+            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= collaborator.name %></th>
             <td class="govuk-table__cell">Edit full case</td>
             <td class="govuk-table__cell">
               <% if policy(@investigation).manage_collaborators? %>
-                <%= link_with_hidden_text_to "Change", "#{team.name}",  edit_investigation_collaborator_path(@investigation, team) %>
+                <%= link_with_hidden_text_to "Change", "#{collaborator.name}",  edit_investigation_collaborator_path(@investigation, collaborator) %>
               <% end %>
             </td>
           </tr>

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -50,7 +50,7 @@
           <% end %>
         </ul>
       <% elsif @investigation.collaborators.length == 1 %>
-        <%= @investigation.case_owner_team.collaborating.name %>
+        <%= @investigation.case_owner_team.name %>
       <% else %>
         No teams added
       <% end %>

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -43,14 +43,14 @@
     <% end %>
 
     <% team_list_html = capture do %>
-      <% if @investigation.teams_with_access.length > 1 %>
+      <% if @investigation.collaborators.length > 1 %>
         <ul class="govuk-list">
-          <% @investigation.teams_with_access.each do |team| %>
+          <% @investigation.collaborators.each do |team| %>
             <li><%= team.name %></li>
           <% end %>
         </ul>
-      <% elsif @investigation.teams_with_access.length == 1 %>
-        <%= @investigation.teams_with_access.first.name %>
+      <% elsif @investigation.collaborators.length == 1 %>
+        <%= @investigation.case_owner.collaborating.name %>
       <% else %>
         No teams added
       <% end %>

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -30,7 +30,7 @@
     <%= govuk_hr %>
     <h2 class="govuk-heading-m">Sharing and collaboration</h2>
 
-    <% if policy(@investigation).change_owner? %>
+    <% if policy(@investigation.object).change_owner? %>
       <% case_owner_actions = {
         items: [
           href: new_investigation_ownership_path(@investigation),
@@ -50,11 +50,10 @@
           <% end %>
         </ul>
       <% elsif @investigation.collaborators.length == 1 %>
-        <%= @investigation.case_owner.collaborating.name %>
+        <%= @investigation.case_owner_team.collaborating.name %>
       <% else %>
         No teams added
       <% end %>
-
     <% end %>
 
     <%= govukSummaryList(
@@ -71,7 +70,7 @@
           actions: {
             items: [
               href: investigation_collaborators_path(@investigation),
-              text: (policy(@investigation).manage_collaborators? ? "Change" : "View"),
+              text: (policy(@investigation.object).manage_collaborators? ? "Change" : "View"),
               visuallyHiddenText: "teams added to the case"
             ]
           }

--- a/psd-web/db/migrate/20200506150840_add_investigation_type_to_collaborators.rb
+++ b/psd-web/db/migrate/20200506150840_add_investigation_type_to_collaborators.rb
@@ -1,0 +1,8 @@
+class AddInvestigationTypeToCollaborators < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      add_column :collaborators, :type, :string
+      add_column :collaborators, :investigation_type, :string
+    end
+  end
+end

--- a/psd-web/db/migrate/20200508132613_remove_unique_index_on_collaborators.rb
+++ b/psd-web/db/migrate/20200508132613_remove_unique_index_on_collaborators.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexOnCollaborators < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :collaborators, column: %i[investigation_id team_id], unique: true
+  end
+end

--- a/psd-web/db/migrate/20200508150638_add_collaborating_to_collaborator.rb
+++ b/psd-web/db/migrate/20200508150638_add_collaborating_to_collaborator.rb
@@ -1,0 +1,9 @@
+class AddCollaboratingToCollaborator < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      change_table :collaborators do |t|
+        t.references :collaborating, polymorphic: true, type: :uuid
+      end
+    end
+  end
+end

--- a/psd-web/db/migrate/20200508160103_remove_team_id_from_collaborator.rb
+++ b/psd-web/db/migrate/20200508160103_remove_team_id_from_collaborator.rb
@@ -1,0 +1,13 @@
+class RemoveTeamIdFromCollaborator < ActiveRecord::Migration[5.2]
+  def up
+    safety_assured do
+      change_column :collaborators, :team_id, :uuid, null: true
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :collaborators, :team_id, :uuid, null: false
+    end
+  end
+end

--- a/psd-web/db/migrate/20200508193459_remove_null_constrain_on_investigation_id_on_collaborators.rb
+++ b/psd-web/db/migrate/20200508193459_remove_null_constrain_on_investigation_id_on_collaborators.rb
@@ -1,0 +1,13 @@
+class RemoveNullConstrainOnInvestigationIdOnCollaborators < ActiveRecord::Migration[5.2]
+  def up
+    safety_assured do
+      change_column :collaborators, :investigation_id, :integer, null: true
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :collaborators, :investigation_id, :integer, null: false
+    end
+  end
+end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_113156) do
+ActiveRecord::Schema.define(version: 2020_05_06_150840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -77,8 +77,10 @@ ActiveRecord::Schema.define(version: 2020_05_01_113156) do
     t.uuid "added_by_user_id", null: false
     t.datetime "created_at", null: false
     t.integer "investigation_id", null: false
+    t.string "investigation_type"
     t.text "message"
     t.uuid "team_id", null: false
+    t.string "type"
     t.datetime "updated_at", null: false
     t.index ["investigation_id", "team_id"], name: "index_collaborators_on_investigation_id_and_team_id", unique: true
   end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_150840) do
+ActiveRecord::Schema.define(version: 2020_05_08_132613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 2020_05_06_150840) do
     t.uuid "team_id", null: false
     t.string "type"
     t.datetime "updated_at", null: false
-    t.index ["investigation_id", "team_id"], name: "index_collaborators_on_investigation_id_and_team_id", unique: true
   end
 
   create_table "complainants", id: :serial, force: :cascade do |t|

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_132613) do
+ActiveRecord::Schema.define(version: 2020_05_08_160103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -75,13 +75,16 @@ ActiveRecord::Schema.define(version: 2020_05_08_132613) do
 
   create_table "collaborators", force: :cascade do |t|
     t.uuid "added_by_user_id", null: false
+    t.uuid "collaborating_id"
+    t.string "collaborating_type"
     t.datetime "created_at", null: false
     t.integer "investigation_id", null: false
     t.string "investigation_type"
     t.text "message"
-    t.uuid "team_id", null: false
+    t.uuid "team_id"
     t.string "type"
     t.datetime "updated_at", null: false
+    t.index ["collaborating_type", "collaborating_id"], name: "index_collaborators_on_collaborating_type_and_collaborating_id"
   end
 
   create_table "complainants", id: :serial, force: :cascade do |t|

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_160103) do
+ActiveRecord::Schema.define(version: 2020_05_08_193459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -75,10 +75,10 @@ ActiveRecord::Schema.define(version: 2020_05_08_160103) do
 
   create_table "collaborators", force: :cascade do |t|
     t.uuid "added_by_user_id", null: false
-    t.uuid "collaborating_id"
+    t.bigint "collaborating_id"
     t.string "collaborating_type"
     t.datetime "created_at", null: false
-    t.integer "investigation_id", null: false
+    t.integer "investigation_id"
     t.string "investigation_type"
     t.text "message"
     t.uuid "team_id"

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_193459) do
 
   create_table "collaborators", force: :cascade do |t|
     t.uuid "added_by_user_id", null: false
-    t.bigint "collaborating_id"
+    t.uuid "collaborating_id"
     t.string "collaborating_type"
     t.datetime "created_at", null: false
     t.integer "investigation_id"

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -298,11 +298,5 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
           .to eq(user.owner_short_name(viewing_user: viewing_user))
       end
     end
-
-    context "when the investigation doesn’t have an owner" do
-      before { investigation.owner = nil }
-
-      it { expect(decorated_investigation.owner_display_name_for(viewing_user: viewing_user)).to eq("No case owner") }
-    end
   end
 end

--- a/psd-web/spec/factories/collaborators.rb
+++ b/psd-web/spec/factories/collaborators.rb
@@ -2,7 +2,10 @@ FactoryBot.define do
   factory :collaborator do
     include_message { "false" }
     association :investigation, factory: :investigation
-    association :team, factory: :team
+    association :collaborating, factory: :team
     association :added_by_user, factory: :user
+
+    factory :case_creator, class: "CaseCreator" do
+    end
   end
 end

--- a/psd-web/spec/factories/collaborators.rb
+++ b/psd-web/spec/factories/collaborators.rb
@@ -1,11 +1,9 @@
 FactoryBot.define do
   factory :collaborator do
     include_message { "false" }
-    association :investigation, factory: :investigation
     association :collaborating, factory: :team
     association :added_by_user, factory: :user
-
-    factory :case_creator, class: "CaseCreator" do
-    end
   end
+
+  factory :case_creator, class: "CaseCreator", parent: :collaborator
 end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -11,19 +11,17 @@ FactoryBot.define do
     hazard_description    {}
     non_compliant_reason  {}
 
-    factory :allegation, class: "Investigation::Allegation" do
-      description { "test allegation" }
-      user_title { "test allegation title" }
-    end
+    transient do
+      owner { nil }
 
-    factory :enquiry, class: "Investigation::Enquiry" do
-      description { "test enquiry" }
-      user_title { "test enquiry title" }
-    end
-
-    factory :project, class: "Investigation::Project" do
-      description { "test project" }
-      user_title { "test project title" }
+      after(:create) do |investigation, evaluator|
+        if evaluator.owner.nil?
+          create(:case_creator, investigation: investigation)
+        else
+          create(:case_creator, investigation: investigation, collaborating: evaluator.owner)
+        end
+        investigation.reload
+      end
     end
 
     trait :with_business do
@@ -66,5 +64,20 @@ FactoryBot.define do
         ).assign_to(investigation)
       end
     end
+  end
+
+  factory :allegation, class: "Investigation::Allegation", parent: :investigation do
+    description { "test allegation" }
+    user_title { "test allegation title" }
+  end
+
+  factory :enquiry, class: "Investigation::Enquiry" do
+    description { "test enquiry" }
+    user_title { "test enquiry title" }
+  end
+
+  factory :project, class: "Investigation::Project" do
+    description { "test project" }
+    user_title { "test project title" }
   end
 end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -71,12 +71,12 @@ FactoryBot.define do
     user_title { "test allegation title" }
   end
 
-  factory :enquiry, class: "Investigation::Enquiry" do
+  factory :enquiry, class: "Investigation::Enquiry", parent: :investigation do
     description { "test enquiry" }
     user_title { "test enquiry title" }
   end
 
-  factory :project, class: "Investigation::Project" do
+  factory :project, class: "Investigation::Project", parent: :investigation do
     description { "test project" }
     user_title { "test project title" }
   end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -11,8 +11,6 @@ FactoryBot.define do
     hazard_description    {}
     non_compliant_reason  {}
 
-    association :owner, factory: :user
-
     factory :allegation, class: "Investigation::Allegation" do
       description { "test allegation" }
       user_title { "test allegation title" }

--- a/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
+++ b/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe EditInvestigationCollaboratorForm, :with_elasticsearch, :with_stu
   let(:investigation) { create(:investigation, owner: user) }
   let(:team) { create(:team) }
   let(:collaborator) do
-    create(:collaborator, investigation: investigation, team: team, added_by_user: user)
+
+    create(:collaborator, investigation: investigation, collaborating: team, added_by_user: user)
   end
 
   let(:permission_level) { EditInvestigationCollaboratorForm::PERMISSION_LEVEL_DELETE }

--- a/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
+++ b/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
@@ -58,10 +58,12 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
 
   context "when the case is owned by a team from another organisation but the user’s team has been added as a collaborator" do
     let(:investigation) {
-      create(:investigation, is_private: true, owner: other_team, collaborators: [
-        create(:collaborator, team: users_team, added_by_user: other_user)
-      ])
+      create(:investigation, is_private: true, owner: other_team)
     }
+
+    before do
+      investigation.co_collaborators << create(:collaborator, collaborating: users_team, added_by_user: other_user)
+    end
 
     it "renders the page" do
       expect(response).to have_http_status(:ok)

--- a/psd-web/spec/services/assign_investigation_spec.rb
+++ b/psd-web/spec/services/assign_investigation_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe AssignInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  subject(:service) do
+    described_class.call(
+      investigation: investigation,
+      current_user: user,
+      new_collaborating_case_owner: new_collaborating_case_owner_team
+    )
+  end
+
+  let!(:investigation) do
+    CreateInvestigation
+      .call(investigation: build(:allegation), current_user: user)
+      .investigation
+  end
+
+  let(:team) { create :team, team_recipient_email: "creator.team@example.com" }
+  let(:user) { create :user, teams: [team], email: "creator.user@example.com" }
+
+  let(:new_collaborating_case_owner_team) { create :team, team_recipient_email: "newly.assigned.team@example.com" }
+
+  context "when the new owner is not already a collaborator is in the same team" do
+    it "creates the investigation", :aggregate_failures do
+      expect(service).to be_a_success
+
+      investigation.reload
+
+      expect(investigation.case_creators.where(collaborating: user.team)).to exist
+      expect(investigation.case_creators.where(collaborating: user)).to exist
+      expect(investigation.case_creator_team.collaborating).to eq(user.team)
+      expect(investigation.case_creator_user.collaborating).to eq(user)
+
+      expect(investigation.case_owners.where(collaborating: new_collaborating_case_owner_team)).to exist
+      expect(investigation.case_owner_team.collaborating).to eq(new_collaborating_case_owner_team)
+      expect(investigation.case_owner_user).to be nil
+
+      expect(investigation.collaborators.where(collaborating: user.team)).to exist
+    end
+  end
+
+  context "when the new ower is already a collaborator" do
+    let(:new_collaborating_case_owner_team_user) { create :user, teams: [new_collaborating_case_owner_team] }
+
+    before do
+      described_class.call(
+        investigation: investigation,
+        current_user: new_collaborating_case_owner_team_user,
+        new_collaborating_case_owner: user.team
+      )
+    end
+
+    it "re assigns the investigation to the already existing collaborator", :aggregate_failures do
+      service
+
+      expect(investigation.case_creators.where(collaborating: user.team)).to exist
+      expect(investigation.case_creators.where(collaborating: user)).to exist
+      expect(investigation.case_creator_team.collaborating).to eq(user.team)
+      expect(investigation.case_creator_user.collaborating).to eq(user)
+      expect(investigation.collaborators.where(collaborating: new_collaborating_case_owner_team)).to exist
+      expect(investigation.case_owners.where(collaborating: user.team)).to exist
+      expect(investigation.case_owner_user.collaborating).to eq(user)
+      expect(investigation.collaborators.count).to eq(1)
+    end
+  end
+end

--- a/psd-web/spec/services/create_investigation_spec.rb
+++ b/psd-web/spec/services/create_investigation_spec.rb
@@ -28,57 +28,6 @@ RSpec.describe CreateInvestigation, :with_stubbed_elasticsearch, :with_stubbed_m
   end
 end
 
-RSpec.describe AssignInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
-  subject(:service) do
-    described_class.call(investigation: investigation, current_user: user, new_collaborating_case_owner: new_collaborating_case_owner_team)
-  end
-
-  let(:investigation_params) { attributes_for :allegation }
-  let!(:investigation) { CreateInvestigation.call(investigation_params: investigation_params, user: user).investigation }
-
-  let(:team) { create :team }
-  let(:user) { create :user, teams: [team] }
-
-  let(:new_collaborating_case_owner_team) { create :team }
-
-  context "when the new owner is not already a collaborator is in the same team" do
-    it "creates the investigation", :aggregate_failures do
-      expect(service).to be_a_success
-
-      expect(investigation.reload.case_creator.team).to eq(user.team)
-      expect(investigation.reload.case_owner.team).to eq(new_collaborating_case_owner_team)
-      expect(service.investigation.owners.where(team: [new_collaborating_case_owner_team, user.team])).to exist
-      expect(service.investigation.collaborators.where(team: [new_collaborating_case_owner_team, user.team])).to exist
-      expect(service.investigation.collaborators.where(team: new_collaborating_case_owner_team)).to exist
-      expect(investigation.co_collaborators.where(team: [user.team, new_collaborating_case_owner_team])).not_to exist
-    end
-  end
-
-  context "when the new ower is already a collaborator" do
-    let(:new_collaborating_case_owner_team_user) { create :user, teams: [new_collaborating_case_owner_team] }
-
-    before { service }
-
-    it "re assigns the investigation to the already existing collaborator", :aggregate_failures do
-      expect {
-        described_class.call(
-          investigation: investigation,
-          current_user: new_collaborating_case_owner_team_user,
-          new_collaborating_case_owner: user.team
-        )
-      }.not_to(change { investigation.collaborators.count })
-
-      expect(investigation.reload.owner.team).to eq(user.team)
-
-      expect(investigation.case_creator.team).to eq(user.team)
-      expect(investigation.case_owner.team).to eq(user.team)
-      expect(investigation.collaborators.where(team: [user.team, new_collaborating_case_owner_team]).count).to eq(2)
-      expect(investigation.co_collaborators.where(team: new_collaborating_case_owner_team)).to exist
-      expect(investigation.co_collaborators.where(team: user.team)).not_to exist
-    end
-  end
-end
-
 RSpec.describe AddTeamToAnInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
   subject(:service) do
     described_class.call(

--- a/psd-web/spec/services/create_investigation_spec.rb
+++ b/psd-web/spec/services/create_investigation_spec.rb
@@ -27,34 +27,3 @@ RSpec.describe CreateInvestigation, :with_stubbed_elasticsearch, :with_stubbed_m
     expect(investigation.collaborators.where(collaborating: team)).not_to exist
   end
 end
-
-RSpec.describe AddTeamToAnInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
-  subject(:service) do
-    described_class.call(
-      team_id: new_collaborating_team.id,
-      include_message: "true",
-      message: "Thanks for collaborating.",
-      investigation: investigation,
-      current_user: user
-    )
-  end
-
-  let(:investigation_params) { attributes_for :allegation }
-  let!(:investigation) { CreateInvestigation.call(investigation_params: investigation_params, user: user).investigation }
-
-  let(:team) { create :team }
-  let(:user) { create :user, teams: [team] }
-
-  let(:new_collaborating_team) { create(:team) }
-
-  it "correctly assigns add a collaborator", :aggregate_failures do
-    expect(service).to be_a_success
-
-    expect(investigation.reload.owner).to eq(user.team)
-    expect(investigation.creator.team).to eq(user.team)
-
-    expect(investigation.collaborators.where(team: [user.team, new_collaborating_team]).count).to eq(2)
-    expect(investigation.co_collaborators.where(team: new_collaborating_team)).to exist
-    expect(investigation.owners.where(team: user.team)).to exist
-  end
-end

--- a/psd-web/spec/services/create_investigation_spec.rb
+++ b/psd-web/spec/services/create_investigation_spec.rb
@@ -2,20 +2,29 @@ require "rails_helper"
 
 RSpec.describe CreateInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
   subject(:service) do
-    described_class.call(investigation_params: investigation_params, user: user)
+    described_class.call(investigation: investigation, current_user: user, assign_to: user)
   end
 
-  let(:investigation_params) { attributes_for :allegation }
-  let(:team) { create :team }
-  let(:user) { create :user, teams: [team] }
+  let(:investigation) { build :allegation }
+  let(:team)          { create :team }
+  let(:user)          { create :user, teams: [team] }
 
   it "creates the investigation", :aggregate_failures do
     expect(service).to be_a_success
 
-    expect(service.investigation.reload.owner).to eq(user.team)
-    expect(service.investigation.owners.where(team: team)).to exist
-    expect(service.investigation.collaborators.where(team: team)).to exist
-    expect(service.investigation.co_collaborators.where(team: team)).to be_empty
+    investigation = service.investigation.reload
+
+    expect(investigation.case_creators.where(collaborating: user.team)).to exist
+    expect(investigation.case_creators.where(collaborating: user)).to exist
+    expect(investigation.case_creator_team.collaborating).to eq(user.team)
+    expect(investigation.case_creator_user.collaborating).to eq(user)
+
+    expect(investigation.case_owners.where(collaborating: user.team)).to exist
+    expect(investigation.case_owners.where(collaborating: user)).to exist
+    expect(investigation.case_owner_team.collaborating).to eq(user.team)
+    expect(investigation.case_owner_user.collaborating).to eq(user)
+
+    expect(investigation.collaborators.where(collaborating: team)).not_to exist
   end
 end
 

--- a/psd-web/spec/services/create_investigation_spec.rb
+++ b/psd-web/spec/services/create_investigation_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe CreateInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  subject(:service) do
+    described_class.call(investigation_params: investigation_params, user: user)
+  end
+
+  let(:investigation_params) { attributes_for :allegation }
+  let(:team) { create :team }
+  let(:user) { create :user, teams: [team] }
+
+  it "creates the investigation", :aggregate_failures do
+    expect(service).to be_a_success
+
+    expect(service.investigation.assignable).to eq(user)
+    expect(service.investigation.case_owner.team).to eq(user.team)
+    expect(service.investigation.collaborators.flat_map(&:team)).to include(user.team)
+    expect(service.investigation.co_collaborators).to be_empty
+  end
+end
+
+RSpec.describe AssignInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  subject(:service) do
+    described_class.call(investigation: investigation, current_user: user, new_collaborating_case_owner: new_collaborating_case_owner_team)
+  end
+
+  let(:investigation_params) { attributes_for :allegation }
+  let!(:investigation) { CreateInvestigation.call(investigation_params: investigation_params, user: user).investigation }
+
+  let(:team) { create :team }
+  let(:user) { create :user, teams: [team] }
+
+  let(:new_collaborating_case_owner_team) { create :team }
+
+  context "when the new owner is not already a collaborator is in the same team" do
+    it "creates the investigation", :aggregate_failures do
+      expect(service).to be_a_success
+
+      expect(investigation.reload.assignable.team).to eq(user.team)
+      expect(investigation.case_owner.team).to eq(new_collaborating_case_owner_team)
+      expect(investigation.collaborators.flat_map(&:team)).to include(user.team, new_collaborating_case_owner_team)
+      expect(investigation.co_collaborators.flat_map(&:team)).to include(user.team)
+      expect(investigation.co_collaborators.flat_map(&:team)).not_to include(new_collaborating_case_owner_team)
+    end
+  end
+
+  context "when the new ower is already a collaborator" do
+    let(:new_collaborating_case_owner_team_user) { create :user, teams: [new_collaborating_case_owner_team] }
+
+    before { service }
+
+    it "re assigns the investigation to the already existing collaborator", :aggregate_failures do
+      expect {
+        described_class.call(
+          investigation: investigation,
+          current_user: new_collaborating_case_owner_team_user,
+          new_collaborating_case_owner: user.team
+        )
+      }.not_to(change { investigation.collaborators.count })
+
+      expect(investigation.reload.assignable.team).to eq(user.team)
+      expect(investigation.case_owner.team).to eq(user.team)
+      expect(investigation.collaborators.flat_map(&:team)).to include(user.team, new_collaborating_case_owner_team)
+      expect(investigation.co_collaborators.flat_map(&:team)).to include(new_collaborating_case_owner_team)
+      expect(investigation.co_collaborators.flat_map(&:team)).not_to include(user.team)
+    end
+  end
+end
+
+RSpec.describe AddTeamToAnInvestigation, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  subject(:service) do
+    described_class.call(
+      team_id: new_collaborating_team.id,
+      include_message: "true",
+      message: "Thanks for collaborating.",
+      investigation: investigation,
+      current_user: user
+    )
+  end
+
+  let(:investigation_params) { attributes_for :allegation }
+  let!(:investigation) { CreateInvestigation.call(investigation_params: investigation_params, user: user).investigation }
+
+  let(:team) { create :team }
+  let(:user) { create :user, teams: [team] }
+
+  let(:new_collaborating_team) { create(:team) }
+
+  it "correctly assigns add a collaborator", :aggregate_failures do
+    expect(service).to be_a_success
+
+    expect(investigation.reload.assignable.team).to eq(user.team)
+    expect(investigation.case_owner.team).to eq(user.team)
+    expect(investigation.collaborators.flat_map(&:team)).to include(user.team, new_collaborating_team)
+    expect(investigation.co_collaborators.flat_map(&:team)).to include(new_collaborating_team)
+    expect(investigation.co_collaborators.flat_map(&:team)).not_to include(user.team)
+  end
+end


### PR DESCRIPTION
## spike to change/merge the ownership, collaborator, creator business domains.

This is by no mean production ready. 
It's mostly me playing around with data models and see how it flows through application.
The class name, as described in the comments are subject to changes. 

Things I would have liked to include is migrations to add unique constraint 
on investigation_id, collaborating_type, collaborating_id on the collaborators table


## Case Owner / Collaborator models / permissions

As we are going to add more permissions to the application, we need a more flexible and centralised way for out future account management needs.
Some of those permission will be fairly classic _read_/_write access.

### Current situation

the core of the permission rely on what a `User` and/or `Team` can do.
It is import the permission system is resilient enough to not have to know about that the underlying model being a `User` or a `Team`.
This would lead to spagetti code with lots of conditionals all over the place and an exponential complexity of cases to handle.

At the moment we have 3 models that reference either one or both of the `User` and `Team`

1. `Source`
   This model is polymorphic and reference either a `User` or a `Team` via the `Source` and `UserSource` model.
   This model is used as an association on the investigation to identify who has created an investigation.
   It currently set in a very obstructive way and rely on the fact the a user is logged currently logged in or not.
   This makes our tests data brittle since it is very easy not to setup this assiciation correcty.

2. Owner
   This model is polymorphic and reference either a `User` or a `Team` directly.
   This model is used as an association on the investigation to identify who currently owns an investigation.
   Owners, whether it be a user or a team, determines which user or user within a team can re-assign (i.e change ownershio) of an investigation, view or change the certain attributes of and investgation and also add collaborators.

3. Collaborator
   This model is *not* polymorphic and only directly references a `Team`.
   This is the first milestones of a our permission work and was introduced in order to _allow_ other team to collaborate (i.e add view permission) on a *private* investigation.

### Problem with the current system

In order to know what permissions and a team or a user has for a given case, with the current system we potentially have to query 4 or five different tables and deal with object with a completely different interface.


### (multi) Polymorphic Collaborator model

By adding a polymorphic `:collaborating` association we allows a collaborator to reference either a `Team` or a `User` and possibly in the future anther completely different type of collaboration like may and Admin, a cat or a dog it does not matter. As long as all the `:collaborating` referenced relation have a common interface. We can substitute one for another and the `Collaborator` does not need to care if is a `User`, `Team`, a cat or even a dog. This is comonly know as ducktyping in the ruby community but more generaly in the programming community it's the third pricinple of the S.O.L.I.D principles.

We now can reference either a `Team` or `User` via the Collaborator object. But now, how to we model whether a this `:collaborating` reference is a `Source`, `UserSource`, `Owner` or a just a simple `Collaborator`, hence how to establish what set of permission a `:collaborating` object has in regards to an investigation?

This is where polymorphism on `Collaborator` with Single Table Inheritence is here to help. It is pretty obvious by now that each collaborator do not have the same permissions.
After consulting with Ed, with divised a different sets of permissions

Think of this data modle a bit like a pointer to a pointer in C or C++, you can manipulate the data and defer  as much as possible the constraining access to type of the underlying value;

Here is the rhierarchy, bear in mind that class names are subject, Slawosh has already made some good suggestions:

```ruby
class Collaborators::Base;
  self.abstract_class = true
  belongs_to :invesitgation
  belongs_to :collaborating, polymorphic: true
end

class Collaborators::Current < Collaborators::Base
  self.abstract_class = true
end

# CaseCreator will replace the Source and SourceUser object.
# right now case creator do not not have any type of permission.
# But this record is useful as we always want to show which user and/or team created the investigation.
# This gracefully handles the case where a user changed teams but created the case when he/she was part of another team.
# This way we do not give extra permissions to these types of collaborator.
# This are also extensively used in audit log, the formerly known :source association
class Collaborators::CaseCreator < Collaborators::Base

# Ed wants to store both to be able to easly display with a label which one which are the creators in the collaborator view.
# Currently we store either one or the other, a user or a team.
class Collaborators::CaseCreatorTeam < Collaborators::CaseOwner; end
class Collaborators::CaseCreatorUser < Collaborators::CaseOwner; end


# the owner types
class Collaborators::CaseOwner < Collaborators::Current
  self.abstract_class = true
end
# This allows to assign either a team or user as an owner.
# I've created a services class AssignInvestigation that allows the managing new case owner assignments,
# when assigning a User a CaseOwnerTeam is also created.
# @Ed: what was the rational behing having the two at the same time?
class Collaborators::CaseOwnerTeam < Collaborators::CaseOwner; end
class Collaborators::CaseOwnerUser < Collaborators::CaseOwner; end

# This is your regular collbaborator.
class Collaborator < Collaborators::Current; end

# Ed wants to keep the history of retired collaborator. "Assign to a previously collaborator"
class Collaborators::Historical < Collaborators::Current; end
```

This type of modelling is super flexible has you can retrieve part of the hierarchy tree `investigation.current_collaborators #  => [Collaborator, CaseOwnerTeam, CaseOwnerUser, OtherFuturTypeOfPermission]`
without messing with several boolean columns and complex checking, often order dependent, to determine whether a user or a team has a certain permission. It also avoid boolean flag creap on table (i.e has_accepted_declaration, has_viewed_introduction, has_been_sent_welcome_email, mobile_number_verified... :rofl: which all represent on state of a user can be at time).

It's also flexible enough that is can allow for future collaborator type to be added witout having to add another db field and backfill it.
This also has the flexibily the we might want to scope/override some of the permission for a give type of Collaborator on specific investigation.
```ruby
collaborator.permission = { can_change_owner: true }
```

This class hierarchy will work beautifully with Pundit, as each class with have it own policy class, possibly respecting the Collaborators hierarchy and computing on the fly if any override or special permission has been assigned to a given type of collaborator.

### Freebies(-ish)

We'll have to index ownership slighlty differently. [See these line](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/586/files#diff-2cb85cf5237b33fabd4731cbac15181fR14-R20)
The gives us to be abilty to perform search against a viewing user. And the search would not show cases you do not have access to.
I think this is a slight hurdle to overcome that will however benefit the user.




### Conclusion

This is a fair bit of work, but it should remove a lot of the complexity.
I'd would split this in probaly several steps:
1. First deployable: chunk: Keep the data structures Source, UserSource but start double writing to collaborators (CaseCreator and CaseOwner) table at the same time as source and owner.
2. Second deployable: Backfill hisetorical data and
3. Swap view to use, the new data structure
4. fix the search ( this can be done on a concurrently to step 2 and 3)
5. bundle steps 3 and 4 and deploy together.

