### PR TITLE
Restrict secondary authentication page

### DIFF
--- a/psd-web/app/controllers/secondary_authentications_controller.rb
+++ b/psd-web/app/controllers/secondary_authentications_controller.rb
@@ -10,6 +10,8 @@ class SecondaryAuthenticationsController < ApplicationController
   skip_before_action :set_cache_headers
 
   def new
+    return render("errors/forbidden", status: :forbidden) unless session[:secondary_authentication_user_id]
+
     @secondary_authentication_form = SecondaryAuthenticationForm.new(user_id: session[:secondary_authentication_user_id])
   end
 
@@ -28,7 +30,7 @@ class SecondaryAuthenticationsController < ApplicationController
 private
 
   def hide_nav?
-    if secondary_authentication.operation == SecondaryAuthentication::INVITE_USER
+    if secondary_authentication&.operation == SecondaryAuthentication::INVITE_USER
       super
     else
       true
@@ -36,7 +38,7 @@ private
   end
 
   def secondary_nav_items
-    if secondary_authentication.operation == SecondaryAuthentication::INVITE_USER
+    if secondary_authentication&.operation == SecondaryAuthentication::INVITE_USER
       super
     else
       [text: "Sign out", href: destroy_user_session_path]
@@ -44,7 +46,7 @@ private
   end
 
   def secondary_authentication
-    @secondary_authentication_form.secondary_authentication
+    @secondary_authentication_form&.secondary_authentication
   end
 
   def redirect_to_saved_path

--- a/psd-web/spec/requests/secondary_authentication_spec.rb
+++ b/psd-web/spec/requests/secondary_authentication_spec.rb
@@ -1,114 +1,123 @@
 require "rails_helper"
 
 RSpec.describe "Secondary Authentication submit", :with_stubbed_notify, type: :request do
