### PR TITLE
Fix incorrect emails being sent

### DIFF
--- a/psd-web/app/models/audit_activity/investigation/add.rb
+++ b/psd-web/app/models/audit_activity/investigation/add.rb
@@ -66,4 +66,11 @@ class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
   def restricted_title
     title
   end
+
+  private
+    # Do not send investigation_updated mail when case added. This overrides
+    # inherited functionality in the Activity model :(
+    def entities_to_notify
+      []
+    end
 end

--- a/psd-web/app/models/audit_activity/investigation/add.rb
+++ b/psd-web/app/models/audit_activity/investigation/add.rb
@@ -70,7 +70,5 @@ class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
   private
     # Do not send investigation_updated mail when case added. This overrides
     # inherited functionality in the Activity model :(
-    def entities_to_notify
-      []
-    end
+    def notify_relevant_users; end
 end

--- a/psd-web/app/models/audit_activity/investigation/add.rb
+++ b/psd-web/app/models/audit_activity/investigation/add.rb
@@ -67,8 +67,9 @@ class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
     title
   end
 
-  private
-    # Do not send investigation_updated mail when case added. This overrides
-    # inherited functionality in the Activity model :(
-    def notify_relevant_users; end
+private
+
+  # Do not send investigation_updated mail when case added. This overrides
+  # inherited functionality in the Activity model :(
+  def notify_relevant_users; end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_added.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_added.rb
@@ -7,7 +7,5 @@ class AuditActivity::Investigation::TeamAdded < AuditActivity::Investigation::Ba
     # This is handled by the AddTeamToAnInvestigation service, but this
     # override is required to prevent a duplicate investigation_updated email
     # being enqueued, which will fail
-    def entities_to_notify
-      []
-    end
+    def notify_relevant_users; end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_added.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_added.rb
@@ -3,9 +3,10 @@ class AuditActivity::Investigation::TeamAdded < AuditActivity::Investigation::Ba
     "Team added by #{source&.show}, #{pretty_date_stamp}"
   end
 
-  private
-    # This is handled by the AddTeamToAnInvestigation service, but this
-    # override is required to prevent a duplicate investigation_updated email
-    # being enqueued, which will fail
-    def notify_relevant_users; end
+private
+
+  # This is handled by the AddTeamToAnInvestigation service, but this
+  # override is required to prevent a duplicate investigation_updated email
+  # being enqueued, which will fail
+  def notify_relevant_users; end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_added.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_added.rb
@@ -2,4 +2,12 @@ class AuditActivity::Investigation::TeamAdded < AuditActivity::Investigation::Ba
   def subtitle
     "Team added by #{source&.show}, #{pretty_date_stamp}"
   end
+
+  private
+    # This is handled by the AddTeamToAnInvestigation service, but this
+    # override is required to prevent a duplicate investigation_updated email
+    # being enqueued, which will fail
+    def entities_to_notify
+      []
+    end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_deleted.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_deleted.rb
@@ -2,4 +2,12 @@ class AuditActivity::Investigation::TeamDeleted < AuditActivity::Investigation::
   def subtitle
     "Team removed by #{source&.show}, #{pretty_date_stamp}"
   end
+
+  private
+    # This is handled by EditInvestigationCollaboratorForm, but this
+    # override is required to prevent a duplicate investigation_updated email
+    # being enqueued, which will fail
+    def entities_to_notify
+      []
+    end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_deleted.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_deleted.rb
@@ -3,9 +3,10 @@ class AuditActivity::Investigation::TeamDeleted < AuditActivity::Investigation::
     "Team removed by #{source&.show}, #{pretty_date_stamp}"
   end
 
-  private
-    # This is handled by EditInvestigationCollaboratorForm, but this
-    # override is required to prevent a duplicate investigation_updated email
-    # being enqueued, which will fail
-    def notify_relevant_users; end
+private
+
+  # This is handled by EditInvestigationCollaboratorForm, but this
+  # override is required to prevent a duplicate investigation_updated email
+  # being enqueued, which will fail
+  def notify_relevant_users; end
 end

