### PR TITLE
Remove RSpec 2 style expectation

### DIFF
--- a/psd-web/spec/features/investigation_edit_spec.rb
+++ b/psd-web/spec/features/investigation_edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stu
   scenario "allows to edit some the attributes" do
     sign_in user
     visit investigation_path(investigation)
-    expect(page).to have_content("Change summary")
+    expect(page).to have_link("Change summary", href: "/cases/#{investigation.pretty_id}/edit_summary")
 
     click_link "Change summary"
 

--- a/psd-web/spec/features/investigation_edit_spec.rb
+++ b/psd-web/spec/features/investigation_edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Ability to edit an investigation", :with_elasticsearch, :with_stu
   scenario "allows to edit some the attributes" do
     sign_in user
     visit investigation_path(investigation)
-    page.should have_content("Change summary")
+    expect(page).to have_content("Change summary")
 
     click_link "Change summary"
 


### PR DESCRIPTION
## CHANGES:
1. Monkey patched `should` has been deprecated for years. RSpec 3 has a much better expectation `expect` that does not require monkey patching objects on the fly.
2. Assert content on the page using css selector based `have_link` over `have_content` when we introduced RSpec, it's has been agreed to use specific css selector over `have_content` as they are more robust