### PR TITLE
Fix broken styling on activities

### DIFF
--- a/psd-web/app/models/audit_activity/investigation/update_visibility.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_visibility.rb
@@ -1,7 +1,7 @@
 class AuditActivity::Investigation::UpdateVisibility < AuditActivity::Investigation::Base
   def self.from(investigation)
     title = "#{investigation.case_type.upcase_first} visibility
-            #{investigation.is_private ? 'Restricted' : 'Unrestricted'}"
+            #{investigation.is_private ? 'restricted' : 'unrestricted'}"
     super(investigation, title, sanitize_text(investigation.visibility_rationale))
   end
 

--- a/psd-web/app/views/investigations/activities/_activity_card.html.erb
+++ b/psd-web/app/views/investigations/activities/_activity_card.html.erb
@@ -6,7 +6,7 @@
 <li>
   <h3 class="govuk-heading-s"><%= title %></h3>
 
-  <p class="govuk-body-s.timeline-details"><%= activity.subtitle %>
+  <p class="govuk-body-s timeline-details"><%= activity.subtitle %></p>
 
   <% if restricted %>
     <%= render "restricted", activity: activity %>
@@ -43,11 +43,11 @@
     <% end %>
 
     <% if activity.product_id %>
-      <%= link_to "View product details", product_url(activity.product_id), class: "psd-block-link" %>
+      <%= link_to "View product details", product_url(activity.product_id), class: "govuk-link psd-block-link" %>
     <% end %>
 
     <% if activity.business_id %>
-      <%= link_to "View business details", business_url(activity.business_id), class: "psd-block-link" %>
+      <%= link_to "View business details", business_url(activity.business_id), class: "govuk-link psd-block-link" %>
     <% end %>
 
     <% if activity.has_attachment? %>

--- a/psd-web/app/views/investigations/activities/investigation/_add_allegation.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_add_allegation.html.erb
@@ -1,30 +1,33 @@
-<strong>Allegation details</strong>
-
-<br>
+<h4 class="govuk-heading-s">Allegation details</h4>
 
 <% if activity.metadata['investigation']['coronavirus_related'] %>
-  <br>
-  <%= t("audit_activity.investigation.coronavirus_related") %>
-  <br>
+  <p class="govuk-body">
+    <%= t("audit_activity.investigation.coronavirus_related") %>
+  </p>
 <% end %>
 
 <% if activity.metadata['investigation']['product_category'] %>
-  <br>
-  Product category: <strong><%= activity.metadata['investigation']['product_category'] %></strong>
+  <p class="govuk-body">
+    Product category: <strong><%= activity.metadata['investigation']['product_category'] %></strong>
+  </p>
 <% end %>
 
 <% if activity.metadata['investigation']['hazard_type'] %>
-  <br>
-  Hazard type: <strong><%= activity.metadata['investigation']['hazard_type'] %></strong>
+  <p class="govuk-body">
+    Hazard type: <strong><%= activity.metadata['investigation']['hazard_type'] %></strong>
+  </p>
 <% end %>
 
 <% if activity.metadata['attachment'] %>
-  Attachment: <strong><%= activity.metadata['attachment']['filename'] %></strong><br>
+  <p class="govuk-body">
+    Attachment: <strong><%= activity.metadata['attachment']['filename'] %></strong>
+  </p>
 <% end %>
 
 <% if activity.metadata['investigation']['description'] %>
-  <br>
-  <%= activity.metadata['investigation']['description'] %>
+  <p class="govuk-body">
+    <%= activity.metadata['investigation']['description'] %>
+  </p>
 <% end %>
 
 <%= render "investigations/activities/investigation/complainant", activity: activity, complainant: activity.complainant if activity.complainant %>

--- a/psd-web/app/views/investigations/activities/investigation/_add_enquiry.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_add_enquiry.html.erb
@@ -1,20 +1,21 @@
-<strong>Enquiry details</strong>
-
-<br>
+<h4 class="govuk-heading-s">Enquiry details</h4>
 
 <% if activity.metadata['investigation']['coronavirus_related'] %>
-  <br>
-  <%= t("audit_activity.investigation.coronavirus_related") %>
-  <br>
+  <p class="govuk-body">
+    <%= t("audit_activity.investigation.coronavirus_related") %>
+  </p>
 <% end %>
 
 <% if activity.metadata['attachment'] %>
-  Attachment: <strong><%= activity.metadata['attachment']['filename'] %></strong><br>
+  <p class="govuk-body">
+    Attachment: <strong><%= activity.metadata['attachment']['filename'] %></strong>
+  </p>
 <% end %>
 
 <% if activity.metadata['investigation']['description'] %>
-  <br>
-  <%= activity.metadata['investigation']['description'] %>
+  <p class="govuk-body">
+    <%= activity.metadata['investigation']['description'] %>
+  </p>
 <% end %>
 
 <%= render "investigations/activities/investigation/complainant", activity: activity, complainant: activity.complainant if activity.complainant %>

