### PR TITLE
Extract domains whitelisting OTPs to a yaml file

### DIFF
--- a/psd-web/app/models/secondary_authentication.rb
+++ b/psd-web/app/models/secondary_authentication.rb
@@ -103,7 +103,9 @@ private
     return false if uris.length != 1
 
     uri = uris.first
-    uri =~ /staging\.product-safety-database\.service\.gov\.uk|psd-pr-\d{3,5}\.london\.cloudapps\.digital/
+    Rails.application.config.domains_allowing_otp_whitelisting["domains-regexps"].any? do |domain_regexp|
+      uri =~ domain_regexp
+    end
   rescue StandardError
     false
   end

--- a/psd-web/config/constants/domains_allowing_otp_whitelisting.yml
+++ b/psd-web/config/constants/domains_allowing_otp_whitelisting.yml
@@ -1,0 +1,4 @@
+---
+domains-regexps:
+  - !ruby/regexp /staging\.product-safety-database\.service\.gov\.uk/
+  - !ruby/regexp /psd-pr-\d{3,5}\.london\.cloudapps\.digital/

--- a/psd-web/config/initializers/constants.rb
+++ b/psd-web/config/initializers/constants.rb
@@ -16,3 +16,6 @@ Rails.application.config.team_names = YAML.load_file(
 Rails.application.config.whitelisted_emails = YAML.load_file(
   Rails.root.join("config/constants/whitelisted_emails.yml")
 )
+Rails.application.config.domains_allowing_otp_whitelisting = YAML.load_file(
+  Rails.root.join("config/constants/domains_allowing_otp_whitelisting.yml")
+)


### PR DESCRIPTION
Extract the regular expressions defining the domains where secondary authentication One Time Password codes can be whitelisted to a constants YAML file.

We do not want to set this in ENV VARS per environment due to strict security requirements. To avoid an easy (and hard to trace) mess up because an env var was incorrectly set.

We neither want urls hardcoded in our business logic.

Extracting these regular expressions defining our urls into a YAML file of constants is a solution that sits in the middle of the mentioned two approaches.
