### PR TITLE
View only permission tests

### DIFF
--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
   let(:investigation)    { create(:enquiry, owner: user.team) }
   let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, team: create(:team)) }
 
-  scenario "when another user from differnt team,it doesn't allow to add business" do
+  scenario "when user from another team,it doesn't allow to add business" do
     sign_in another_user_another_team
     visit "/cases/#{investigation.pretty_id}/businesses"
     page.should have_no_content("Add business")

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -17,14 +17,12 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
   let(:investigation)    { create(:enquiry, owner: user.team) }
   let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, team: create(:team)) }
 
-
- 
-  scenario "As another user from differnt team,it doesn't allow to add business" do 
-      sign_in another_user_another_team
-      visit "/cases/#{investigation.pretty_id}/businesses"
-      page.should have_no_content("Add business")
+  scenario "when another user from differnt team,it doesn't allow to add business" do
+    sign_in another_user_another_team
+    visit "/cases/#{investigation.pretty_id}/businesses"
+    page.should have_no_content("Add business")
   end
-  
+
   scenario "Adding a business" do
     sign_in user
     visit "/cases/#{investigation.pretty_id}/businesses/new"

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -94,5 +94,6 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
 
     expect_to_be_on_remove_business_page
     click_button "Remove business"
+    expect_confirmation_banner("Business was successfully removed.")
   end
 end

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -15,10 +15,18 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
   let(:job_title)        { Faker::Job.title }
   let(:user)             { create(:user, :activated) }
   let(:investigation)    { create(:enquiry, owner: user.team) }
+  let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, team: create(:team)) }
 
-  before { sign_in user }
 
+ 
+  scenario "As another user from differnt team,it doesn't allow to add business" do 
+      sign_in another_user_another_team
+      visit "/cases/#{investigation.pretty_id}/businesses"
+      page.should have_no_content("Add business")
+  end
+  
   scenario "Adding a business" do
+    sign_in user
     visit "/cases/#{investigation.pretty_id}/businesses/new"
 
     # Don't select a business type

--- a/psd-web/spec/features/add_business_spec.rb
+++ b/psd-web/spec/features/add_business_spec.rb
@@ -90,6 +90,23 @@ RSpec.feature "Adding and removing business to a case", :with_stubbed_mailer, :w
     expect(page).to have_css("dt.govuk-summary-list__key",   text: "Contact")
     expect(page).to have_css("dd.govuk-summary-list__value", text: expected_contact)
 
+    # edit business details
+    click_link "View business"
+    click_link "Edit details"
+
+    expect_to_be_on_investigation_edit_business_details_page
+
+    within_fieldset "Business details" do
+      fill_in "Registered or legal name", with: business_details + "edit details"
+      fill_in "Company number",           with: company_number   + "906"
+    end
+
+    click_button "Save business"
+    expect_confirmation_banner("Business was successfully updated.")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: business_details + "edit details")
+    expect(page).to have_css("dd.govuk-summary-list__value", text: company_number   + "906")
+
+    visit "/cases/#{investigation.pretty_id}/businesses"
     click_link "Remove business"
 
     expect_to_be_on_remove_business_page

--- a/psd-web/spec/features/add_test_results_spec.rb
+++ b/psd-web/spec/features/add_test_results_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
   let(:date) { Faker::Date.backward(days: 14) }
   let(:file) { Rails.root + "test/fixtures/files/test_result.txt" }
 
-  context "when another user from different team" do
+  context "when user from another team" do
     scenario "doesn't allow to add test results" do
       sign_in(another_user_another_team)
       visit "/cases/#{investigation.pretty_id}/activity"

--- a/psd-web/spec/features/add_test_results_spec.rb
+++ b/psd-web/spec/features/add_test_results_spec.rb
@@ -8,16 +8,14 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
   let(:date) { Faker::Date.backward(days: 14) }
   let(:file) { Rails.root + "test/fixtures/files/test_result.txt" }
 
-  context "as another user from different team" do
+  context "when another user from different team" do
     scenario "doesn't allow to add test results" do
-      
       sign_in(another_user_another_team)
       visit "/cases/#{investigation.pretty_id}/activity"
       page.should have_content("Add comment")
       page.should have_no_content("Add activity")
     end
   end
-
 
   context "when leaving the form fields empty" do
     scenario "shows error messages" do

--- a/psd-web/spec/features/investigation_edit_spec.rb
+++ b/psd-web/spec/features/investigation_edit_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stubbed_mailer, type: :feature do
-  let(:investigation) { create(:project, owner: user) }
-  let(:user) { create(:user, :activated) }
-
-  before { sign_in user }
+  let!(:investigation) { create(:project, owner: user) }
+  let!(:user) { create(:user, :activated) }
+  let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, team: create(:team)) }
 
   scenario "allows to edit some the attributes" do
+    sign_in user
     visit investigation_path(investigation)
-
+    page.should have_content("Change summary")
+   
     click_link "Change summary"
 
     fill_in "investigation[description]", with: "new description"
@@ -23,4 +24,12 @@ RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stu
 
     expect(page).to have_css(".govuk-summary-list__row .govuk-summary-list__key + .govuk-summary-list__value", text: "Coronavirus related case")
   end
+  
+  scenario "user from other team cannot edit summary" do
+    sign_in another_user_another_team
+    visit investigation_path(investigation)
+    page.should have_no_content("Change summary")
+  end
+
+
 end

--- a/psd-web/spec/features/investigation_edit_spec.rb
+++ b/psd-web/spec/features/investigation_edit_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stu
     sign_in user
     visit investigation_path(investigation)
     page.should have_content("Change summary")
-   
+
     click_link "Change summary"
 
     fill_in "investigation[description]", with: "new description"
@@ -24,12 +24,10 @@ RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stu
 
     expect(page).to have_css(".govuk-summary-list__row .govuk-summary-list__key + .govuk-summary-list__value", text: "Coronavirus related case")
   end
-  
+
   scenario "user from other team cannot edit summary" do
     sign_in another_user_another_team
     visit investigation_path(investigation)
     page.should have_no_content("Change summary")
   end
-
-
 end

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -28,6 +28,11 @@ module PageExpectations
     expect(page).to have_selector("legend", text: "Business details")
   end
 
+  def expect_to_be_on_investigation_edit_business_details_page
+    expect(page).to have_title("Edit business - Product safety database - GOV.UK")
+    expect(page).to have_selector("legend", text: "Business details")
+  end
+
   def expect_to_be_on_remove_business_page
     expect(page).to have_current_path(/\/cases\/#{investigation.pretty_id}\/businesses\/\d+\/remove/)
     expect(page).to have_selector("h2", text: "Remove business")


### PR DESCRIPTION
added view only tests as another user in existing feature specs

## Description
Added  a simple view only tests, this means user who don't have permission won't be able to add product, add test result or edit summary. 

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