--- a/psd-web/app/views/investigations/activities/investigation/_add_project.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_add_project.html.erb
@@ -1,16 +1,17 @@
-<strong>Project details</strong>
+<h4 class="govuk-heading-s">Project details</h4>
 
-<br>
+
 
 <% if activity.metadata['investigation']['coronavirus_related'] %>
-  <br>
-  <%= t("audit_activity.investigation.coronavirus_related") %>
-  <br>
+  <p class="govuk-body">
+    <%= t("audit_activity.investigation.coronavirus_related") %>
+  </p>
 <% end %>
 
 <% if activity.metadata['investigation']['description'] %>
-  <br>
-  <%= activity.metadata['investigation']['description'] %>
+  <p class="govuk-body">
+    <%= activity.metadata['investigation']['description'] %>
+  </p>
 <% end %>
 
 <%= render "investigations/activities/investigation/owner", owner: activity.owner if activity.owner %>

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -31,7 +31,7 @@
     <% complainant_info << "Other details: <strong>#{escape_once(complainant.other_details)}</strong>" %>
   <% end %>
 
-  <% if complainant_info %>
+  <% if complainant_info.any? %>
     <p class="govuk-body">
       <%= complainant_info.join("<br />").html_safe %>
     </p>

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -16,29 +16,24 @@
   <% complainant_info = [] %>
 
   <% if complainant.name.present? %>
-    <% complainant_info << "Name: <strong>#{complainant.name}</strong>" %>
+    <% complainant_info << "Name: <strong>#{escape_once(complainant.name)}</strong>" %>
   <% end %>
 
   <% if complainant.phone_number.present? %>
-    <% complainant_info << "Phone number: <strong>#{complainant.phone_number}</strong>" %>
+    <% complainant_info << "Phone number: <strong>#{escape_once(complainant.phone_number)}</strong>" %>
   <% end %>
 
   <% if complainant.email_address.present? %>
-    <% complainant_info << "Email address: <strong>#{complainant.email_address}</strong>" %>
+    <% complainant_info << "Email address: <strong>#{escape_once(complainant.email_address)}</strong>" %>
   <% end %>
 
   <% if complainant.other_details.present? %>
-    <% complainant_info << "Other details: <strong>#{complainant.other_details}</strong>" %>
+    <% complainant_info << "Other details: <strong>#{escape_once(complainant.other_details)}</strong>" %>
   <% end %>
 
   <% if complainant_info %>
     <p class="govuk-body">
-      <% complainant_info.each do |info| %>
-        <%= info %>
-        <% if !complainant_info.last != info %>
-          <br>
-        <% end %>
-      <% end %>
+      <%= complainant_info.join("<br />").html_safe %>
     </p>
   <% end %>
 

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -33,7 +33,12 @@
 
   <% if complainant_info %>
     <p class="govuk-body">
-      <%= complainant_info.join("<br>").html_safe %>
+      <% complainant_info.each do |info| %>
+        <%= info %>
+        <% if !complainant_info.last != info %>
+          <br>
+        <% end %>
+      <% end %>
     </p>
   <% end %>
 

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -1,33 +1,40 @@
-<br><br>
-<strong>Complainant</strong>
-<br>
+<h4 class="govuk-heading-s">Complainant</h4>
 
+<%# Teams not involved in a case can know complainant type %>
+<% if complainant.complainant_type %>
+  <p class="govuk-body">
+    Type: <strong><%= complainant.complainant_type %></strong>
+  </p>
+<% end %>
+
+<%# Teams not involved in a case shouldn't complianant contact details %>
 <% if !complainant.can_be_displayed?(current_user) %>
   <%= render "restricted", activity: activity %>
 
 <% else %>
-  <% if complainant.name %>
-    <br>
-    Name: <strong><%= complainant.name %></strong>
+
+  <% complainant_info = [] %>
+
+  <% if complainant.name.present? %>
+    <% complainant_info << "Name: <strong>#{complainant.name}</strong>" %>
   <% end %>
 
-  <% if complainant.complainant_type %>
-    <br>
-    Type: <strong><%= complainant.complainant_type %></strong>
+  <% if complainant.phone_number.present? %>
+    <% complainant_info << "Phone number: <strong>#{complainant.phone_number}</strong>" %>
   <% end %>
 
-  <% if complainant.phone_number %>
-    <br>
-    Phone number: <strong><%= complainant.phone_number %></strong>
+  <% if complainant.email_address.present? %>
+    <% complainant_info << "Email address: <strong>#{complainant.email_address}</strong>" %>
   <% end %>
 
-  <% if complainant.email_address %>
-    <br>
-    Email address: <strong><%= complainant.email_address %></strong>
+  <% if complainant.other_details.present? %>
+    <% complainant_info << "Other details: <strong>#{complainant.other_details}</strong>" %>
   <% end %>
 
