### PR TITLE
Fix sidekiq healthcheck spec

### DIFF
--- a/psd-web/app/models/audit_activity/investigation/update_owner.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_owner.rb
@@ -49,6 +49,8 @@ private
   end
 
   def compute_relevant_entities(model:, compute_users_from_entity:)
+    return [] unless investigation.saved_changes.key?("owner_id")
+
     previous_owner_id = investigation.saved_changes["owner_id"][0]
     previous_owner = model.find_by(id: previous_owner_id)
     new_owner = investigation.owner

--- a/psd-web/app/models/audit_activity/investigation/update_owner.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_owner.rb
@@ -49,8 +49,9 @@ private
   end
 
   def compute_relevant_entities(model:, compute_users_from_entity:)
-    previous_owner_id = investigation.saved_changes["owner_id"][0]
-    previous_owner = model.find_by(id: previous_owner_id)
+    return [] unless investigation.owner_id_changed?
+
+    previous_owner = model.find_by(id: investigation.owner_id_was)
     new_owner = investigation.owner
     owner_changed_by = source.user
 

--- a/psd-web/app/models/audit_activity/investigation/update_owner.rb
+++ b/psd-web/app/models/audit_activity/investigation/update_owner.rb
@@ -49,9 +49,8 @@ private
   end
 
   def compute_relevant_entities(model:, compute_users_from_entity:)
-    return [] unless investigation.owner_id_changed?
-
-    previous_owner = model.find_by(id: investigation.owner_id_was)
+    previous_owner_id = investigation.saved_changes["owner_id"][0]
+    previous_owner = model.find_by(id: previous_owner_id)
     new_owner = investigation.owner
     owner_changed_by = source.user
 

--- a/psd-web/config/application.rb
+++ b/psd-web/config/application.rb
@@ -23,8 +23,9 @@ module ProductSafetyDatabase
     config.eager_load_paths << Rails.root.join("presenters")
     config.autoload_paths << Rails.root.join("app/forms/concerns")
 
+    config.sidekiq_queue = ENV.fetch("SIDEKIQ_QUEUE", "psd")
     config.active_job.queue_adapter = :sidekiq
-    config.action_mailer.deliver_later_queue_name = "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}-mailers"
+    config.action_mailer.deliver_later_queue_name = "#{config.sidekiq_queue}-mailers"
 
     # This changes Rails timezone, but keeps ActiveRecord in UTC
     config.time_zone = "Europe/London"

--- a/psd-web/spec/requests/health_spec.rb
+++ b/psd-web/spec/requests/health_spec.rb
@@ -3,15 +3,27 @@ require "rails_helper"
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "Health Check", :with_elasticsearch, :with_stubbed_mailer, :with_2fa do
   describe "/health/all" do
+    let(:sidekiq_latency) { 29 }
+    let(:sidekiq_queue) { instance_double(Sidekiq::Queue, latency: sidekiq_latency) }
+    let(:auth_headers) { { "Authorization" => "Basic #{Base64.encode64('health:check')}" } }
+
     before do
       create(:allegation)
       Investigation.import refresh: true, force: true
+      allow(Sidekiq::Queue).to receive(:new).with("psd").and_return(sidekiq_queue)
     end
 
     it "checks health" do
-      auth_headers = { "Authorization" => "Basic #{Base64.encode64('health:check')}" }
       get health_all_path, headers: auth_headers
       expect(response).to be_successful
+    end
+
+    context "when sidekiq is not responsive" do
+      let(:sidekiq_latency) { 31 }
+
+      it do
+        expect { get health_all_path, headers: auth_headers }.to raise_error(RuntimeError, "Sidekiq queue latency is above 30 seconds")
+      end
     end
   end
 end


### PR DESCRIPTION
## CHANGES: 

1. Fix the spec that fails if sidekiq is not running. We want our test suite to avoid depending on other things except databases.
2. Access environment variables configuration via the the standard `Rails.application.config` 
3. Add a spec that was missing.
4. updated `OwnerUpdate#compute_relevant_entities` to avoid lookup into `saved_changes[owner_id]` if it does not exist