### PR TITLE
Delete existing review app when deploying to prevent deployment errors

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -11,7 +11,7 @@ The `master` branch represents our staging and production environments. Anything
 
 ### Review applications
 
-In order to make the PR review process fast and independent, it is possible to create a short lived environment for a given change. In order to create your environment, run `REVIEW_INSTANCE_NAME=ticket-123 ./psd-web/deploy-review.sh`, where `ticket-123` is desired name of review app.
+In order to make the PR review process fast and independent, it is possible to create a short lived environment for a given change. In order to create your environment, run `APP_NAME=ticket-123 ./psd-web/deploy-review.sh`, where `ticket-123` is desired name of review app.
 
 By default, the database is shared, but it can be overriden by setting the `DB_NAME` env variable. This will create a new database instance, however this can take several minutes.
 

--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -37,15 +37,8 @@ then
   WORKER_MAX_THREADS=10
 fi
 
-# Set the amount of time in minutes that the CLI will wait for all instances to start.
-# Because of the rolling deployment strategy, this should be set to at least the amount of
-# time each app takes to start multiplied by the number of instances.
-#
-# See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
-export CF_STARTUP_TIMEOUT=10
-
 # Deploy the app
-cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
+cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS
 
 # Remove the copied infrastructure env files to clean up
 rm -fR ${PWD-.}/psd-web/env/

--- a/psd-web/deploy-review.sh
+++ b/psd-web/deploy-review.sh
@@ -17,13 +17,8 @@ then
   DB_NAME=psd-review-database
 fi
 
-# Unbind any databases which may already be bound to this app (if it already exists) and which are no longer required
-for existing_db_name in `cf7 services | grep $APP_NAME | grep postgres | awk '{print $1}'`; do
-  if [ $existing_db_name != $DB_NAME ]
-  then
-    cf7 unbind-service $APP_NAME $existing_db_name
-  fi
-done
+# Delete the old app. previously we replaced it but this caused issues with race conditions and re-binding databases when migrations were added
+cf7 delete -f -r $APP_NAME
 
 cf7 create-service postgres small-10 $DB_NAME -c '{"enable_extensions": ["pgcrypto"]}'
 
@@ -48,14 +43,6 @@ fi
 #
 # See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
 export CF_STARTUP_TIMEOUT=10
-
-
-# Cancel any existing deployments in progress
-if cf7 cancel-deployment $APP_NAME
-then
-  # Wait enough time for cancellation to finish
-  sleep 6
-fi
 
 # Deploy the app
 cf7 push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This change deletes an existing review app before starting to deploy. This ensures we can push as frequently as we want and the GitHub action should not fail because a previous deployment is still in progress.

I have tested this manually from my machine and it seems to fail the previous deployment immediately no matter where it has got to, which is exactly what we want.

Also tested on CI by pushing a second commit while the first deployment was still working, and then rebasing while the second deployment was working. Example of failure triggered when another deployment starts here: https://github.com/UKGovernmentBEIS/beis-opss-psd/runs/674907421?check_suite_focus=true

This is a simpler solution than the existing workarounds I previously added, which I have now removed.

Also fixed an error in the docs for manually deploying review apps.