### PR TITLE
Fix error when trying to display automatically updated case ownership change activity

### DIFF
--- a/psd-web/app/views/investigations/activities/investigation/_automatically_update_owner.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_automatically_update_owner.html.erb
@@ -1,0 +1,1 @@
+<%# Nothing to show %>

--- a/psd-web/app/views/investigations/activities/investigation/_update_owner.html.erb
+++ b/psd-web/app/views/investigations/activities/investigation/_update_owner.html.erb
@@ -1,1 +1,1 @@
-<%= markdown simple_format(activity.metadata["rationale"]) %>
+<%= markdown simple_format(activity.body) %>


### PR DESCRIPTION
This fixes a missing view template error when trying to show activities of type `AuditActivity::Investigation::AutomaticallyUpdateOwner`.

There's no feature test for the deletion of users (where this activity arises) so we'll need to add one separately. This is a quick fix.

At the moment we need a blank template even if there's nothing to show. Perhaps there is a better way which we can implement later.

