### PR TITLE
Reject mobile phone numbers with too many digits

### DIFF
--- a/psd-web/app/validators/phone_validator.rb
+++ b/psd-web/app/validators/phone_validator.rb
@@ -1,13 +1,20 @@
 class PhoneValidator < ActiveModel::EachValidator
   ACCEPTED_PREFIXES = %w[7 07 447 4407 00447].freeze
   DEFAULT_ERROR = "is not a valid phone number".freeze
-  MINIMUM_LENGTH = 10
+  ACCEPTED_LENGTH = 10
 
   def validate_each(record, attribute, value)
     digits = value.delete("^0-9")
 
-    if digits.length < MINIMUM_LENGTH || !digits.start_with?(*ACCEPTED_PREFIXES)
+    if !digits.start_with?(*ACCEPTED_PREFIXES) || normalised_number(digits).length != ACCEPTED_LENGTH
       record.errors[attribute] << (options[:message] || DEFAULT_ERROR)
     end
+  end
+
+private
+
+  def normalised_number(phone_number)
+    _prefix, match, after = phone_number.partition("7")
+    match + after
   end
 end

--- a/psd-web/spec/features/registration_spec.rb
+++ b/psd-web/spec/features/registration_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
 
       expect_to_be_on_resend_secondary_authentication_page
       find("details summary", text: "Change where the text message is sent").click
-      fill_in "Mobile number", with: "70123456789"
+      fill_in "Mobile number", with: "07012345678"
 
       click_button "Resend security code"
       expect_to_be_on_secondary_authentication_page
@@ -54,7 +54,7 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
       click_link("Your account", match: :first)
 
       expect(page).to have_h1("Your account")
-      expect(page).to have_summary_item(key: "Mobile number", value: "70123456789")
+      expect(page).to have_summary_item(key: "Mobile number", value: "07012345678")
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
 
   def fill_in_registration_form
     fill_in "Full name",     with: Faker::Movies::Lebowski.character
-    fill_in "Mobile number", with: "71234567890"
+    fill_in "Mobile number", with: "07123456789"
     fill_in "Password",      with: "testpassword"
     click_on "Continue"
   end

--- a/psd-web/spec/forms/resend_secondary_authentication_code_form_spec.rb
+++ b/psd-web/spec/forms/resend_secondary_authentication_code_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ResendSecondaryAuthenticationCodeForm, :with_stubbed_mailer do
       let(:user) { create(:user, mobile_number_verified: true) }
 
       context "with a mobile number with correct format in the params" do
-        let(:mobile_number) { "70123456789" }
+        let(:mobile_number) { "07012345678" }
 
         include_examples "valid form"
       end
@@ -49,7 +49,7 @@ RSpec.describe ResendSecondaryAuthenticationCodeForm, :with_stubbed_mailer do
       let(:user) { create(:user, mobile_number_verified: false) }
 
       context "with a mobile number with correct format in the params" do
-        let(:mobile_number) { "70123456789" }
+        let(:mobile_number) { "07012345678" }
 
         include_examples "valid form"
       end

--- a/psd-web/spec/validators/phone_validator_spec.rb
+++ b/psd-web/spec/validators/phone_validator_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe PhoneValidator do
 
   invalid_phone_numbers = [
     "712345671",
+    "71234567123",
     "00123456789",
     "+111123 456789",
     "564544554455544"


### PR DESCRIPTION
Numbers with too many digits are being rejected by UK Notify API based in this validation:

https://github.com/alphagov/notifications-utils/blob/652d9bab827238e9fd247bd2d4e273336419d9cd/notifications_utils/recipients.py#L425

Right now these errors are silently happening in the background ([Error tracker issue](https://sentry.io/organizations/beis/issues/1661381821/?project=1329381)) so the user is not aware of them.

This PR will bring a form validation error to the user so the mobile number is rejected in our service form submission instead of being rejected by Notify API in the background.