--- a/psd-web/app/models/audit_activity/investigation/team_deleted.rb
+++ b/psd-web/app/models/audit_activity/investigation/team_deleted.rb
@@ -7,7 +7,5 @@ class AuditActivity::Investigation::TeamDeleted < AuditActivity::Investigation::
     # This is handled by EditInvestigationCollaboratorForm, but this
     # override is required to prevent a duplicate investigation_updated email
     # being enqueued, which will fail
-    def entities_to_notify
-      []
-    end
+    def notify_relevant_users; end
 end

--- a/psd-web/spec/features/add_activity_entry_spec.rb
+++ b/psd-web/spec/features/add_activity_entry_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with
       expect_to_be_on_case_page(case_id: investigation.pretty_id)
       expect(page).to have_css(".hmcts-banner", text: "Comment was successfully added.")
 
-      expect(delivered_emails.map(&:recipient).uniq).to eq ["creator@example.com", "active@example.com"]
+      expect(delivered_emails.map(&:recipient).uniq.sort).to eq ["active@example.com", "creator@example.com"]
       expect(delivered_emails.last.personalization).to include(
         name: "Active user",
         subject_text: "Allegation updated",

--- a/psd-web/spec/features/add_activity_entry_spec.rb
+++ b/psd-web/spec/features/add_activity_entry_spec.rb
@@ -1,14 +1,17 @@
 require "rails_helper"
 
 RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
-  let(:creator_user) { create(:user, :activated, email: "creator@example.com") }
-  let(:investigation) { create(:investigation, owner: creator_user) }
-  let(:investigation_path) { "/cases/#{investigation.pretty_id}" }
+  let!(:creator_user) { create(:user, :activated, email: "creator@example.com", team: team_without_email, organisation: team_without_email.organisation) }
+  let(:team_without_email) { create(:team, team_recipient_email: nil) }
+
+  let(:investigation_owner) { creator_user }
+  let(:investigation) { create(:allegation, owner: investigation_owner) }
+  let(:commentator_user) { create(:user, :activated) }
 
   scenario "Picking an activity type" do
     sign_in creator_user
 
-    visit investigation_path
+    visit "/cases/#{investigation.pretty_id}"
 
     click_link "Add activity"
 
@@ -20,17 +23,17 @@ RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with
   end
 
   scenario "Assigned user to the case receives activity notifications" do
-    commentator_user = create(:user, :activated, team: create(:team))
-
     sign_in commentator_user
 
-    visit investigation_path
+    visit "/cases/#{investigation.pretty_id}"
 
     click_link "Add comment"
+
     add_comment
 
-    expect(page).to have_current_path(investigation_path)
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
     expect(page).to have_css(".hmcts-banner", text: "Comment was successfully added.")
+
     expect(delivered_emails.last.recipient).to eq creator_user.email
     expect(delivered_emails.last.personalization).to include(
       name: creator_user.name,
@@ -39,29 +42,33 @@ RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with
     )
   end
 
-  scenario "Updates on cases owned by teams without team email send a notification to their active users" do
-    team_without_email = create(:team, team_recipient_email: nil)
-    active_user = create(:user, :activated, email: "active@example.com", team: team_without_email)
-    commentator_user = create(:user, :activated)
+  context "when the case is owned by a team which does not have an email address" do
+    let(:investigation_owner) { team_without_email }
 
-    create(:user, :inactive, email: "not_activated@example.com", team: team_without_email)
-    create(:user, :activated, :deleted, email: "deleted@example.com", team: team_without_email)
-    investigation.update_attribute(:owner, team_without_email)
+    before do
+      create(:user, :activated, email: "active@example.com", name: "Active user", team: team_without_email, organisation: team_without_email.organisation)
+      create(:user, :inactive, email: "not_activated@example.com", team: team_without_email, organisation: team_without_email.organisation)
+      create(:user, :activated, :deleted, email: "deleted@example.com", team: team_without_email, organisation: team_without_email.organisation)
+    end
 
-    sign_in commentator_user
+    scenario "case updates send a notification to the team's active users" do
+      sign_in commentator_user
 
-    visit investigation_path
-    click_link "Add comment"
-    add_comment
+      visit "/cases/#{investigation.pretty_id}"
+      click_link "Add comment"
 
-    expect(page).to have_current_path(investigation_path)
-    expect(page).to have_css(".hmcts-banner", text: "Comment was successfully added.")
-    expect(delivered_emails.map(&:recipient).uniq).to eq ["creator@example.com", "active@example.com"]
-    expect(delivered_emails.last.personalization).to include(
-      name: active_user.name,
-      subject_text: "Allegation updated",
-      update_text: "#{commentator_user.name} (test team) commented on the allegation."
-    )
+      add_comment
+
+      expect_to_be_on_case_page(case_id: investigation.pretty_id)
+      expect(page).to have_css(".hmcts-banner", text: "Comment was successfully added.")
+
+      expect(delivered_emails.map(&:recipient).uniq).to eq ["creator@example.com", "active@example.com"]
+      expect(delivered_emails.last.personalization).to include(
+        name: "Active user",
+        subject_text: "Allegation updated",
+        update_text: "#{commentator_user.name} (test team) commented on the allegation."
+      )
+    end
   end
 
   def add_comment

--- a/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
+++ b/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
@@ -4,12 +4,7 @@ RSpec.describe EditInvestigationCollaboratorForm, :with_elasticsearch, :with_stu
   let!(:investigation) { create(:allegation, owner: creator) }
   let(:creator) { create(:user, :activated, team: creator_team, organisation: creator_team.organisation) }
   let(:creator_team) { create(:team) }
-
   let(:team) { create(:team) }
-
-  let(:editor) do
-    create(:collaboration_edit_access, investigation: investigation, collaborator: team, added_by_user: user)
-  end
 
   # Use a second user to perform the change so that we can test the generic
   # investigation_updated email doesn't get sent
@@ -32,6 +27,8 @@ RSpec.describe EditInvestigationCollaboratorForm, :with_elasticsearch, :with_stu
   end
 
   let(:form) { described_class.new(params) }
+
+  before { create(:collaboration_edit_access, investigation: investigation, collaborator: team, added_by_user: user) }
 
   describe "#save!" do
     context "when deleting" do

--- a/psd-web/spec/services/add_team_to_an_investigation_spec.rb
+++ b/psd-web/spec/services/add_team_to_an_investigation_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe AddTeamToAnInvestigation, :with_stubbed_mailer, :with_stubbed_elasticsearch do
   describe ".call" do
     context "with required parameters" do
-      let(:investigation) { create(:allegation) }
+      # Create the case before running tests so that we can check which emails are sent by the service
+      let!(:investigation) { create(:allegation) }
+
       let(:user) { create(:user) }
       let(:team) { create(:team, name: "Testing team") }
       let(:message) { "Thanks for collaborating." }
@@ -37,6 +39,10 @@ RSpec.describe AddTeamToAnInvestigation, :with_stubbed_mailer, :with_stubbed_ela
             expect(collaborator.team_id).to eql(team.id)
           end
         end
+      end
+
+      it "does not queue the generic case updated mailer job", :with_test_queue_adapter do
+        expect { result }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
       end
 
       # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
https://trello.com/c/EynEb43M/573-generic-case-updated-emails-incorrectly-being-sent-when-team-added-removed-from-case

## Description
Fixes several bugs related to email notifications for a case:

* When a case is created, the [code which creates the audit log activity](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/models/audit_activity/investigation/base.rb#L4) assumes `User.current` is set, which it is not in our non-feature specs. This set the `source` of that activity to `nil` which meant that the [inherited functionality all the way down in `Activity`](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/psd-web/app/models/activity.rb#L82) would send a 'case updated' email when it never should do. This created false positives in our tests.
* Fixing the above revealed an issue with the feature spec for adding comments, which relied on this false positive. I fixed the issue and also improved the code in this file.
* The `AuditActivity::Investigation::TeamAdded` and `AuditActivity::Investigation::TeamDeleted` classes did not override the inherited functionality from `Activity`, so in certain circumstances it would send the generic 'case updated' email *in addition to* the correct, specific emails sent in the service/form classes. This has been [observed in production](https://sentry.io/organizations/beis/issues/1463173953/?project=1329381&referrer=slack). In addition the team deleted test was not set up in the specific way needed to reveal this issue, so I fixed that to create the failing test. The team added test was unaware of the extra email so I added a failing test to that before fixing the issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
