### PR TITLE
Fix for missing extension on placeholder graphic

### DIFF
--- a/psd-web/app/views/documents/_document_preview.html.erb
+++ b/psd-web/app/views/documents/_document_preview.html.erb
@@ -31,11 +31,10 @@
       </div>
     <% else %>
       <div class="app-document-preview__placeholder" aria-hidden="true">
-        <%= image_tag "document_placeholder.png", alt: "" do %>
-          <span class="app-document-preview__filetype">
-            <%= document_file_extension(document) %>
-          </span>
-        <% end %>
+        <%= image_tag "document_placeholder.png", alt: "" %>
+        <span class="app-document-preview__filetype">
+          <%= document_file_extension(document) %>
+        </span>
       </div>
     <% end %>
   <% else %>


### PR DESCRIPTION
Fix for a bug with missing extension on preview placeholders.

Before:
<img width="908" alt="Screenshot 2020-06-01 at 12 03 38" src="https://user-images.githubusercontent.com/2204224/83403223-2d964700-a400-11ea-8139-77c9dc87d3e0.png">

After:
<img width="923" alt="Screenshot 2020-06-01 at 12 03 24" src="https://user-images.githubusercontent.com/2204224/83403232-30913780-a400-11ea-9e74-2740e5bfc281.png">
