### PR TITLE
Refactor the rows object into a helper

### DIFF
--- a/psd-web/app/helpers/investigations_helper.rb
+++ b/psd-web/app/helpers/investigations_helper.rb
@@ -229,4 +229,64 @@ module InvestigationsHelper
 
     all_past_owners || []
   end
+
+  # This builds an array from an investigation which can then
+  # be passed as a `rows` argument to the govukSummaryList() helper.
+  def about_the_case_rows(investigation)
+    rows = [
+      {
+        key: { text: "Status" },
+        value: { text: investigation.status },
+        actions: {
+          items: [
+            {
+              href: status_investigation_path(investigation),
+              text: "Change",
+              visuallyHiddenText: "status"
+            }
+          ]
+        }
+      },
+      {
+        key: { text: "Coronavirus related" },
+        value: { text: I18n.t(investigation.coronavirus_related, scope: "case.coronavirus_related") },
+        actions: {
+          items: [
+            {
+              href: investigation_coronavirus_related_path(investigation),
+              text: "Change",
+              visuallyHiddenText: "coronavirus status"
+            }
+          ]
+        }
+      },
+      {
+        key: { text: "Created by" },
+        value: { text: investigation.created_by }
+      },
+      {
+        key: { text: "Date created" },
+        value: { text: investigation.created_at.to_s(:govuk) }
+      },
+      {
+        key: { text: "Last updated" },
+        value: { text: "#{time_ago_in_words(investigation.updated_at)} ago" },
+        actions: {
+          items: [
+            { href: new_investigation_activity_path(investigation),
+              text: "Add activity" }
+          ]
+        }
+      }
+    ]
+
+    if investigation.complainant_reference.present?
+      rows << {
+        key: { text: "Trading Standards reference" },
+        value: { text: investigation.complainant_reference }
+      }
+    end
+
+    rows
+  end
 end

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -82,63 +82,9 @@
     <%= govuk_hr %>
     <h2 class="govuk-heading-m">About the case</h2>
 
-    <% about_the_case_rows = [
-      {
-        key: { text: "Status" },
-        value: { text: @investigation.status },
-        actions: {
-          items: [
-            {
-              href: status_investigation_path(@investigation),
-              text: "Change",
-              visuallyHiddenText: "status"
-            }
-          ]
-        }
-      },
-      {
-        key: { text: "Coronavirus related" },
-        value: { text: I18n.t(@investigation.coronavirus_related, scope: "case.coronavirus_related") },
-        actions: {
-          items: [
-            {
-              href: investigation_coronavirus_related_path(@investigation),
-              text: "Change",
-              visuallyHiddenText: "coronavirus status"
-            }
-          ]
-        }
-      },
-      {
-        key: { text: "Created by" },
-        value: { text: @investigation.created_by }
-      },
-      {
-        key: { text: "Date created" },
-        value: { text: @investigation.created_at.to_s(:govuk) }
-      },
-      {
-        key: { text: "Last updated" },
-        value: { text: "#{time_ago_in_words(@investigation.updated_at)} ago" },
-        actions: {
-          items: [
-            { href: new_investigation_activity_path(@investigation),
-              text: "Add activity" }
-          ]
-        }
-      }
-    ] %>
-
-    <% if @investigation.complainant_reference.present?
-      about_the_case_rows << {
-        key: { text: "Trading Standards reference" },
-        value: { text: @investigation.complainant_reference }
-      }
-     end %>
-
     <%= govukSummaryList(
       classes: "govuk-summary-list--no-border",
-      rows: about_the_case_rows
+      rows: about_the_case_rows(@investigation)
     ) %>
   </div>
 


### PR DESCRIPTION
This moves the building of the `rows` argument passed to the `govukSummaryList()` helper with the "About the case" section to its own helper.

This is mainly to avoid having a condition within the view template.

See [discussion on parent Pull Request](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/588#discussion_r423549075).