### PR TITLE
Fix flaky test

### DIFF
--- a/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
+++ b/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Investigations::DisplayTextHelper, type: :helper do
   describe "#investigation_owner", :with_stubbed_mailer, :with_stubbed_notify, :with_stubbed_elasticsearch do
     context "when the case owner is a user" do
       let(:team) { create(:team, name: "Southampton Council") }
-      let(:user) { create(:user, team: team) }
+      let(:user) { create(:user, team: team, name: "John Doe") }
       let(:investigation) { create(:investigation, owner: user) }
 
       it "displays their team name as well as their name" do
         result = helper.investigation_owner(investigation)
-        expect(result).to eq("#{user.name}<br>Southampton Council")
+        expect(result).to eq("John Doe<br>Southampton Council")
       end
     end
 


### PR DESCRIPTION
Faker adds HTML characters there are escaped. Such as in this [test](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/649/checks?check_run_id=708778365).

