### PR TITLE
Page for showing corrective actions

### DIFF
--- a/psd-web/app/controllers/investigations/view_corrective_actions_controller.rb
+++ b/psd-web/app/controllers/investigations/view_corrective_actions_controller.rb
@@ -1,0 +1,9 @@
+class Investigations::ViewCorrectiveActionsController < ApplicationController
+  def show
+    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    authorize @investigation, :view_non_protected_details?
+    @corrective_action = @investigation.corrective_actions.find(params[:id])
+
+    render "investigations/corrective_actions/show"
+  end
+end

--- a/psd-web/app/controllers/investigations/view_corrective_actions_controller.rb
+++ b/psd-web/app/controllers/investigations/view_corrective_actions_controller.rb
@@ -1,6 +1,6 @@
 class Investigations::ViewCorrectiveActionsController < ApplicationController
   def show
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :view_non_protected_details?
     @corrective_action = @investigation.corrective_actions.find(params[:id])
 

--- a/psd-web/app/models/audit_activity/corrective_action/add.rb
+++ b/psd-web/app/models/audit_activity/corrective_action/add.rb
@@ -7,6 +7,22 @@ class AuditActivity::CorrectiveAction::Add < AuditActivity::CorrectiveAction::Ba
     "Corrective action was added to the #{investigation.case_type.upcase_first} by #{source&.show(viewer)}."
   end
 
+  # Returns the actual CorrectiveAction record.
+  #
+  # This is a hack, as there is currently no direct association between the
+  # AuditActivity record and the corrective action record it is about. So the only
+  # way to retrieve this is by relying upon our current behaviour of attaching the
+  # same actual file to all of the AuditActivity, Investigation and CorrectiveAction records.
+  #
+  # If no file was associated with the corrective action, this fails.
+  def corrective_action
+    if attachment.attached?
+      attachment.blob.attachments
+        .find_by(record_type: "CorrectiveAction")
+        .record
+    end
+  end
+
 private
 
   def subtitle_slug

--- a/psd-web/app/views/investigations/activities/_activity_card.html.erb
+++ b/psd-web/app/views/investigations/activities/_activity_card.html.erb
@@ -53,7 +53,7 @@
     <% if activity.is_a? AuditActivity::Test::Result %>
       <%= link_with_hidden_text_to "View test result", " from #{activity.test_result.date.to_s(:govuk)}", investigation_test_result_path(@investigation, activity.test_result.id) %>
 
-    <% elsif activity.is_a?(AuditActivity::CorrectiveAction::Add) && activity.corrective_action%>
+    <% elsif activity.is_a?(AuditActivity::CorrectiveAction::Add) && activity.corrective_action %>
       <%=  link_to "View corrective action", investigation_action_path(@investigation, activity.corrective_action), class: "govuk-link" %>
     <% elsif activity.has_attachment? %>
       <% activity.attachments.each do |name, attachment| %>

--- a/psd-web/app/views/investigations/activities/_activity_card.html.erb
+++ b/psd-web/app/views/investigations/activities/_activity_card.html.erb
@@ -52,6 +52,9 @@
 
     <% if activity.is_a? AuditActivity::Test::Result %>
       <%= link_with_hidden_text_to "View test result", " from #{activity.test_result.date.to_s(:govuk)}", investigation_test_result_path(@investigation, activity.test_result.id) %>
+
+    <% elsif activity.is_a?(AuditActivity::CorrectiveAction::Add) && activity.corrective_action%>
+      <%=  link_to "View corrective action", investigation_action_path(@investigation, activity.corrective_action), class: "govuk-link" %>
     <% elsif activity.has_attachment? %>
       <% activity.attachments.each do |name, attachment| %>
         <%= link_to "View #{name}", attachment, class: "psd-block-link", target: "_blank", rel: 'noopener' %>