-  <% if complainant.other_details %>
-    <br><br>
-    <%= complainant.other_details %>
+  <% if complainant_info %>
+    <p class="govuk-body">
+      <%= complainant_info.join("<br>").html_safe %>
+    </p>
   <% end %>
+
 <% end %>

--- a/psd-web/app/views/investigations/activities/investigation/_owner.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_owner.html.erb
@@ -1,2 +1,3 @@
-<br><br>
-Case owner: <%= owner.decorate.display_name(viewer: current_user) %>
+<p class="govuk-body">
+  Case owner: <%= owner.decorate.display_name(viewer: current_user) %>
+</p>

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -140,9 +140,9 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       expect(page).to have_css("p", text: "Case is related to the coronavirus outbreak.")
       expect(page).to have_css("p", text: enquiry.fetch(:enquiry_description))
       expect(page).to have_css("p", text: "Attachment: testImage.png")
-      expect(page).to have_css("p", text: "Name: #{contact.fetch(:contact_name)}")
-      expect(page).to have_css("p", text: "Email address: #{contact.fetch(:contact_email)}")
-      expect(page).to have_css("p", text: "Phone number: #{contact.fetch(:contact_phone)}")
+      expect(page).to have_text("Name: #{contact.fetch(:contact_name)}")
+      expect(page).to have_text("Email address: #{contact.fetch(:contact_email)}")
+      expect(page).to have_text("Phone number: #{contact.fetch(:contact_phone)}")
       expect(page).to have_link("View attachment", href: /^.*testImage\.png$/)
     end
   end

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -140,9 +140,9 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       expect(page).to have_css("p",            text: "Case is related to the coronavirus outbreak.")
       expect(page).to have_css("p",            text: enquiry.fetch(:enquiry_description))
       expect(page).to have_css("p",            text: "Attachment: testImage.png")
-      expect(page).to have_css("p.govuk-body", text: /Name: #{contact.fetch(:contact_name)}/)
-      expect(page).to have_css("p.govuk-body", text: /Email address: #{contact.fetch(:contact_email)}/)
-      expect(page).to have_css("p.govuk-body", text: /Phone number: #{contact.fetch(:contact_phone)}/)
+      expect(page).to have_css("p.govuk-body", text: /Name: #{Regexp.escape(contact.fetch(:contact_name))}/)
+      expect(page).to have_css("p.govuk-body", text: /Email address: #{Regexp.escape(contact.fetch(:contact_email))}/)
+      expect(page).to have_css("p.govuk-body", text: /Phone number: #{Regexp.escape(contact.fetch(:contact_phone))}/)
       expect(page).to have_link("View attachment", href: /^.*testImage\.png$/)
     end
   end

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -136,13 +136,13 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
 
   def expect_details_on_activity_page(contact, enquiry)
     within ".govuk-list" do
-      expect(page).to have_css("h3", text: "Enquiry logged: #{enquiry.fetch(:enquiry_title)}")
-      expect(page).to have_css("p", text: "Case is related to the coronavirus outbreak.")
-      expect(page).to have_css("p", text: enquiry.fetch(:enquiry_description))
-      expect(page).to have_css("p", text: "Attachment: testImage.png")
-      expect(page).to have_text("Name: #{contact.fetch(:contact_name)}")
-      expect(page).to have_text("Email address: #{contact.fetch(:contact_email)}")
-      expect(page).to have_text("Phone number: #{contact.fetch(:contact_phone)}")
+      expect(page).to have_css("h3",           text: "Enquiry logged: #{enquiry.fetch(:enquiry_title)}")
+      expect(page).to have_css("p",            text: "Case is related to the coronavirus outbreak.")
+      expect(page).to have_css("p",            text: enquiry.fetch(:enquiry_description))
+      expect(page).to have_css("p",            text: "Attachment: testImage.png")
+      expect(page).to have_css("p.govuk-body", text: /Name: #{contact.fetch(:contact_name)}/)
+      expect(page).to have_css("p.govuk-body", text: /Email address: #{contact.fetch(:contact_email)}/)
+      expect(page).to have_css("p.govuk-body", text: /Phone number: #{contact.fetch(:contact_phone)}/)
       expect(page).to have_link("View attachment", href: /^.*testImage\.png$/)
     end
   end


### PR DESCRIPTION
#631 inadvertently changed the styling of activities. This fixes it.

After:
![Screenshot 2020-05-22 at 12 19 11](https://user-images.githubusercontent.com/2204224/82662926-a3dbc200-9c26-11ea-998f-2a4fa18eb487.png)

Before:
![Screenshot 2020-05-22 at 12 19 19](https://user-images.githubusercontent.com/2204224/82662947-accc9380-9c26-11ea-904d-3387a7ec08e7.png)

Other fixes:
 * Uses paragraphs where appropriate rather than `<br>`
 * Moves complainant type out of restricted area as it's not meant to be hidden.
 * Reformats the complainant details to use a single paragraph.