### PR TITLE
Restrict visibility of generic attachments

### DIFF
--- a/psd-web/app/controllers/investigations/supporting_information_controller.rb
+++ b/psd-web/app/controllers/investigations/supporting_information_controller.rb
@@ -9,6 +9,7 @@ module Investigations
       @investigation                = investigation.decorate
       @supporting_information       = investigation.supporting_information_attachments.decorate
       @other_supporting_information = investigation.generic_supporting_information_attachments.decorate
+      @generic_attachments_visible  = investigation.teams_with_access.include?(current_user.team)
 
       @breadcrumbs = {
         items: [

--- a/psd-web/app/controllers/investigations/supporting_information_controller.rb
+++ b/psd-web/app/controllers/investigations/supporting_information_controller.rb
@@ -9,7 +9,6 @@ module Investigations
       @investigation                = investigation.decorate
       @supporting_information       = investigation.supporting_information_attachments.decorate
       @other_supporting_information = investigation.generic_supporting_information_attachments.decorate
-      @generic_attachments_visible  = investigation.teams_with_access.include?(current_user.team)
 
       @breadcrumbs = {
         items: [

--- a/psd-web/app/views/documents/_document_card.html.erb
+++ b/psd-web/app/views/documents/_document_card.html.erb
@@ -31,14 +31,7 @@
            rel: 'noopener' %>
 
         <% if !parent.is_a?(Investigation) || policy(parent).update?(user: current_user) %>
-          <%= link_with_hidden_text_to "Edit #{image_document_text(document)}",
-            "(#{title})",
-            edit_associated_document_path(parent, document),
-            class: "govuk-link app-block-link govuk-!-margin-right-3" %>
-          <%= link_with_hidden_text_to "Remove #{image_document_text(document)}",
-            "(#{title})",
-            remove_associated_document_path(parent, document),
-            class: "govuk-link app-block-link" %>
+          <%= render "documents/document_card_links", document: document, parent: parent %>
         <% end %>
       <% end %>
     <% end %>

--- a/psd-web/app/views/documents/_document_card_links.html.erb
+++ b/psd-web/app/views/documents/_document_card_links.html.erb
@@ -1,0 +1,8 @@
+<%= link_with_hidden_text_to "Edit #{image_document_text(document)}",
+  "(#{document.title})",
+  edit_associated_document_path(parent, document),
+  class: "govuk-link app-block-link govuk-!-margin-right-3" %>
+<%= link_with_hidden_text_to "Remove #{image_document_text(document)}",
+  "(#{document.title})",
+  remove_associated_document_path(parent, document),
+  class: "govuk-link app-block-link" %>

--- a/psd-web/app/views/documents/_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_generic_document_card.html.erb
@@ -1,0 +1,34 @@
+<%
+  document = document.decorate
+  title = document.title
+  safe = document.metadata["safe"]
+%>
+
+<div class="govuk-grid-row govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: false %>
+  </div>
+
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= title %></h2>
+    <span class="govuk-hint govuk-!-font-size-16">
+      <%= formatted_file_updated_date(document) %>
+    </span>
+
+    <p><%= t("supporting_information.restricted_generic.placeholder") %></p>
+    <p class="govuk-body"><%= document.description %></p>
+
+    <% if safe %>
+      <%= link_with_hidden_text_to "View #{pretty_type_description(document)}",
+          "(#{title}, opens in a new window)",
+          document,
+          class: "govuk-link app-block-link govuk-!-margin-right-3",
+          target: '_blank',
+          rel: 'noopener' %>
+
+      <% if policy(parent).update?(user: current_user) %>
+        <%= render "documents/document_card_links", document: document, parent: parent %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/psd-web/app/views/documents/_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_generic_document_card.html.erb
@@ -1,5 +1,4 @@
 <%
-  document = document.decorate
   title = document.title
   safe = document.metadata["safe"]
 %>

--- a/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
@@ -1,0 +1,16 @@
+<% document = document.decorate %>
+
+<div class="govuk-grid-row govuk-!-padding-bottom-6">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: true %>
+  </div>
+
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t("supporting_information.restricted_generic.title") %></h2>
+    <span class="govuk-hint govuk-!-font-size-16">
+      <%= formatted_file_updated_date(document) %>
+    </span>
+
+    <p><%= t("supporting_information.restricted_generic.description") %></p>
+  </div>
+</div>

--- a/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
@@ -11,6 +11,6 @@
       <%= formatted_file_updated_date(document) %>
     </span>
 
-    <p><%= t("supporting_information.restricted_generic.description") %></p>
+    <p><%= t("supporting_information.restricted_generic.placeholder") %></p>
   </div>
 </div>

--- a/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
@@ -1,5 +1,3 @@
-<% document = document.decorate %>
-
 <div class="govuk-grid-row govuk-!-padding-bottom-6">
   <div class="govuk-grid-column-one-quarter">
     <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: true %>

--- a/psd-web/app/views/investigations/tabs/_supporting_information.erb
+++ b/psd-web/app/views/investigations/tabs/_supporting_information.erb
@@ -22,7 +22,7 @@
 
 <% if @generic_attachments_visible %>
   <% @other_supporting_information.each do |attachement| %>
-    <%= render "documents/document_card", document: attachement, parent: @investigation %>
+    <%= render "documents/generic_document_card", document: attachement, parent: @investigation %>
   <% end %>
 <% else %>
   <% @other_supporting_information.each do |attachement| %>

--- a/psd-web/app/views/investigations/tabs/_supporting_information.erb
+++ b/psd-web/app/views/investigations/tabs/_supporting_information.erb
@@ -21,12 +21,12 @@
 <% end %>
 
 <% if @generic_attachments_visible %>
-  <% @other_supporting_information.each do |attachement| %>
-    <%= render "documents/generic_document_card", document: attachement, parent: @investigation %>
+  <% @other_supporting_information.each do |attachment| %>
+    <%= render "documents/generic_document_card", document: attachment, parent: @investigation %>
   <% end %>
 <% else %>
-  <% @other_supporting_information.each do |attachement| %>
-    <%= render "documents/restricted_generic_document_card", document: attachement %>
+  <% @other_supporting_information.each do |attachment| %>
+    <%= render "documents/restricted_generic_document_card", document: attachment %>
   <% end %>
 <% end %>
 

--- a/psd-web/app/views/investigations/tabs/_supporting_information.erb
+++ b/psd-web/app/views/investigations/tabs/_supporting_information.erb
@@ -20,7 +20,7 @@
   <%= render "documents/document_card", document: attachement, parent: @investigation %>
 <% end %>
 
-<% if @generic_attachments_visible %>
+<% if policy(@investigation).view_protected_details?(user: current_user) %>
   <% @other_supporting_information.each do |attachment| %>
     <%= render "documents/generic_document_card", document: attachment, parent: @investigation %>
   <% end %>

--- a/psd-web/app/views/investigations/tabs/_supporting_information.erb
+++ b/psd-web/app/views/investigations/tabs/_supporting_information.erb
@@ -20,8 +20,14 @@
   <%= render "documents/document_card", document: attachement, parent: @investigation %>
 <% end %>
 
-<% @other_supporting_information.each do |attachement| %>
-  <%= render "documents/document_card", document: attachement, parent: @investigation %>
+<% if @generic_attachments_visible %>
+  <% @other_supporting_information.each do |attachement| %>
+    <%= render "documents/document_card", document: attachement, parent: @investigation %>
+  <% end %>
+<% else %>
+  <% @other_supporting_information.each do |attachement| %>
+    <%= render "documents/restricted_generic_document_card", document: attachement %>
+  <% end %>
 <% end %>
 
 <% if @supporting_information.none? && @other_supporting_information.none?  %>

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
   supporting_information:
     restricted_generic:
       title: "Attachment"
-      description: "Only teams added to the case can view this attachment"
+      placeholder: "Only teams added to the case can view this attachment"
   investigations:
     coronavirus_related:
       show:

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -57,6 +57,10 @@ en:
     is_private:
       false: Visible to all
       true: Restricted for legal privilege
+  supporting_information:
+    restricted_generic:
+      title: "Attachment"
+      description: "Only teams added to the case can view this attachment"
   investigations:
     coronavirus_related:
       show:

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation) { create(:investigation, :with_document, owner: user.team) }
 
   include_context "with all types of supporting information"

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -1,22 +1,38 @@
 require "rails_helper"
 
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
-  let(:investigation) { create(:investigation, owner: user.team) }
+  let(:user) { create(:user, :activated, has_viewed_introduction: true) }
+  let(:investigation) { create(:investigation, :with_document, owner: user.team) }
 
   include_context "with all types of supporting information"
 
-  before { sign_in user }
+  context "when the team from the user viewing the information owns the investigation" do
+    before { sign_in user }
 
-  scenario "completing the add attachment flow saves the attachment" do
-    visit "/cases/#{investigation.pretty_id}"
+    scenario "completing the add attachment flow saves the attachment" do
+      visit "/cases/#{investigation.pretty_id}"
+      click_link "Supporting information"
+      expect(page).to have_css("h2", text: corrective_action.documents.first.title)
+      expect(page).to have_css("h2", text: email.email_file.decorate.title)
+      expect(page).to have_css("h2", text: phone_call.transcript.decorate.title)
+      expect(page).to have_css("h2", text: meeting.transcript.decorate.title)
+      expect(page).to have_css("h2", text: test_request.documents.first.decorate.title)
+      expect(page).to have_css("h2", text: test_result.documents.first.decorate.title)
+      expect(page).to have_css("h2", text: investigation.documents.first.title)
+    end
+  end
 
-    click_link "Supporting information"
-    expect(page).to have_css("h2", text: corrective_action.documents.first.title)
-    expect(page).to have_css("h2", text: email.email_file.decorate.title)
-    expect(page).to have_css("h2", text: phone_call.transcript.decorate.title)
-    expect(page).to have_css("h2", text: meeting.transcript.decorate.title)
-    expect(page).to have_css("h2", text: test_request.documents.first.decorate.title)
-    expect(page).to have_css("h2", text: test_result.documents.first.decorate.title)
+  context "when the user does not belong to any of the teams with access to the investigation" do
+    let(:other_user) { create(:user, :activated, has_viewed_introduction: true) }
+
+    before { sign_in other_user }
+
+    scenario "viewing the supporting information displays restricted information for the generic attachments" do
+      visit "/cases/#{investigation.pretty_id}"
+      click_link "Supporting information"
+      expect(page).not_to have_css("h2", text: investigation.documents.first.title)
+      expect(page).to have_css("h2", text: "Attachment")
+      expect(page).to have_css("p", text: "Only teams added to the case can view this attachment")
+    end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://trello.com/c/u4CDPR33/553-3-dont-reveal-generic-attachments-to-teams-not-involved-in-a-case)

Only users belonging to a team that has permissions on the investigation will be able to view the details of the investigation generic attachments when visiting the investigation supporting information tab.

Other users will be aware of the attachment existence but won't be able to view the preview, title or description from them.

### An user not belonging to any of the teams with access to the investigation will see:
![Screenshot from 2020-06-05 13-30-06](https://user-images.githubusercontent.com/1227578/83876392-b4b12b00-a730-11ea-8c1c-05b00d501875.png)

### While an user with access will see 
![Screenshot from 2020-06-05 13-25-48](https://user-images.githubusercontent.com/1227578/83876398-b67aee80-a730-11ea-9524-1b5284fdc890.png)

(don't mind the preview format showing different extensions, they're different docs):