### PR TITLE
Pass restriction to template

### DIFF
--- a/psd-web/app/views/documents/_document_card.html.erb
+++ b/psd-web/app/views/documents/_document_card.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row govuk-!-padding-bottom-6">
   <div class="govuk-grid-column-one-quarter">
-    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: true %>
+    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: restricted %>
   </div>
 
   <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
We recently seem to have accidentally hardcoded that document previews are *always* restricted. This caused our thumbnail display to break. This fixes it so we pass in using the relevant policies.