### PR TITLE
Fix flash message showing wrong name

### DIFF
--- a/psd-web/app/controllers/investigations/ownership_controller.rb
+++ b/psd-web/app/controllers/investigations/ownership_controller.rb
@@ -29,7 +29,7 @@ class Investigations::OwnershipController < ApplicationController
     @investigation.owner = potential_owner
     @investigation.owner_rationale = params[:investigation][:owner_rationale]
     @investigation.save
-    redirect_to investigation_path(@investigation), flash: { success: "#{@investigation.case_type.upcase_first} owner changed to #{@investigation.owner.display_name}" }
+    redirect_to investigation_path(@investigation), flash: { success: "#{@investigation.case_type.upcase_first} owner changed to #{potential_owner.decorate.display_name}" }
   end
 
 private

--- a/psd-web/spec/features/change_ownership_for_investigation_spec.rb
+++ b/psd-web/spec/features/change_ownership_for_investigation_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
 
     fill_and_submit_change_owner_reason_form
 
+    expect_confirmation_banner("Allegation owner changed to " + another_active_user.name)
     expect_page_to_show_case_owner(another_active_user)
     expect_activity_page_to_show_case_owner_changed_to(another_active_user)
   end
@@ -49,6 +50,7 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
 
     fill_and_submit_change_owner_reason_form
 
+    expect_confirmation_banner("Allegation owner changed to " + user.team.name)
     expect_page_to_show_case_owner(user.team)
     expect_activity_page_to_show_case_owner_changed_to(user.team)
   end


### PR DESCRIPTION
The change of owner flash message was showing the previous owner rather than the new owner.