### PR TITLE
Add restriction to case overview

### DIFF
--- a/psd-web/app/controllers/investigations/activities_controller.rb
+++ b/psd-web/app/controllers/investigations/activities_controller.rb
@@ -40,8 +40,6 @@ module Investigations
         redirect_to new_investigation_corrective_action_path(@investigation)
       when "business"
         redirect_to new_investigation_business_path(@investigation)
-      when "visibility"
-        redirect_to visibility_investigation_path(@investigation)
       when "alert"
         redirect_to new_investigation_alert_path(@investigation)
       else

--- a/psd-web/app/helpers/activity_helper.rb
+++ b/psd-web/app/helpers/activity_helper.rb
@@ -11,8 +11,6 @@ module ActivityHelper
       "product": "Add a product to the case",
       "business": "Add a business to the case"
     }
-    visibility_text = @investigation.is_private ? "Unrestrict this case" : "Restrict this case for legal privilege"
-    base_types["visibility"] = visibility_text if policy(@investigation).change_owner_or_status?
     base_types["alert"] = "Send email alert about this case" if policy(@investigation).send_email_alert?
 
     base_types

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -40,8 +40,16 @@
           visuallyHiddenText: "case owner"
         ]
       } %>
+      <% case_restriction_actions = {
+        items: [
+          href: visibility_investigation_path(@investigation),
+          text: "Change",
+          visuallyHiddenText: "case restriction"
+        ]
+      } %>
     <% else %>
       <% case_owner_actions = {} %>
+      <% case_restriction_actions = {} %>
     <% end %>
 
     <% team_list_html = capture do %>
@@ -77,6 +85,11 @@
               visuallyHiddenText: "teams added to the case"
             ]
           }
+        },
+        {
+          key: { text: "Case restriction" },
+          value: { text: @investigation.is_private? ? "Restricted" : "Unrestricted" },
+          actions: case_restriction_actions
         }
       ]
     ) %>

--- a/psd-web/spec/features/change_case_visibility_restriction_spec.rb
+++ b/psd-web/spec/features/change_case_visibility_restriction_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Change case restriction status", :with_stubbed_elasticsearch, :wi
       click_button "Save"
 
       expect_to_be_on_case_page(case_id: case_id)
-      expect_confirmation_banner("Allegation was successfully updated.")
+      expect_confirmation_banner("Allegation was successfully updated")
       expect(page).to have_summary_item(key: "Case restriction", value: "Restricted")
     end
   end

--- a/psd-web/spec/features/change_case_visibility_restriction_spec.rb
+++ b/psd-web/spec/features/change_case_visibility_restriction_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.feature "Change case restriction status", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
+  let(:user) do
+    create(
+      :user,
+      :activated,
+      team: create(:team, name: "Portsmouth Trading Standards"),
+      name: "Bob Jones"
+    )
+  end
+
+  let(:case_id) { investigation.pretty_id }
+
+  before do
+    sign_in(user)
+  end
+
+  context "when the user is the owner of the case" do
+    let(:investigation) do
+      create(
+        :allegation,
+        owner: user
+      )
+    end
+
+    scenario "user can change the restriction status of the case" do
+      visit "/cases/#{case_id}"
+
+      expect_to_be_on_case_page(case_id: case_id)
+      expect(page).to have_summary_item(key: "Case restriction", value: "Unrestricted")
+      expect(page).to have_link "Change case restriction"
+      click_link "Change case restriction"
+
+      expect(page).to have_h1("Legal privilege")
+      choose "Restricted for legal privilege"
+      fill_in "Comment / rationale", with: "Restriction reason"
+      click_button "Save"
+
+      expect_to_be_on_case_page(case_id: case_id)
+      expect_confirmation_banner("Allegation was successfully updated.")
+      expect(page).to have_summary_item(key: "Case restriction", value: "Restricted")
+    end
+  end
+
+  context "when the user is not the case owner" do
+    let(:investigation) do
+      create(
+        :allegation,
+        owner: create(:user)
+      )
+    end
+
+    scenario "user can’t change the restriction status of the case" do
+      visit "/cases/#{case_id}"
+      expect_to_be_on_case_page(case_id: case_id)
+      expect(page).to have_summary_item(key: "Case restriction", value: "Unrestricted")
+      expect(page).not_to have_link "Change case restriction"
+    end
+  end
+end


### PR DESCRIPTION
This adds case restriction status as a row on the case overview, removing the feature from 'add activity'.

I've branched off of #606 to get the new restriction policies for this.

Shows the current restriction status, and if the viewing user has rights to change status, a change link.

Screenshot:

![Screenshot 2020-05-19 at 15 39 56](https://user-images.githubusercontent.com/2204224/82340307-00e93500-99e7-11ea-8de7-1a58539b2649.png)
