### PR TITLE
Bump govuk-frontend from 3.6.0 to 3.7.0

### DIFF
--- a/psd-web/package.json
+++ b/psd-web/package.json
@@ -11,7 +11,7 @@
     "accessible-autocomplete": "2.0.2",
     "copy-webpack-plugin": "5.1.1",
     "govuk-country-and-territory-autocomplete": "1.0.1",
-    "govuk-frontend": "3.6.0",
+    "govuk-frontend": "3.7.0",
     "html5shiv": "3.7.3",
     "jquery": "3.5.1",
     "oldie": "1.3.0",

--- a/psd-web/yarn.lock
+++ b/psd-web/yarn.lock
@@ -3948,10 +3948,10 @@ govuk-country-and-territory-autocomplete@1.0.1:
     openregister-picker-engine "^1.2.1"
     webpack-sources "^1.3.0"
 
-govuk-frontend@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.6.0.tgz#f0d1e6ec3c0eb33616adfdff28ff778fe518d085"
-  integrity sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A==
+govuk-frontend@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.7.0.tgz#2eb2130c3c9f7c701c7ecdb300cc91106275a414"
+  integrity sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.4"


### PR DESCRIPTION
See [changelog](https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0)

Should make the CSS compilation a bit faster.