-  subject(:submit_2fa) do
-    post secondary_authentication_path,
-         params: {
-           secondary_authentication_form: {
-             otp_code: submitted_code,
-             user_id: user.id
+  describe "#new" do
+    it "cannot be directly accessed" do
+      get new_secondary_authentication_path
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "#create" do
+    subject(:submit_2fa) do
+      post secondary_authentication_path,
+           params: {
+             secondary_authentication_form: {
+               otp_code: submitted_code,
+               user_id: user.id
+             }
            }
-         }
-  end
-
-  let(:attempts) { 0 }
-  let(:direct_otp_sent_at) { Time.new.utc }
-  let(:secondary_authentication) { SecondaryAuthentication.new(user) }
-  let(:submitted_code) { secondary_authentication.direct_otp }
-  let(:max_attempts) { SecondaryAuthentication::MAX_ATTEMPTS }
-  let(:second_factor_attempts_locked_at) { nil }
-
-  let(:previous_attempts_count) { 1 }
-  let(:user) do
-    create(
-      :user,
-      :activated,
-      mobile_number_verified: false,
-      direct_otp_sent_at: direct_otp_sent_at,
-      second_factor_attempts_count: attempts,
-      second_factor_attempts_locked_at: second_factor_attempts_locked_at
-    )
-  end
-
-  before do
-    sign_in(user)
-  end
-
-  shared_examples_for "code not accepted" do |*errors|
-    it "does not leave the two factor form page" do
-      submit_2fa
-      expect(response).to render_template(:new)
     end
 
-    it "displays an error to the user" do
-      submit_2fa
-      errors.each do |error|
-        expect(response.body).to include(error)
+    let(:attempts) { 0 }
+    let(:direct_otp_sent_at) { Time.new.utc }
+    let(:secondary_authentication) { SecondaryAuthentication.new(user) }
+    let(:submitted_code) { secondary_authentication.direct_otp }
+    let(:max_attempts) { SecondaryAuthentication::MAX_ATTEMPTS }
+    let(:second_factor_attempts_locked_at) { nil }
+
+    let(:previous_attempts_count) { 1 }
+    let(:user) do
+      create(
+        :user,
+        :activated,
+        mobile_number_verified: false,
+        direct_otp_sent_at: direct_otp_sent_at,
+        second_factor_attempts_count: attempts,
+        second_factor_attempts_locked_at: second_factor_attempts_locked_at
+      )
+    end
+
+    before do
+      sign_in(user)
+    end
+
+    shared_examples_for "code not accepted" do |*errors|
+      it "does not leave the two factor form page" do
+        submit_2fa
+        expect(response).to render_template(:new)
+      end
+
+      it "displays an error to the user" do
+        submit_2fa
+        errors.each do |error|
+          expect(response.body).to include(error)
+        end
       end
     end
-  end
 
-  context "when code is invalid" do
-    let(:submitted_code) { "" }
+    context "when code is invalid" do
+      let(:submitted_code) { "" }
 
-    include_examples "code not accepted", "Enter the security code"
-  end
-
-  context "with correct otp" do
-    it "redirects to the main page" do
-      submit_2fa
-      expect(response).to redirect_to(root_path)
+      include_examples "code not accepted", "Enter the security code"
     end
 
-    it "user is signed in" do
-      submit_2fa
-      follow_redirect!
-      expect(response.body).to include("Sign out")
+    context "with correct otp" do
+      it "redirects to the main page" do
+        submit_2fa
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "user is signed in" do
+        submit_2fa
+        follow_redirect!
+        expect(response.body).to include("Sign out")
+      end
+
+      it "marks the mobile number as verified" do
+        submit_2fa
+        expect(user.reload.mobile_number_verified).to be true
+      end
     end
 
-    it "marks the mobile number as verified" do
-      submit_2fa
-      expect(user.reload.mobile_number_verified).to be true
+    context "with incorrect otp" do
+      let(:submitted_code) { secondary_authentication.direct_otp.reverse }
+
+      include_examples "code not accepted", "Incorrect security code"
     end
-  end
 
-  context "with incorrect otp" do
-    let(:submitted_code) { secondary_authentication.direct_otp.reverse }
-
-    include_examples "code not accepted", "Incorrect security code"
-  end
-
-  context "with expired otp" do
-    let(:direct_otp_sent_at) { (SecondaryAuthentication::OTP_EXPIRY_SECONDS * 2).seconds.ago }
-
-    include_examples "code not accepted", "The security code has expired. New code sent."
-  end
-
-  context "with too many attempts" do
-    let(:attempts) { max_attempts + 1 }
-
-    include_examples "code not accepted", "Incorrect security code"
-  end
-
-  context "with resending otp code" do
-    # rubocop:disable RSpec/AnyInstance
-    context "when code is expired" do
+    context "with expired otp" do
       let(:direct_otp_sent_at) { (SecondaryAuthentication::OTP_EXPIRY_SECONDS * 2).seconds.ago }
 
-      context "when secondary authentication is locked" do
-        let(:second_factor_attempts_locked_at) { Time.now.utc }
+      include_examples "code not accepted", "The security code has expired. New code sent."
+    end
 
-        it "does not send the code" do
-          expect_any_instance_of(SecondaryAuthentication).not_to receive(:generate_and_send_code)
+    context "with too many attempts" do
+      let(:attempts) { max_attempts + 1 }
+
+      include_examples "code not accepted", "Incorrect security code"
+    end
+
+    context "with resending otp code" do
+      # rubocop:disable RSpec/AnyInstance
+      context "when code is expired" do
+        let(:direct_otp_sent_at) { (SecondaryAuthentication::OTP_EXPIRY_SECONDS * 2).seconds.ago }
+
+        context "when secondary authentication is locked" do
+          let(:second_factor_attempts_locked_at) { Time.now.utc }
+
+          it "does not send the code" do
+            expect_any_instance_of(SecondaryAuthentication).not_to receive(:generate_and_send_code)
+            submit_2fa
+          end
+        end
+
+        it "resends the code" do
+          expect_any_instance_of(SecondaryAuthentication).to receive(:generate_and_send_code)
           submit_2fa
         end
       end
-
-      it "resends the code" do
-        expect_any_instance_of(SecondaryAuthentication).to receive(:generate_and_send_code)
-        submit_2fa
-      end
+      # rubocop:enable RSpec/AnyInstance
     end
-    # rubocop:enable RSpec/AnyInstance
   end
 end


### PR DESCRIPTION
[Related errors in our error tracker](https://sentry.io/organizations/beis/issues/1637054689/?environment=prod&project=1329381)

Only users with a secondary authentication user id in their session should be able to access the secondary authentication page.
This restriction aims to avoid the errors being triggered by users/bots directly accession the secondary authentication page instead of being redirected there by an action that required 2FA.

