### PR TITLE
Remove brackets from link helper

### DIFF
--- a/psd-web/app/views/documents/_document_card.html.slim
+++ b/psd-web/app/views/documents/_document_card.html.slim
@@ -20,12 +20,12 @@ ruby:
 
       - if safe
         = link_with_hidden_text_to "View #{pretty_type_description(document)}",
-            "#{title}, opens in a new window", document,
+            "(#{title}, opens in a new window)", document,
             class: "govuk-link app-block-link govuk-!-margin-right-3",
               target: '_blank', rel: 'noopener'
         = link_with_hidden_text_to "Edit #{image_document_text(document)}",
-            title, edit_associated_document_path(parent, document),
+            "(#{title})", edit_associated_document_path(parent, document),
             class: "govuk-link app-block-link govuk-!-margin-right-3"
         = link_with_hidden_text_to "Remove #{image_document_text(document)}",
-            title, remove_associated_document_path(parent, document),
+            "(#{title})", remove_associated_document_path(parent, document),
             class: "govuk-link app-block-link"

--- a/psd-web/app/views/investigations/tabs/_businesses.html.slim
+++ b/psd-web/app/views/investigations/tabs/_businesses.html.slim
@@ -19,9 +19,9 @@
       h2.govuk-heading-m
         = ib.relationship.upcase_first
       = business_summary_list ib.business
-      = link_with_hidden_text_to "View business", ib.business.trading_name,
+      = link_with_hidden_text_to "View business", "(#{ib.business.trading_name})",
         ib.business, class: "govuk-link app-block-link govuk-!-margin-right-3"
-      = link_with_hidden_text_to "Remove business", ib.business.trading_name,
+      = link_with_hidden_text_to "Remove business", "(#{ib.business.trading_name})",
         remove_investigation_business_path(@investigation, ib.business),
         class: "govuk-link app-block-link"
 

--- a/psd-web/app/views/investigations/tabs/_products.html.slim
+++ b/psd-web/app/views/investigations/tabs/_products.html.slim
@@ -17,9 +17,9 @@
 
   = render "product_summary", product: product do
     / Add visually hidden product name to make links unique
-    = link_with_hidden_text_to "View product", product.name, product,
+    = link_with_hidden_text_to "View product", "(#{product.name})", product,
       class: "app-block-link govuk-link govuk-!-margin-right-3"
-    = link_with_hidden_text_to "Remove product", product.name,
+    = link_with_hidden_text_to "Remove product", "(#{product.name})",
       remove_investigation_product_path(@investigation, product),
       class: "app-block-link govuk-link"
 - if @investigation.products.length.zero?

--- a/psd-web/app/views/link_helper/_link_with_hidden_text_to.html.erb
+++ b/psd-web/app/views/link_helper/_link_with_hidden_text_to.html.erb
@@ -1,1 +1,1 @@
-<%= text %><span class="govuk-visually-hidden"> (<%= hidden_text %>)</span>
+<%= text %><span class="govuk-visually-hidden"> <%= hidden_text %></span>

--- a/psd-web/spec/helpers/link_helper_spec.rb
+++ b/psd-web/spec/helpers/link_helper_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe LinkHelper do
 
     let(:url) { root_path }
     let(:title) { "Home page" }
-    let(:hidden_text) { "hidden text" }
+    let(:hidden_text) { "(hidden text)" }
     let(:class_name) { "test" }
 
     it "outputs hidden text" do
-      expect(link).to eq("<a class=\"#{class_name}\" href=\"#{url}\">#{title}<span class=\"govuk-visually-hidden\"> (#{hidden_text})</span>\n</a>")
+      expect(link).to eq("<a class=\"#{class_name}\" href=\"#{url}\">#{title}<span class=\"govuk-visually-hidden\"> #{hidden_text}</span>\n</a>")
     end
   end
 end


### PR DESCRIPTION
The hidden link helper was forcing hidden text to be in brackets. This isn't always needed.

I've removed the default text and reapplied where we want it.

Should outwardly look the same to users.