--- a/psd-web/app/views/investigations/corrective_actions/show.html.erb
+++ b/psd-web/app/views/investigations/corrective_actions/show.html.erb
@@ -1,0 +1,75 @@
+<% page_heading = @corrective_action.summary %>
+<% page_title page_heading %>
+
+<% content_for :after_header do %>
+  <%= govukBackLink(
+    text: "Back",
+    href: investigation_path(@investigation)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">Corrective action</span>
+    <h1 class="govuk-heading-l"><%= page_heading %></h1>
+
+    <div class="app-meta-area">
+      <p class="govuk-body govuk-hint">
+        Added <%= @corrective_action.created_at.to_s(:govuk) %>
+      </p>
+    </div>
+
+    <% rows = [
+      {
+        key: { text: "Date" },
+        value: { text: @corrective_action.date_decided.to_s(:govuk) }
+      },
+      {
+        key: { text: "Product" },
+        value: { html: link_to(@corrective_action.product.name, product_path(@corrective_action.product)) }
+      },
+      {
+        key: { text: "Legislation" },
+        value: { text: @corrective_action.legislation }
+      },
+      {
+        key: { text: "Type of action" },
+        value: { text: @corrective_action.measure_type.upcase_first }
+      },
+      {
+        key: { text: "Duration of measure" },
+        value: { text: @corrective_action.duration.upcase_first }
+      },
+      {
+        key: { text: "Scope" },
+        value: { text: @corrective_action.geographic_scope }
+      }
+    ]
+
+    if @corrective_action.details.present?
+      rows << {
+        key: { text: "Other details" },
+        value: { text: @corrective_action.details }
+      }
+    end
+    %>
+    <%= govukSummaryList(rows: rows) %>
+  </div>
+
+  <% if @corrective_action.documents.any? %>
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m">Attachments</h1>
+      <% @corrective_action.documents.each do |document| %>
+        <p class="govuk-body"><%= link_to document.filename, document, class: "govuk-link" %></p>
+
+        <%= document_placeholder(document_file_extension(document)) %>
+
+        <% if document.blob.metadata["description"].present? %>
+          <p class="govuk-body"><%= document.blob.metadata["description"] %></p>
+        <% end %>
+
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/psd-web/app/views/investigations/corrective_actions/show.html.erb
+++ b/psd-web/app/views/investigations/corrective_actions/show.html.erb
@@ -22,7 +22,7 @@
 
     <% rows = [
       {
-        key: { text: "Date" },
+        key: { text: "Date of action" },
         value: { text: @corrective_action.date_decided.to_s(:govuk) }
       },
       {

--- a/psd-web/app/views/investigations/corrective_actions/show.html.erb
+++ b/psd-web/app/views/investigations/corrective_actions/show.html.erb
@@ -26,12 +26,16 @@
         value: { text: @corrective_action.date_decided.to_s(:govuk) }
       },
       {
+        key: { text: "Legislation" },
+        value: { text: @corrective_action.legislation }
+      },
+      {
         key: { text: "Product" },
         value: { html: link_to(@corrective_action.product.name, product_path(@corrective_action.product)) }
       },
       {
-        key: { text: "Legislation" },
-        value: { text: @corrective_action.legislation }
+        key: { text: "Business" },
+        value: { html: @corrective_action.business ? link_to(@corrective_action.business.trading_name, business_path(@corrective_action.business)) : "Not specified" }
       },
       {
         key: { text: "Type of action" },

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -140,6 +140,8 @@ Rails.application.routes.draw do
 
     resources :test_results, controller: "investigations/test_results", only: :show, path: "test-results"
 
+    resources :actions, controller: "investigations/view_corrective_actions", only: :show, path: "corrective-actions"
+
     resources :tests, controller: "investigations/tests", only: %i[show create update] do
       collection do
         get :new_request

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
 
     expect_to_be_on_corrective_action_page(case_id: investigation.pretty_id)
 
-    expect(page).to have_summary_item(key: "Date", value: "1 May 2020")
+    expect(page).to have_summary_item(key: "Date of action", value: "1 May 2020")
     expect(page).to have_summary_item(key: "Product", value: "MyBrand Washing Machine")
     expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
     expect(page).to have_summary_item(key: "Type of action", value: "Mandatory")

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -130,6 +130,14 @@ module PageExpectations
     end
   end
 
+  def expect_to_be_on_corrective_action_page(case_id:, corrective_action_id: nil)
+    if corrective_action_id
+      expect(page).to have_current_path("/cases/#{case_id}/corrective-actions/#{corrective_action_id}")
+    else
+      expect(page).to have_current_path(/\/cases\/#{case_id}\/corrective-actions\/[\d]+/)
+    end
+  end
+
   # Add an allegation flow
   def expect_to_be_on_allegation_complainant_page
     expect(page).to have_current_path("/allegation/complainant")


### PR DESCRIPTION
Following on from #668, this adds a new page for viewing "corrective actions" (product recalls, etc). 

This is currently only linked to from the Activity timeline, but will soon be listed and linked to from a "Supporting information" tab, replacing the "Attachments" tab.  Due to existing database model limitations, it is currently only possibly to create the link from the Activity timeline if a file was attached to the corrective action. This can be remedied in a future change.

## Screenshots

### Before

Activity timeline entry links only to the attachment:

<img width="835" alt="Screenshot 2020-06-04 at 09 21 40" src="https://user-images.githubusercontent.com/30665/83733373-59eed500-a645-11ea-99c6-3ef3c4bd7603.png">

### After

Activity timeline entry links to the corrective action (only if an attachment was added):

<img width="697" alt="Screenshot 2020-06-04 at 09 21 53" src="https://user-images.githubusercontent.com/30665/83733445-71c65900-a645-11ea-8451-7009cc783fd4.png">

New corrective action page:

<img width="967" alt="Screenshot 2020-06-04 at 09 22 07" src="https://user-images.githubusercontent.com/30665/83733481-7ee34800-a645-11ea-9679-64e4c8722b19.png">

### Implementation notes

We have an existing `CorrectiveActionsController` but that uses the `show` action as part of the "add a corrective action" flow. To avoid conflicting with or refactoring that immediately, I’ve added a new `ViewCorrectiveActionsController`, which isn't ideal but is a short-term compromise.