### PR TITLE
Render 404 page not found for invalid wizard steps

### DIFF
--- a/psd-web/app/controllers/application_controller.rb
+++ b/psd-web/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :nav_items, :secondary_nav_items, :previous_search_params, :current_user
 
+  rescue_from Wicked::Wizard::InvalidStepError, with: :render_404_page
+
   def set_current_user
     return unless user_signed_in?
 
@@ -111,5 +113,11 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(*)
     root_path
+  end
+
+private
+
+  def render_404_page
+    render "errors/not_found", status: :not_found
   end
 end

--- a/psd-web/spec/requests/invalid_wizard_step_spec.rb
+++ b/psd-web/spec/requests/invalid_wizard_step_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Invalid steps within wizards", :with_stubbed_elasticsearch, :with_stubbed_notify, :with_stubbed_mailer, type: :request do
+  let(:user) { create(:user, :opss_user, :activated) }
+  let(:investigation) { create(:investigation, owner: user.team) }
+
+  before { sign_in(user) }
+
+  context "when requesting an invalid step" do
+    before do
+      get "/cases/#{investigation.pretty_id}/corrective_actions/invalid-step"
+    end
+
+    it "renders 'Page not found'" do
+      expect(response).to render_template("errors/not_found")
+    end
+
+    it "renders with a 404 status code" do
+      expect(response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
Prevents an invalid URL from throwing a 500 error.