### PR TITLE
Fix name in ownership emails

### DIFF
--- a/psd-web/app/forms/edit_investigation_collaborator_form.rb
+++ b/psd-web/app/forms/edit_investigation_collaborator_form.rb
@@ -63,11 +63,7 @@ private
 
   def schedule_delete_email(emails)
     emails.each do |email|
-      NotifyMailer.team_deleted_from_case_email(email_payload, to_email: email).deliver_later
+      NotifyMailer.team_deleted_from_case_email(message: message, investigation: investigation, team_deleted: team, user_who_deleted: user, to_email: email).deliver_later
     end
-  end
-
-  def email_payload
-    { permission_level: permission_level, include_message: include_message, message: message, investigation: investigation, team: team, user: user }
   end
 end

--- a/psd-web/app/mailers/notify_mailer.rb
+++ b/psd-web/app/mailers/notify_mailer.rb
@@ -107,11 +107,13 @@ class NotifyMailer < GovukNotifyRails::Mailer
   def team_added_to_case_email(collaborator, to_email:)
     set_template(TEMPLATES[:team_added_to_case])
 
+    user_name = collaborator.added_by_user.decorate.display_name(viewer: collaborator.team)
+
     optional_message = if collaborator.message.present?
                          [
                            I18n.t(
                              :message_from,
-                             user_name: collaborator.added_by_user.name,
+                             user_name: user_name,
                              scope: "mail.team_added_to_case"
                            ),
                            inset_text_for_notify(collaborator.message)
@@ -121,7 +123,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
                        end
 
     set_personalisation(
-      updater_name: collaborator.added_by_user.name,
+      updater_name: user_name,
       optional_message: optional_message,
       investigation_url: investigation_url(collaborator.investigation)
     )

--- a/psd-web/app/mailers/notify_mailer.rb
+++ b/psd-web/app/mailers/notify_mailer.rb
@@ -131,28 +131,29 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: to_email)
   end
 
-  def team_deleted_from_case_email(form, to_email:)
+  def team_deleted_from_case_email(message:, investigation:, team_deleted:, user_who_deleted:, to_email:)
     set_template(TEMPLATES[:team_deleted_from_case])
-    form = OpenStruct.new(form) # form comes as hash due to rails 5 serialization issues
 
-    optional_message = if form.message.present?
+    user_name = user_who_deleted.decorate.display_name(viewer: team_deleted)
+
+    optional_message = if message.present?
                          [
                            I18n.t(
                              :message_from,
-                             user_name: form.user.name,
+                             user_name: user_name,
                              scope: "mail.team_removed_from_case"
                            ),
-                           inset_text_for_notify(form.message)
+                           inset_text_for_notify(message)
                          ].join("\n\n")
                        else
                          ""
                        end
 
     set_personalisation(
-      case_type: form.investigation.case_type.to_s.downcase,
-      case_title: form.investigation.decorate.title,
-      case_id: form.investigation.pretty_id,
-      updater_name: form.user.name,
+      case_type: investigation.case_type.to_s.downcase,
+      case_title: investigation.decorate.title,
+      case_id: investigation.pretty_id,
+      updater_name: user_name,
       optional_message: optional_message,
     )
 

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -72,8 +72,8 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     notification_email = delivered_emails.last
 
     expect(notification_email.recipient).to eq("enquiries@southampton.gov.uk")
-    expect(notification_email.personalization[:updater_name]).to eq("Bob Jones")
-    expect(notification_email.personalization[:optional_message]).to eq("Message from Bob Jones:\n\n^ Thanks for collaborating on this case with us.")
+    expect(notification_email.personalization[:updater_name]).to eq("Bob Jones (Portsmouth Trading Standards)")
+    expect(notification_email.personalization[:optional_message]).to eq("Message from Bob Jones (Portsmouth Trading Standards):\n\n^ Thanks for collaborating on this case with us.")
     expect(notification_email.personalization[:investigation_url]).to end_with("/cases/#{investigation.pretty_id}")
 
     click_link "Back"

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -140,8 +140,8 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect(notification_email.personalization_value(:case_id)).to eq(investigation.pretty_id)
     expect(notification_email.personalization_value(:case_type)).to eq("allegation")
     expect(notification_email.personalization_value(:case_title)).to eq(investigation.decorate.title)
-    expect(notification_email.personalization_value(:updater_name)).to eq(user.name)
-    expect(notification_email.personalization_value(:optional_message)).to eq("Message from #{user.name}:\n\n^ Thanks for collaborating on this case with us.")
+    expect(notification_email.personalization_value(:updater_name)).to eq("Bob Jones (Portsmouth Trading Standards)")
+    expect(notification_email.personalization_value(:optional_message)).to eq("Message from Bob Jones (Portsmouth Trading Standards):\n\n^ Thanks for collaborating on this case with us.")
 
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 


### PR DESCRIPTION
https://trello.com/c/eYtohraA/544-refactor-display-names

## Description
This fixes a minor bug in the notification emails which are sent when a team is added or removed from a case.

They did not show the team name of the user who added or removed your team. In normal circumstances the recipient would not be in the same team as the person who added or removed, since in that case they would already be a collaborator on the case.

In the case of the team deleted email I have also refactored the interface to the mailer since it depended on being given a serialised form object, which is unnecessary and slightly cumbersome. Passing the individual arguments instead will make it easier to call this method elsewhere if required and makes it easier to test. Since there were no unit tests for the mailer I added some.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?