### PR TITLE
Remove redundant method

### DIFF
--- a/psd-web/app/helpers/investigations/visibility_helper.rb
+++ b/psd-web/app/helpers/investigations/visibility_helper.rb
@@ -1,8 +1,0 @@
-module Investigations::VisibilityHelper
-  def visibility_options
-    {
-      public: "Visible to all",
-      private: "Restricted for legal privilege"
-    }
-  end
-end

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -77,10 +77,6 @@ class Investigation < ApplicationRecord
     is_closed? ? "Closed" : "Open"
   end
 
-  def pretty_visibility
-    is_private ? ApplicationController.helpers.visibility_options[:private] : ApplicationController.helpers.visibility_options[:public]
-  end
-
   def important_owner_people
     people = [].to_set
     people << owner if owner.is_a? User

--- a/psd-web/app/views/investigations/visibility.html.slim
+++ b/psd-web/app/views/investigations/visibility.html.slim
@@ -18,9 +18,9 @@
                                      classes: "govuk-label--m" } },
                hint: { text: "Restricted cases are visible only to the organisation that created them and the \
                organisation of the current case owner." },
-               items: [{ text: visibility_options[:public],
+               items: [{ text: t(false, scope: "case.is_private"),
                          value: "false" },
-                       { text: visibility_options[:private],
+                       { text: t(true, scope: "case.is_private"),
                          value: "true" }]
       = render "form_components/govuk_textarea",
                key: :visibility_rationale,

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -54,6 +54,9 @@ en:
       true: "Coronavirus related case"
       false: "Not a coronavirus related case"
     protected_details: "Only teams added to the case can view %{data_type}"
+    is_private:
+      false: Visible to all
+      true: Restricted for legal privilege
   investigations:
     coronavirus_related:
       show:


### PR DESCRIPTION
## Description
This method appears to be unused anywhere and so we can safely remove it.

Also removed the helper it was calling (_in the model_ 😱) by reimplementing functionality with `I18n`.