### PR TITLE
Extend tests edit business details

### DIFF
--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -90,6 +90,23 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Contact")
     expect(page).to have_css("dd.govuk-summary-list__value", text: expected_contact)
 
+    # edit business details
+    click_link "View business"
+    click_link "Edit details"
+
+    expect_to_be_on_investigation_edit_business_details_page
+
+    within_fieldset "Business details" do
+      fill_in "Registered or legal name", with: business_details + "edit details"
+      fill_in "Company number",           with: company_number   + "906"
+    end
+
+    click_button "Save business"
+    expect_confirmation_banner("Business was successfully updated.")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: business_details + "edit details")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: company_number   + "906")
+
+    visit "/cases/#{investigation.pretty_id}/businesses"
     click_link "Remove business"
 
     expect_to_be_on_remove_business_page

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -28,6 +28,11 @@ module PageExpectations
     expect(page).to have_selector("legend", text: "Business details")
   end
 
+  def expect_to_be_on_investigation_edit_business_details_page
+    expect(page).to have_title("Edit business - Product safety database - GOV.UK")
+    expect(page).to have_selector("legend", text: "Business details")
+  end
+
   def expect_to_be_on_remove_business_page
     expect(page).to have_current_path(/\/cases\/#{investigation.pretty_id}\/businesses\/\d+\/remove/)
     expect(page).to have_selector("h2", text: "Remove business")


### PR DESCRIPTION
Added one test around edit business details in an existing feature spec

Note: This is based on existing pr 606- ( my bad) so dependent on 606 to go first in master before this can be merged.

## Description
Just a minor change- added one additional step within existing test to validate edit business

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
