### PR TITLE
Change OPSS Processing team name

### DIFF
--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -21,16 +21,6 @@ class Team < ApplicationRecord
     users.include?(user)
   end
 
-  def self.ensure_names_up_to_date
-    return if Rails.env.test?
-
-    missing = Rails.application.config.team_names["organisations"]["opss"] - all.collect(&:name)
-
-    return true if missing.empty?
-
-    raise "Team name #{missing.join(', ')} not found"
-  end
-
   def self.get_visible_teams(user)
     team_names = Rails.application.config.team_names["organisations"]["opss"]
     return where(name: team_names) if user.is_opss?

--- a/psd-web/config/constants/important_team_names.yml
+++ b/psd-web/config/constants/important_team_names.yml
@@ -2,5 +2,5 @@
 organisations:
   opss:
     - OPSS Incident Management
-    - OPSS Operational Support Unit
+    - OPSS Operational support unit
     - OPSS Trading Standards Co-ordination

--- a/psd-web/config/constants/important_team_names.yml
+++ b/psd-web/config/constants/important_team_names.yml
@@ -2,5 +2,5 @@
 organisations:
   opss:
     - OPSS Incident Management
-    - OPSS Processing
+    - OPSS Operational Support Unit
     - OPSS Trading Standards Co-ordination

--- a/psd-web/db/seeds.rb
+++ b/psd-web/db/seeds.rb
@@ -466,7 +466,7 @@ if run_seeds
   else
     organisation = Organisation.create!(name: "Office for Product Safety and Standards")
     enforcement  = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
-    processing   = Team.create!(name: "OPSS Operational Support Unit", team_recipient_email: nil, "organisation": organisation)
+    op_support   = Team.create!(name: "OPSS Operational Support Unit", team_recipient_email: nil, "organisation": organisation)
 
     Team.create!(name: "OPSS Science and Tech", team_recipient_email: nil, "organisation": organisation)
     Team.create!(name: "OPSS Trading Standards Co-ordination", team_recipient_email: nil, "organisation": organisation)
@@ -490,7 +490,7 @@ if run_seeds
       password_confirmation: "testpassword",
       organisation: organisation,
       mobile_number_verified: true,
-      team: processing,
+      team: op_support,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
 

--- a/psd-web/db/seeds.rb
+++ b/psd-web/db/seeds.rb
@@ -465,8 +465,8 @@ if run_seeds
     end
   else
     organisation = Organisation.create!(name: "Office for Product Safety and Standards")
-    enforcement  = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
-    op_support   = Team.create!(name: "OPSS Operational Support Unit", team_recipient_email: nil, "organisation": organisation)
+    enforcement = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
+    operational_support = Team.create!(name: "OPSS Operational support unit", team_recipient_email: nil, "organisation": organisation)
 
     Team.create!(name: "OPSS Science and Tech", team_recipient_email: nil, "organisation": organisation)
     Team.create!(name: "OPSS Trading Standards Co-ordination", team_recipient_email: nil, "organisation": organisation)
@@ -490,7 +490,7 @@ if run_seeds
       password_confirmation: "testpassword",
       organisation: organisation,
       mobile_number_verified: true,
-      team: op_support,
+      team: operational_support,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
 

--- a/psd-web/db/seeds.rb
+++ b/psd-web/db/seeds.rb
@@ -466,7 +466,7 @@ if run_seeds
   else
     organisation = Organisation.create!(name: "Office for Product Safety and Standards")
     enforcement  = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
-    processing   = Team.create!(name: "OPSS Processing", team_recipient_email: nil, "organisation": organisation)
+    processing   = Team.create!(name: "OPSS Operational Support Unit", team_recipient_email: nil, "organisation": organisation)
 
     Team.create!(name: "OPSS Science and Tech", team_recipient_email: nil, "organisation": organisation)
     Team.create!(name: "OPSS Trading Standards Co-ordination", team_recipient_email: nil, "organisation": organisation)


### PR DESCRIPTION
https://trello.com/c/1RGPhcbs/239-1-rename-the-opss-processing-team

## Description
This team is considered 'important' for the purposes of always being displayed on the change owner page for OPSS users, and we also use it for seeds, so I've updated the code accordingly.

When this is deployed I will update the team name manually. Until this is done the team will not be displayed on the change owner page, but there should be no other issues.

Review app seeds have already been updated.

Also removed some related redundant code which appears to no longer be used.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
