### PR TITLE
Remove User.current from display name

### DIFF
--- a/psd-web/app/decorators/user_decorator.rb
+++ b/psd-web/app/decorators/user_decorator.rb
@@ -13,7 +13,7 @@ class UserDecorator < Draper::Decorator
   end
 
   # viewer could be a Team or User
-  def display_name(viewer: User.current)
+  def display_name(viewer:)
     suffix = " (#{team.name})" if team != viewer&.team
     "#{name}#{suffix}#{deleted_suffix}"
   end

--- a/psd-web/app/helpers/investigations/user_filters_helper.rb
+++ b/psd-web/app/helpers/investigations/user_filters_helper.rb
@@ -27,7 +27,7 @@ module Investigations::UserFiltersHelper
     render "form_components/govuk_select",
            key: :case_owner_is_someone_else_id,
            form: form,
-           items: entities.map { |e| { text: e.display_name, value: e.id } },
+           items: entities.map { |e| { text: e.display_name(viewer: current_user), value: e.id } },
            label: { text: "Name" },
            is_autocomplete: true
   end
@@ -36,7 +36,7 @@ module Investigations::UserFiltersHelper
     render "form_components/govuk_select",
            key: :created_by_someone_else_id,
            form: form,
-           items: entities.map { |e| { text: e.display_name, value: e.id } },
+           items: entities.map { |e| { text: e.display_name(viewer: current_user), value: e.id } },
            label: { text: "Name" },
            is_autocomplete: true
   end

--- a/psd-web/app/views/investigations/activities/_restricted.html.erb
+++ b/psd-web/app/views/investigations/activities/_restricted.html.erb
@@ -1,5 +1,5 @@
 <%
-  creator = activity.source&.user&.organisation&.name || activity.source&.show
+  creator = activity.source&.user&.organisation&.name || activity.source&.show(current_user)
 %>
 
 <p><%= render "components/hmcts_badge", text: "Restricted access", classes: "hmcts-badge--grey" %></p>

--- a/psd-web/app/views/investigations/index.xlsx.axlsx
+++ b/psd-web/app/views/investigations/index.xlsx.axlsx
@@ -15,7 +15,7 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
       investigation.product_category,
       investigation.hazard_type,
       investigation.coronavirus_related?,
-      investigation.owner ? investigation.owner.decorate.display_name : "No case owner",
+      investigation.owner ? investigation.owner.decorate.display_name(viewer: current_user) : "No case owner",
       investigation.creator_user&.name,
       complainant.present? ? complainant&.name : "",
       complainant.present? ? complainant&.email_address : "",

--- a/psd-web/app/views/investigations/ownership/_owner_form.html.slim
+++ b/psd-web/app/views/investigations/ownership/_owner_form.html.slim
@@ -4,7 +4,7 @@
 
   ruby:
     items = investigation.important_owner_people.map do |user|
-      { text: user.decorate.display_name, value: user.id, checked: investigation.owner == user }
+      { text: user.decorate.display_name(viewer: current_user), value: user.id, checked: investigation.owner == user }
     end
 
     someone_in_your_team = capture do
@@ -35,7 +35,7 @@
     items.push divider: "Teams"
 
     teams = investigation.important_owner_teams.map do |team|
-      { text: team.decorate.display_name, value: team.id, checked: investigation.owner == team }
+      { text: team.decorate.display_name(viewer: current_user), value: team.id, checked: investigation.owner == team }
     end
     items.concat teams
 

--- a/psd-web/app/views/investigations/ownership/_owner_selection.html.slim
+++ b/psd-web/app/views/investigations/ownership/_owner_selection.html.slim
@@ -1,7 +1,7 @@
 ruby:
   actual_items = items.map do |item|
     {
-      text: item.decorate.display_name,
+      text: item.decorate.display_name(viewer: current_user),
       value: item.id
     }
   end

--- a/psd-web/app/views/investigations/ownership/confirm.html.erb
+++ b/psd-web/app/views/investigations/ownership/confirm.html.erb
@@ -21,7 +21,7 @@
       <%= render "minimal_investigation_heading", investigation: @investigation, title: page_heading %>
       <p>
         You are changing the case owner to:
-        <strong><%= @potential_owner.display_name || @potential_owner.name %></strong>
+        <strong><%= @potential_owner.decorate.display_name(viewer: current_user) %></strong>
       </p>
       <div class="govuk-form-group">
         <%= render "form_components/govuk_textarea",

--- a/psd-web/app/views/investigations/ownership/select-owner.html.slim
+++ b/psd-web/app/views/investigations/ownership/select-owner.html.slim
@@ -14,7 +14,7 @@
       - if @investigation.owner.present?
         p
           ' Current case owner:
-          strong = @investigation.owner.display_name
+          strong = @investigation.owner.decorate.display_name(viewer: current_user)
       - else
         p This case has no owner
 

--- a/psd-web/app/views/investigations/show.pdf.slim
+++ b/psd-web/app/views/investigations/show.pdf.slim
@@ -20,12 +20,12 @@ table[style="width:100%; text-align:left"]
     th
       | Case owner
     td
-      = @investigation.owner.nil? ? "No case owner" : @investigation.owner.display_name
+      = @investigation.owner.nil? ? "No case owner" : @investigation.owner.display_name(viewer: current_user)
   tr
     th
       | Source
     td
-      = @investigation.source.show
+      = @investigation.source.show(current_user)
 - if @investigation.products.any?
   h3
     | Products
@@ -52,6 +52,6 @@ table[style="width:100%; text-align:left"]
         td
           = activity.type.upcase_first
         td
-          = activity.source.show
+          = activity.source.show(current_user)
         td
           = activity.body

--- a/psd-web/app/views/invitations/new.html.erb
+++ b/psd-web/app/views/invitations/new.html.erb
@@ -1,4 +1,4 @@
-<%= page_title "Invite a team member to #{@team.decorate.display_name}", errors: @invite_user_to_team_form.errors.any? %>
+<%= page_title "Invite a team member to #{@team.decorate.display_name(viewer: current_user)}", errors: @invite_user_to_team_form.errors.any? %>
 
 <% content_for :after_header do %>
   <%= govukBackLink(text: "Back", href: @team) %>

--- a/psd-web/app/views/teams/show.html.erb
+++ b/psd-web/app/views/teams/show.html.erb
@@ -1,8 +1,8 @@
-<%= page_title(@team.display_name) %>
+<%= page_title(@team.display_name(viewer: current_user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l"><%= @team.display_name %></h1>
+    <h1 class="govuk-heading-l"><%= @team.display_name(viewer: current_user) %></h1>
 
     <%= link_to "Invite a team member", new_team_invitation_path(@team), class: "govuk-button", role: "button" if current_user.is_team_admin? %>
 

--- a/psd-web/spec/models/user_spec.rb
+++ b/psd-web/spec/models/user_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe User do
     it "includes associations needed for display_name" do
       owners = described_class.get_owners.to_a # to_a forces the query execution and load immediately
       expect(lambda {
-        owners.map { |owner| owner.decorate.display_name }
+        owners.map { |owner| owner.decorate.display_name(viewer: active_user) }
       }).to not_talk_to_db
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This branch is dependent on https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/700 and removes all remaining dependency on `User.current` in calls to `display_name`. Therefore please just look at the last commit in this branch.