### PR TITLE
Improve document link labels

### DIFF
--- a/psd-web/app/helpers/documents_helper.rb
+++ b/psd-web/app/helpers/documents_helper.rb
@@ -18,56 +18,31 @@ module DocumentsHelper
     @parent.documents
   end
 
-  def document_type_label(document_type)
-    case document_type
-    when :correspondence_originator
-      "Correspondence from originator"
-    when :correspondence_business
-      "Correspondence from business"
-    when :correspondence_other
-      "Correspondence from other"
-    when :tech_specs
-      "Technical specifications"
-    when :test_results
-      "Test results"
-    when :risk_assessment
-      "Risk assessment"
-    else
-      "Other"
-    end
-  end
-
-  def document_filetype_label(document)
-    return "Audio" if document.audio?
-    return "Image" if document.image?
-    return "Video" if document.video?
-    return "Text" if document.text?
-
-    case document.content_type
-    when "application/pdf"
-      "PDF"
-    when "application/msword",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-      "Word Document"
-    when "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      "Excel Document"
-    when "application/vnd.ms-powerpoint",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-      "PowerPoint Document"
-    else
-      document_file_extension(document).upcase
-    end
-  end
-
   def document_file_extension(document)
     File.extname(document.filename.to_s)&.remove(".")&.upcase
   end
 
   def pretty_type_description(document)
-    description = ""
-    description += document_file_extension(document) + " " if document_file_extension document
-    description + image_document_text(document)
+    return "audio" if document.audio?
+    return "image" if document.image?
+    return "video" if document.video?
+    return "text document" if document.text?
+
+    case document.content_type
+    when "application/pdf"
+      "PDF document"
+    when "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      "Word document"
+    when "application/vnd.ms-excel",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      "Excel document"
+    when "application/vnd.ms-powerpoint",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+      "PowerPoint document"
+    else
+      document_file_extension(document).upcase
+    end
   end
 
   def formatted_file_updated_date(file)


### PR DESCRIPTION
This improves document link labels, by changing "View XLS document" to "View Excel document", and so on, for known document types.

Also removes some unused helpers.