### PR TITLE
Prevent instantiation of Investigation class

### DIFF
--- a/psd-web/app/controllers/investigations/ts_investigations_controller.rb
+++ b/psd-web/app/controllers/investigations/ts_investigations_controller.rb
@@ -120,7 +120,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.new(investigation_step_params)
+    @investigation = Investigation::Allegation.new(investigation_step_params)
   end
 
   def set_selected_businesses

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -17,6 +17,8 @@ class Investigation < ApplicationRecord
 
   before_validation { trim_line_endings(:user_title, :description, :non_compliant_reason, :hazard_description) }
 
+  validates :type, presence: true # Prevent saving instances of Investigation; must use a subclass instead
+
   validates :description, presence: true, on: :update
   validates :owner_id, presence: { message: "Select case owner" }, on: :update
 
@@ -64,6 +66,12 @@ class Investigation < ApplicationRecord
   # TODO: Refactor to remove this callback hell
   before_create :set_source_to_current_user, :set_owner_as_current_user, :add_pretty_id
   after_create :create_audit_activity_for_case, :send_confirmation_email
+
+  def initialize(*args)
+    raise "Cannot instantiate an Investigation - use one of its subclasses instead" if self.class == Investigation
+
+    super
+  end
 
   def owner_team
     owner&.team
@@ -137,9 +145,9 @@ class Investigation < ApplicationRecord
   end
 
   def reported_reason
-    return if super.blank?
+    return if self[:reported_reason].blank?
 
-    @reported_reason ||= ActiveSupport::StringInquirer.new(super)
+    @reported_reason ||= ActiveSupport::StringInquirer.new(self[:reported_reason])
   end
 
   def child_should_be_displayed?(user)

--- a/psd-web/spec/factories/collaborations.rb
+++ b/psd-web/spec/factories/collaborations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :collaboration, class: "Collaboration" do
     include_message { "false" }
-    association :investigation, factory: :investigation
+    association :investigation, factory: :allegation
     association :collaborator, factory: :team
     association :added_by_user, factory: :user
 

--- a/psd-web/spec/factories/complainants.rb
+++ b/psd-web/spec/factories/complainants.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     other_details { Faker::Lorem.paragraph }
     phone_number { Faker::PhoneNumber.phone_number }
     complainant_type { Complainant::TYPES.keys.sample }
-    investigation
+    association :investigation, factory: :allegation
   end
 
   Complainant::TYPES.each_key do |type|

--- a/psd-web/spec/factories/corrective_actions.rb
+++ b/psd-web/spec/factories/corrective_actions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :corrective_action do
-    investigation
+    association :investigation, factory: :allegation
     product
     summary { Faker::Lorem.sentence }
     date_decided_day { date_decided.day }

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       description { "test allegation" }
       user_title { "test allegation title" }
 
-      factory :allegation_unsafe do
+      factory :allegation_unsafe, class: "Investigation::Allegation" do
         reported_unsafe
       end
     end

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
 
   let(:investigation) do
     create(
-      :investigation,
+      :allegation,
       owner: user
     )
   end

--- a/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
+++ b/psd-web/spec/helpers/investigations/display_text_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Investigations::DisplayTextHelper, type: :helper do
     context "when the case owner is a user" do
       let(:team) { create(:team, name: "Southampton Council") }
       let(:user) { create(:user, team: team, name: "John Doe") }
-      let(:investigation) { create(:investigation, owner: user) }
+      let(:investigation) { create(:allegation, owner: user) }
 
       it "displays their team name as well as their name" do
         result = helper.investigation_owner(investigation)
@@ -15,7 +15,7 @@ RSpec.describe Investigations::DisplayTextHelper, type: :helper do
 
     context "when the case owner is a team" do
       let(:team) { create(:team, name: "Southampton Council") }
-      let(:investigation) { create(:investigation, owner: team) }
+      let(:investigation) { create(:allegation, owner: team) }
 
       it "displays the team name once" do
         result = helper.investigation_owner(investigation)

--- a/psd-web/spec/models/investigation_spec.rb
+++ b/psd-web/spec/models/investigation_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_notify do
   describe "#teams_with_access" do
     context "when there is no case owner" do
-      let(:investigation) { create(:investigation, owner: nil) }
+      let(:investigation) { create(:allegation, owner: nil) }
 
       it "is an empty list" do
         expect(investigation.teams_with_access).to be_empty
@@ -12,7 +12,7 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
 
     context "when there is just a team that is the case owner" do
       let(:team) { create(:team) }
-      let(:investigation) { create(:investigation, owner: team) }
+      let(:investigation) { create(:allegation, owner: team) }
 
       it "is a list of just the team" do
         expect(investigation.teams_with_access).to eql([team])
