### PR TITLE
Fixes a breaking test caused by a change in date format.

### DIFF
--- a/psd-web/spec/features/record_email_activity_spec.rb
+++ b/psd-web/spec/features/record_email_activity_spec.rb
@@ -206,7 +206,7 @@ RSpec.feature "Adding a record email activity to a case", :with_stubbed_elastics
 
   def expect_case_activity_page_to_show_restricted_information
     item = page.find("h3", text: "Email added").find(:xpath, "..")
-    expect(item).to have_text("Email recorded by #{user.name} (#{user.team.name}), #{Time.zone.today.strftime('%d %B %Y')}")
+    expect(item).to have_text("Email recorded by #{user.name} (#{user.team.name}), #{Time.zone.today.strftime('%e %B %Y').lstrip}")
     expect(item).to have_text("Restricted access")
     expect(item).to have_text("Consumer contact details hidden to comply with GDPR legislation. Contact #{user.organisation.name}, who created this activity, to obtain these details if required.")
   end

--- a/psd-web/spec/features/record_phone_call_activity_spec.rb
+++ b/psd-web/spec/features/record_phone_call_activity_spec.rb
@@ -197,7 +197,7 @@ RSpec.feature "Adding a record phone call activity to a case", :with_stubbed_ela
 
   def expect_case_activity_page_to_show_restricted_information
     item = page.find("h3", text: "Phone call added").find(:xpath, "..")
-    expect(item).to have_text("Phone call by #{user.name} (#{user.team.name}), #{Time.zone.today.strftime('%d %B %Y')}")
+    expect(item).to have_text("Phone call by #{user.name} (#{user.team.name}), #{Time.zone.today.strftime('%e %B %Y').lstrip}")
     expect(item).to have_text("Restricted access")
     expect(item).to have_text("Consumer contact details hidden to comply with GDPR legislation. Contact #{user.organisation.name}, who created this activity, to obtain these details if required.")
   end


### PR DESCRIPTION
We switched from using `%d %B %Y`  (eg `01 June 2020`) to `'%e %B %Y` (eg ` 1 June 2020`) but forgot to update the tests. This only became apparent on the 1st of the month. :smile:

Had to add an `lstrip` to the tests to strip the leading space, as `%e` uses space-padding, but Capybara collapses multiple whitespaces together.