### PR TITLE
Only show complainant details on case added activity if user is collaborating on the case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2020-06-12
+- Users of all teams added to a case can now view complainant contact details on the case activity page.
+
 ## 2020-06-05
 – Added the ability to view the details of correspondence added to the case on their own page.
 

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -84,7 +84,7 @@ module Investigations::DisplayTextHelper
 
   def should_be_hidden(result, source, investigation)
     return true if correspondence_should_be_hidden(result, source, investigation)
-    return true if (source.include? "complainant") && !investigation&.complainant&.can_be_displayed?(current_user)
+    return true if (source.include? "complainant") && !policy(investigation).view_protected_details?
 
     false
   end

--- a/psd-web/app/models/audit_activity/investigation/add.rb
+++ b/psd-web/app/models/audit_activity/investigation/add.rb
@@ -45,7 +45,7 @@ class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
   def can_display_all_data?(user)
     return true if self[:metadata].present? || investigation.complainant.blank?
 
-    investigation.complainant.can_be_displayed?(user)
+    Pundit.policy(user, investigation).view_protected_details?
   end
 
   # Only used for old records prior to metadata implementation

--- a/psd-web/app/models/complainant.rb
+++ b/psd-web/app/models/complainant.rb
@@ -19,16 +19,4 @@ class Complainant < ApplicationRecord
 
   validates :name, length: { maximum: 100 }
   validates :other_details, length: { maximum: 10_000 }
-
-  def can_be_displayed?(user)
-    can_be_seen_by_user?(user) || investigation.child_should_be_displayed?(user)
-  end
-
-private
-
-  def can_be_seen_by_user?(user)
-    return true if investigation.creator_user.has_gdpr_access?(user)
-
-    complainant_type != "Consumer"
-  end
 end

--- a/psd-web/app/views/investigations/activities/investigation/_add_project.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_add_project.html.erb
@@ -1,7 +1,5 @@
 <h4 class="govuk-heading-s">Project details</h4>
 
-
-
 <% if activity.metadata['investigation']['coronavirus_related'] %>
   <p class="govuk-body">
     <%= t("audit_activity.investigation.coronavirus_related") %>

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -9,7 +9,7 @@
 
 <%# Teams not involved in a case shouldn't complianant contact details %>
 <% if !policy(@investigation).view_protected_details? %>
-  <%= render "restricted", activity: activity %>
+  <p class="govuk-hint"><%= t("case.protected_details", data_type: "#{@investigation.case_type} contact details") %></p>
 
 <% else %>
   <% complainant_info = [] %>

--- a/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_complainant.html.erb
@@ -8,11 +8,10 @@
 <% end %>
 
 <%# Teams not involved in a case shouldn't complianant contact details %>
-<% if !complainant.can_be_displayed?(current_user) %>
+<% if !policy(@investigation).view_protected_details? %>
   <%= render "restricted", activity: activity %>
 
 <% else %>
-
   <% complainant_info = [] %>
 
   <% if complainant.name.present? %>

--- a/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_allegation_as_opss_user_spec.rb
@@ -191,8 +191,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page).to have_text("Hazard type: #{allegation.fetch(:hazard_type)}")
     expect(page).to have_text(allegation.fetch(:description))
 
-    expect(page).to have_text("Restricted access")
-    expect(page).to have_text("Consumer contact details hidden to comply with GDPR legislation. Contact test organisation, who created this activity, to obtain these details if required.")
+    expect(page).to have_css("p", text: "Only teams added to the case can view allegation contact details")
 
     expect(page).not_to have_text("Name")
     expect(page).not_to have_text("Email address")

--- a/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/psd-web/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -171,8 +171,7 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       expect(page).to have_css("p", text: "Case is related to the coronavirus outbreak.")
       expect(page).to have_css("p", text: enquiry.fetch(:enquiry_description))
 
-      expect(page).to have_text("Restricted access")
-      expect(page).to have_text("Consumer contact details hidden to comply with GDPR legislation. Contact test organisation, who created this activity, to obtain these details if required.")
+      expect(page).to have_css("p", text: "Only teams added to the case can view enquiry contact details")
 
       expect(page).not_to have_text("Name")
       expect(page).not_to have_text("Email address")

--- a/psd-web/spec/support/audit_activity_investigation.rb
+++ b/psd-web/spec/support/audit_activity_investigation.rb
@@ -155,15 +155,21 @@ RSpec.shared_examples "an audit activity for investigation added" do
 
       context "when there is a complainant" do
         let(:factory_trait) { :with_complainant }
-        let(:complainant) { investigation.complainant }
 
-        before do
-          allow(complainant).to receive(:can_be_displayed?).with(user).and_return(true)
+        context "when the user is on a team collaborating on the case" do
+          before do
+            create(:collaboration_edit_access, investigation: investigation, collaborator: user.team)
+          end
+
+          it "returns true" do
+            expect(can_display).to be true
+          end
         end
 
-        it "returns the value of complainant#can_be_displayed?", :aggregate_failures do
-          expect(can_display).to be true
-          expect(complainant).to have_received(:can_be_displayed?).with(user).once
+        context "when the user is not on a team collaborating on the case" do
+          it "returns false" do
+            expect(can_display).to be false
+          end
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/3HP9NsVf/554-hide-enquiry-source-contact-details-in-activity-log

## Description
This tweaks the logic which determines whether a user can view complainant details on the activity log entry for case created. It now uses the new policy which specifies that the user must be on a team added as a collaborator to the case. Previously, the user had to be in the same team or organisation as the person who created the case.

I've also removed the now-redundant `Complainant#can_be_displayed?` method which was only used elsewhere in the search results text highlighting feature. We are currently discussing how best to improve this feature and the indexing of complainants so I have not changed this.

Note: The copy has not been changed from the existing generic text. I think the copy is probably fine as-is, but we might want something more tailored or consistent with other places where contact details are hidden.

### Screenshots

Example case: https://psd-pr-696.london.cloudapps.digital/cases/2006-0018 (created by OPSS user).

#### User on a team on the case

<img width="857" alt="Screenshot 2020-06-08 at 13 54 06" src="https://user-images.githubusercontent.com/408371/84032806-c8a69800-a98f-11ea-837d-e9b0385b7b87.png">

#### Searching for complainant email address (team on case)

<img width="925" alt="Screenshot 2020-06-08 at 14 00 34" src="https://user-images.githubusercontent.com/408371/84033249-77e36f00-a990-11ea-8189-458a4078d79a.png">


#### User on a team not on the case

<img width="837" alt="Screenshot 2020-06-08 at 13 55 08" src="https://user-images.githubusercontent.com/408371/84032823-d0fed300-a98f-11ea-989d-925f908cd073.png">

#### Searching for complainant email address (not on case)

<img width="919" alt="Screenshot 2020-06-08 at 13 59 16" src="https://user-images.githubusercontent.com/408371/84033158-56828300-a990-11ea-9671-f6d897cf6fda.png">


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
- [x] Has the CHANGELOG been updated? (If change is worth telling users about.)