@@ -24,7 +24,7 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
       let(:collaborator_team) { create(:team) }
       let(:investigation) do
         create(
-          :investigation,
+          :allegation,
           owner: team,
           edit_access_collaborations: [
             create(:collaboration_edit_access, collaborator: collaborator_team)
@@ -40,7 +40,7 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
 
   describe "#owner_team" do
     context "when there is no case owner" do
-      let(:investigation) { create(:investigation, owner: nil) }
+      let(:investigation) { create(:allegation, owner: nil) }
 
       it "is nil" do
         expect(investigation.owner_team).to be_nil
@@ -49,7 +49,7 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
 
     context "when there is a team as the case owner" do
       let(:team) { create(:team) }
-      let(:investigation) { create(:investigation, owner: team) }
+      let(:investigation) { create(:allegation, owner: team) }
 
       it "is is the team" do
         expect(investigation.owner_team).to eql(team)
@@ -59,7 +59,7 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
     context "when there is a user who belongs to a team that is the case owner" do
       let(:team) { create(:team) }
       let(:user) { create(:user, team: team) }
-      let(:investigation) { create(:investigation, owner: user) }
+      let(:investigation) { create(:allegation, owner: user) }
 
       it "is is the team the user belongs to" do
         expect(investigation.owner_team).to eql(team)

--- a/psd-web/spec/requests/add_collaborator_spec.rb
+++ b/psd-web/spec/requests/add_collaborator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Adding a collaborator to a case", type: :request, with_stubbed_m
 
   context "when the collaborator params are valid" do
     let(:message) { "Thanks for collaborating on this case" }
-    let(:investigation) { create(:investigation, owner: user) }
+    let(:investigation) { create(:allegation, owner: user) }
     let(:other_team) { create(:team) }
 
     before do
@@ -41,7 +41,7 @@ RSpec.describe "Adding a collaborator to a case", type: :request, with_stubbed_m
 
   context "when the collaborator params are invalid" do
     let(:message) { "Thanks for collaborating on this case" }
-    let(:investigation) { create(:investigation, owner: user) }
+    let(:investigation) { create(:allegation, owner: user) }
     let(:other_team) { create(:team) }
 
     before do
@@ -66,7 +66,7 @@ RSpec.describe "Adding a collaborator to a case", type: :request, with_stubbed_m
     let(:existing_collaborator_team) { create(:team) }
     let(:investigation) do
       create(
-        :investigation,
+        :allegation,
         owner: user,
         edit_access_collaborations: [
           create(
@@ -97,7 +97,7 @@ RSpec.describe "Adding a collaborator to a case", type: :request, with_stubbed_m
   end
 
   context "when the user isn't part of the team that is the case owner", :with_errors_rendered do
-    let(:investigation) { create(:investigation, owner: create(:team)) }
+    let(:investigation) { create(:allegation, owner: create(:team)) }
 
     before do
       sign_in user

--- a/psd-web/spec/requests/add_comment_spec.rb
+++ b/psd-web/spec/requests/add_comment_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Adding a comment to a case", type: :request, with_stubbed_mailer: true, with_stubbed_elasticsearch: true do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
-  let(:investigation) { create(:investigation) }
+  let(:investigation) { create(:allegation) }
 
   before { sign_in(user) }
 

--- a/psd-web/spec/requests/edit_collaborator_spec.rb
+++ b/psd-web/spec/requests/edit_collaborator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Editig a collaborator for a case", type: :request, with_stubbed_
   let(:user) { create(:user, :activated, has_viewed_introduction: true, team: user_team) }
 
   let(:team) { create(:team) }
-  let(:investigation) { create(:investigation, owner: user) }
+  let(:investigation) { create(:allegation, owner: user) }
   let(:edit_access_collaboration) do
     create(:collaboration_edit_access, investigation: investigation, collaborator: team, added_by_user: user)
   end
@@ -58,7 +58,7 @@ RSpec.describe "Editig a collaborator for a case", type: :request, with_stubbed_
   end
 
   context "when the user isn't part of the team assigned", :with_errors_rendered do
-    let(:investigation) { create(:investigation, owner: create(:team)) }
+    let(:investigation) { create(:allegation, owner: create(:team)) }
 
     it "responds with a 403 (Forbidden) status code on update" do
       put investigation_collaborator_path(investigation.pretty_id, team.id)

--- a/psd-web/spec/requests/invalid_wizard_step_spec.rb
+++ b/psd-web/spec/requests/invalid_wizard_step_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Invalid steps within wizards", :with_stubbed_elasticsearch, :with_stubbed_notify, :with_stubbed_mailer, type: :request do
   let(:user) { create(:user, :opss_user, :activated) }
-  let(:investigation) { create(:investigation, owner: user.team) }
+  let(:investigation) { create(:allegation, owner: user.team) }
 
   before { sign_in(user) }
 

--- a/psd-web/spec/requests/investigations/changing_owner_spec.rb
+++ b/psd-web/spec/requests/investigations/changing_owner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
 
   let(:investigation) do
     create(
-      :investigation,
+      :allegation,
       is_closed: false,
       owner: user_from_owner_team.team,
       edit_access_collaborations: [

--- a/psd-web/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
+++ b/psd-web/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Updating the status of a case", :with_stubbed_elasticsearch, :wi
 
   let(:investigation) do
     create(
-      :investigation,
+      :allegation,
       is_closed: false,
       owner: user_from_owner_team.team,
       edit_access_collaborations: [

--- a/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
+++ b/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when the user is the case owner" do
-    let(:investigation) { create(:investigation, is_private: true, owner: user) }
+    let(:investigation) { create(:allegation, is_private: true, owner: user) }
 
     it "renders the page" do
       expect(response).to have_http_status(:ok)
@@ -25,7 +25,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when the user’s team is the case owner" do
-    let(:investigation) { create(:investigation, is_private: true, owner: users_team) }
+    let(:investigation) { create(:allegation, is_private: true, owner: users_team) }
 
     it "renders the page" do
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when another team from the same organisation is the case owner" do
-    let(:investigation) { create(:investigation, is_private: true, owner: other_team_from_the_same_organisation) }
+    let(:investigation) { create(:allegation, is_private: true, owner: other_team_from_the_same_organisation) }
 
     it "renders the page" do
       expect(response).to have_http_status(:ok)
@@ -41,7 +41,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when a team from a different organisation is the case owner" do
-    let(:investigation) { create(:investigation, is_private: true, owner: other_team) }
+    let(:investigation) { create(:allegation, is_private: true, owner: other_team) }
 
     it "displays an forbidden message" do
       expect(response).to have_http_status(:forbidden)
@@ -49,7 +49,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when a user from from a different organisation is the case owner" do
-    let(:investigation) { create(:investigation, is_private: true, owner: other_user) }
+    let(:investigation) { create(:allegation, is_private: true, owner: other_user) }
 
     it "displays an forbidden message" do
       expect(response).to have_http_status(:forbidden)
@@ -59,7 +59,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   context "when the case is owned by a team from another organisation but the user’s team has been added as a collaborator" do
     let(:investigation) do
       create(
-        :investigation,
+        :allegation,
         is_private: true,
         owner: other_team,
         edit_access_collaborations: [

--- a/psd-web/test/controllers/investigations_controller_test.rb
+++ b/psd-web/test/controllers/investigations_controller_test.rb
@@ -76,7 +76,7 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
   test "should set description" do
     old_description = "old"
     new_description = "description"
-    investigation = Investigation.create(description: old_description, reported_reason: Investigation.reported_reasons[:unsafe])
+    investigation = Investigation::Allegation.create(description: old_description, reported_reason: Investigation.reported_reasons[:unsafe])
     investigation_status = -> { Investigation.find(investigation.id).description }
     assert_changes investigation_status, from: old_description, to: new_description do
       patch edit_summary_investigation_url(investigation),

--- a/psd-web/test/fixtures/investigations.yml
+++ b/psd-web/test/fixtures/investigations.yml
@@ -88,6 +88,7 @@ private:
   description: private investigation
   product_category: Alarms
   is_private: true
+  type: Investigation::Allegation
   pretty_id: 1902-0012
 
 allegation:

--- a/psd-web/test/models/notification_test.rb
+++ b/psd-web/test/models/notification_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NotificationTest < ActiveSupport::TestCase
   setup do
     stub_notify_mailer
-    @investigation = Investigation.create(description: "new investigation for notification test")
+    @investigation = Investigation::Allegation.create(description: "new investigation for notification test")
   end
 
   teardown do
@@ -133,7 +133,7 @@ class NotificationTest < ActiveSupport::TestCase
     User.current = users(:southampton)
     mock_investigation_created(who_will_be_notified: [users(:southampton)])
     @investigation_two = investigations :two
-    Investigation.create(@investigation_two.attributes.merge(id: 123))
+    Investigation::Allegation.create(@investigation_two.attributes.merge(id: 123))
     assert_equal @number_of_notifications, 1
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This prevents an `Investigation` from being instantiated or saved, since cases should always be an instance of one of its subclasses.

This was primarily to ensure our tests more closely reflect real data; I noticed some slightly odd behaviour when writing a test with an investigation factory rather than an allegation.

This is a small step toward creating a service which is responsible for creating the investigation, setting default data, adding audit log entries and sending emails, rather than callbacks. We can then use that in our tests instead.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
