### PR TITLE
Only display complainant contact details on case summary page to teams added to the case

### DIFF
--- a/.github/workflows/overrides/case_permissions_team.env
+++ b/.github/workflows/overrides/case_permissions_team.env
@@ -1,0 +1,1 @@
+export DB_NAME=case_permissions_team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ## 2020-05-26
 - Update service guidance to give details of revised permission model on cases.
 
+## 2020-05-26
+- Only teams added to a case can view complainant contact details on the case summary page.
+
 ## 2020-05-13
 - Allow users that haven't verified their mobile number to change their mobile number while requesting a new security code.
 

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -42,11 +42,12 @@ class InvestigationDecorator < ApplicationDecorator
   end
 
   def source_details_summary_list(user)
-    contact_details = if complainant.can_be_displayed?(user)
-                        complainant.decorate.contact_details
-                      else
-                        "Reporter details are restricted because they contain GDPR protected data."
-                      end
+    contact_details = h.tag.p(I18n.t("case.protected_details", data_type: "#{object.case_type} contact details"), class: "govuk-hint")
+
+    if Pundit.policy(user, object).view_protected_details?
+      contact_details << complainant.decorate.contact_details
+    end
+
     rows = [
       should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,
       should_display_received_by? ? { key: { text: "Received by" }, value: { text: received_type.upcase_first } } : nil,

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -41,12 +41,9 @@ class InvestigationDecorator < ApplicationDecorator
     h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"
   end
 
-  def source_details_summary_list(user)
+  def source_details_summary_list(view_protected_details = false)
     contact_details = h.tag.p(I18n.t("case.protected_details", data_type: "#{object.case_type} contact details"), class: "govuk-hint")
-
-    if Pundit.policy(user, object).view_protected_details?
-      contact_details << complainant.decorate.contact_details
-    end
+    contact_details << h.tag.p(complainant.decorate.contact_details) if view_protected_details
 
     rows = [
       should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -1,6 +1,6 @@
 class InvestigationDecorator < ApplicationDecorator
   delegate_all
-  decorates_associations :documents_attachments, :owner, :source
+  decorates_associations :complainant, :documents_attachments, :owner, :source
 
   PRODUCT_DISPLAY_LIMIT = 6
 
@@ -43,7 +43,7 @@ class InvestigationDecorator < ApplicationDecorator
 
   def source_details_summary_list(view_protected_details = false)
     contact_details = h.tag.p(I18n.t("case.protected_details", data_type: "#{object.case_type} contact details"), class: "govuk-hint")
-    contact_details << h.tag.p(complainant.decorate.contact_details) if view_protected_details
+    contact_details << h.tag.p(complainant.contact_details) if view_protected_details
 
     rows = [
       should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,

--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -43,7 +43,7 @@ class InvestigationDecorator < ApplicationDecorator
 
   def source_details_summary_list(view_protected_details = false)
     contact_details = h.tag.p(I18n.t("case.protected_details", data_type: "#{object.case_type} contact details"), class: "govuk-hint")
-    contact_details << h.tag.p(complainant.contact_details) if view_protected_details
+    contact_details << complainant.contact_details if view_protected_details
 
     rows = [
       should_display_date_received? ? { key: { text: "Received date" }, value: { text: date_received.to_s(:govuk) } } : nil,

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -37,13 +37,7 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def view_protected_details?(user: @user)
-    # Is the user a member of the case owner's team?
-    return true if @record.owner.present? && (@record.owner&.team == user.team)
-
-    # Has the user's team been added to the case as a collaborator?
-    return true if @record.teams.include?(user.team)
-
-    false
+    @record.teams_with_access.include?(user.team)
   end
 
   def send_email_alert?(user: @user)

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -36,6 +36,16 @@ class InvestigationPolicy < ApplicationPolicy
     false
   end
 
+  def view_protected_details?(user: @user)
+    # Is the user a member of the case owner's team?
+    return true if @record.owner.present? && (@record.owner&.team == user.team)
+
+    # Has the user's team been added to the case as a collaborator?
+    return true if @record.teams.include?(user.team)
+
+    false
+  end
+
   def send_email_alert?(user: @user)
     user.is_opss?
   end

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -26,7 +26,7 @@
     <% if @investigation.complainant %>
       <%= govuk_hr %>
       <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.upcase_first %></h2>
-      <%= @investigation.source_details_summary_list(current_user) %>
+      <%= @investigation.source_details_summary_list(policy(@investigation).view_protected_details?) %>
     <% end %>
 
     <%= govuk_hr %>

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
     coronavirus_related:
       true: "Coronavirus related case"
       false: "Not a coronavirus related case"
+    protected_details: "Only teams added to the case can view %{data_type}"
   investigations:
     coronavirus_related:
       show:

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
   end
 
   describe "#source_details_summary_list" do
-    let(:viewing_user) { user }
-    let(:source_details_summary_list) { decorated_investigation.source_details_summary_list(viewing_user) }
+    let(:view_protected_details) { true }
+    let(:source_details_summary_list) { decorated_investigation.source_details_summary_list(view_protected_details) }
 
     it "does not display the Received date" do
       expect(source_details_summary_list).not_to summarise("Received date", text: investigation.date_received.to_s(:govuk))
@@ -138,28 +138,20 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
       expect(source_details_summary_list).to summarise("Source type", text: investigation.complainant.complainant_type)
     end
 
-    context "when the user is on the owner team" do
-      let(:viewing_user) { user }
+    context "when view_protected_details is true" do
+      let(:view_protected_details) { true }
 
       it "displays the complainant details" do
         expect_to_display_protect_details_message
-        expect_to_summarise_complainant_details
+        expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.name)}/)
+        expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.phone_number)}/)
+        expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.email_address)}/)
+        expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.other_details)}/)
       end
     end
 
