### PR TITLE
Fix search results layout

### DIFF
--- a/psd-web/app/views/searches/show.html.erb
+++ b/psd-web/app/views/searches/show.html.erb
@@ -4,28 +4,28 @@
 
 <div class="govuk-grid-row">
   <%= render 'investigations/filters', search: @search, show_relevancy_radion_option: true, submitted_from: "investigation_search" %>
-</div>
 
-<div class="govuk-grid-column-three-quarters"  id="results">
-  <% @investigations.each do |investigation| %>
-    <% result = @answer.results.find { |rs| rs.id.to_i == investigation.id } %>
-    <% if !policy(investigation).show? %>
-      <%= render "investigations/restricted_card", investigation: investigation.decorate %>
-    <% elsif result.respond_to?(:highlight) %>
-      <%= render "investigations/highlight_card", investigation: investigation.decorate, highlights: result.highlight %>
-    <% else %>
-      <%= render "investigations/case_card", investigation: investigation.decorate, sorted_by: @search.sort_by %>
+  <div class="govuk-grid-column-three-quarters"  id="results">
+    <% @investigations.each do |investigation| %>
+      <% result = @answer.results.find { |rs| rs.id.to_i == investigation.id } %>
+      <% if !policy(investigation).show? %>
+        <%= render "investigations/restricted_card", investigation: investigation.decorate %>
+      <% elsif result.respond_to?(:highlight) %>
+        <%= render "investigations/highlight_card", investigation: investigation.decorate, highlights: result.highlight %>
+      <% else %>
+        <%= render "investigations/case_card", investigation: investigation.decorate, sorted_by: @search.sort_by %>
+      <% end %>
     <% end %>
-  <% end %>
-  <%= will_paginate @answer.results %>
-  <br />
-  <% if current_user.is_psd_admin? %>
-    <%= link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params), class: "govuk-link" %>
-  <% end %>
+    <%= will_paginate @answer.results %>
+    <br />
+    <% if current_user.is_psd_admin? %>
+      <%= link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params), class: "govuk-link" %>
+    <% end %>
 
-  <% unless @investigations.any? %>
-    <div style="text-align:center" class="govuk-heading-l">
-      No result
-    </div>
-  <% end %>
+    <% unless @investigations.any? %>
+      <div style="text-align:center" class="govuk-heading-l">
+        No result
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
The search results layout is broken:

<img width="1407" alt="Screenshot 2020-05-12 at 10 17 50" src="https://user-images.githubusercontent.com/408371/81666410-ebe63200-9439-11ea-8acc-7c31fc4ee209.png">

After fix:

<img width="1278" alt="Screenshot 2020-05-12 at 10 18 00" src="https://user-images.githubusercontent.com/408371/81666434-f274a980-9439-11ea-819f-3a62f4209424.png">

This might not be 100% correct and needs cross browser testing.


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