-    context "when the user is on a collaborating team" do
-      let(:viewing_user) { create(:user) }
-
-      before { create(:collaborator, investigation: investigation, team: viewing_user.team, added_by_user: creator) }
-
-      it "displays the complainant details" do
-        expect_to_display_protect_details_message
-        expect_to_summarise_complainant_details
-      end
-    end
-
-    context "when the user is not on a collaborating team" do
-      let(:viewing_user) { create(:user) }
+    context "when view_protected_details is false" do
+      let(:view_protected_details) { false }
 
       it "does not display the Complainant details", :aggregate_failures do
         expect_to_display_protect_details_message
@@ -172,13 +164,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
 
     def expect_to_display_protect_details_message
       expect(source_details_summary_list).to summarise("Contact details", text: /Only teams added to the case can view allegation contact details/)
-    end
-
-    def expect_to_summarise_complainant_details
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.name)}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.phone_number)}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.email_address)}/)
-      expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.other_details)}/)
     end
   end
 

--- a/psd-web/spec/decorators/investigation_decorator_spec.rb
+++ b/psd-web/spec/decorators/investigation_decorator_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
     context "when view_protected_details is true" do
       let(:view_protected_details) { true }
 
-      it "displays the complainant details" do
+      it "displays the complainant details", :aggregate_failures do
         expect_to_display_protect_details_message
         expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.name)}/)
         expect(source_details_summary_list).to summarise("Contact details", text: /#{Regexp.escape(investigation.complainant.phone_number)}/)

--- a/psd-web/spec/features/add_activity_entry_spec.rb
+++ b/psd-web/spec/features/add_activity_entry_spec.rb
@@ -63,11 +63,13 @@ RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with
       expect(page).to have_css(".hmcts-banner", text: "Comment was successfully added.")
 
       expect(delivered_emails.map(&:recipient).uniq.sort).to eq ["active@example.com", "creator@example.com"]
-      expect(delivered_emails.last.personalization).to include(
-        name: "Active user",
-        subject_text: "Allegation updated",
-        update_text: "#{commentator_user.name} (test team) commented on the allegation."
-      )
+
+      delivered_emails.each do |email|
+        expect(email.personalization).to include(
+          subject_text: "Allegation updated",
+          update_text: "#{commentator_user.name} (test team) commented on the allegation."
+        )
+      end
     end
   end
 

--- a/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
@@ -74,7 +74,8 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       expect_page_to_have_h1("Overview")
 
-      expect_details_on_summary_page(contact_details)
+      expect_details_on_summary_page
+      expect_protected_details_on_summary_page(contact_details)
 
       click_link "Products (0)"
       click_link "Add product"
@@ -99,7 +100,12 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       investigation = Investigation.last
 
-      visit "/cases/#{investigation.pretty_id}/activity"
+      visit "/cases/#{investigation.pretty_id}"
+
+      expect_details_on_summary_page
+      expect_protected_details_not_on_summary_page(contact_details)
+
+      click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
       expect_case_activity_page_to_show_restricted_information(allegation_details)
@@ -109,7 +115,12 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       sign_in(other_user_same_team)
 
-      visit "/cases/#{investigation.pretty_id}/activity"
+      visit "/cases/#{investigation.pretty_id}"
+
+      expect_details_on_summary_page
+      expect_protected_details_on_summary_page(contact_details)
+
+      click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
       expect_details_on_activity_page(contact_details, allegation_details)
@@ -145,13 +156,22 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page.find("dt", text: "Description")).to have_sibling("dd", text: description)
   end
 
-  def expect_details_on_summary_page(contact_name:, contact_email:, contact_phone:)
+  def expect_details_on_summary_page
     expect(page.find("dt", text: "Source type")).to have_sibling("dd", text: "Consumer")
+    expect(page.find("dt", text: "Coronavirus related"))
+      .to have_sibling("dd", text: "Coronavirus related case")
+  end
+
+  def expect_protected_details_on_summary_page(contact_name:, contact_email:, contact_phone:)
     expect(page).to have_css("p", text: contact_name)
     expect(page).to have_css("p", text: contact_email)
     expect(page).to have_css("p", text: contact_phone)
-    expect(page.find("dt", text: "Coronavirus related"))
-      .to have_sibling("dd", text: "Coronavirus related case")
+  end
+
+  def expect_protected_details_not_on_summary_page(contact_name:, contact_email:, contact_phone:)
+    expect(page).not_to have_css("p", text: contact_name)
+    expect(page).not_to have_css("p", text: contact_email)
+    expect(page).not_to have_css("p", text: contact_phone)
   end
 
   def expect_details_on_activity_page(contact, allegation)

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -59,7 +59,8 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
 
       expect_page_to_have_h1("Overview")
 
-      expect_details_on_summary_page(contact_details)
+      expect_details_on_summary_page
+      expect_protected_details_on_summary_page(contact_details)
 
       click_on "Activity"
       expect_details_on_activity_page(contact_details, enquiry_details)
@@ -71,7 +72,12 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
 
       investigation = Investigation.last
 
-      visit "/cases/#{investigation.pretty_id}/activity"
+      visit "/cases/#{investigation.pretty_id}"
+
+      expect_details_on_summary_page
+      expect_protected_details_not_on_summary_page(contact_details)
+
+      click_on "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
       expect_case_activity_page_to_show_restricted_information(enquiry_details)
@@ -81,7 +87,12 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
 
       sign_in(other_user_same_team)
 
-      visit "/cases/#{investigation.pretty_id}/activity"
+      visit "/cases/#{investigation.pretty_id}"
+
+      expect_details_on_summary_page
+      expect_protected_details_on_summary_page(contact_details)
+
+      click_on "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
       expect_details_on_activity_page(contact_details, enquiry_details)
@@ -125,13 +136,22 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     end
   end
 
-  def expect_details_on_summary_page(contact_name:, contact_email:, contact_phone:)
+  def expect_details_on_summary_page
     expect(page.find("dt", text: "Source type")).to have_sibling("dd", text: "Consumer")
+    expect(page.find("dt", text: "Coronavirus related"))
+      .to have_sibling("dd", text: "Coronavirus related case")
+  end
+
+  def expect_protected_details_on_summary_page(contact_name:, contact_email:, contact_phone:)
     expect(page).to have_css("p", text: contact_name)
     expect(page).to have_css("p", text: contact_email)
     expect(page).to have_css("p", text: contact_phone)
-    expect(page.find("dt", text: "Coronavirus related"))
-      .to have_sibling("dd", text: "Coronavirus related case")
+  end
+
+  def expect_protected_details_not_on_summary_page(contact_name:, contact_email:, contact_phone:)
+    expect(page).not_to have_css("p", text: contact_name)
+    expect(page).not_to have_css("p", text: contact_email)
+    expect(page).not_to have_css("p", text: contact_phone)
   end
 
   def expect_details_on_activity_page(contact, enquiry)


### PR DESCRIPTION
https://trello.com/c/G1tdeHxB/547-2-dont-show-enquiry-contact-details-to-teams-not-involved-in-case

## Description
This displays a hint text and conditionally displays the contact details of a complainant only if the user is a member of a team on the case (which may be the owner's team or a collaborating team).

I confirmed with @edwardhorsford that this should also apply to allegations as well as enquiries. The hint text changes accordingly.

There's a bit of existing code duplication on the feature specs which I've made a bit worse - I haven't addressed this as it would need a bit more refactoring of the test and creation of some generic helpers, which wasn't directly related. We can do that in a separate pull request.

### Screenshots:

#### Before:
<img width="823" alt="Screenshot 2020-05-26 at 14 31 27" src="https://user-images.githubusercontent.com/408371/82906766-9c395780-9f5d-11ea-96b7-c0ea19ee479d.png">

#### After (Team added to case)
<img width="812" alt="Screenshot 2020-05-26 at 11 42 17" src="https://user-images.githubusercontent.com/408371/82906221-d1917580-9f5c-11ea-89ae-47fe2e1d6e7c.png">

#### After (Team not on case)
<img width="814" alt="Screenshot 2020-05-26 at 11 39 11" src="https://user-images.githubusercontent.com/408371/82906239-d9511a00-9f5c-11ea-8e1b-a25867f272ac.png">


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
- [x] Has the CHANGELOG been updated? (If change is worth telling users about.)
