### PR TITLE
Link to add activity flow from add supporting information flow

### DIFF
--- a/psd-web/app/helpers/investigations_helper.rb
+++ b/psd-web/app/helpers/investigations_helper.rb
@@ -258,7 +258,7 @@ module InvestigationsHelper
     if policy(investigation).update?(user: user)
       activity_actions[:items] << {
         href: new_investigation_activity_path(investigation),
-        text: "Add activity"
+        text: "Add supporting information"
       }
       coronavirus_related_actions[:items] << {
         href: investigation_coronavirus_related_path(investigation),

--- a/psd-web/app/views/investigations/tabs/_activity.html.slim
+++ b/psd-web/app/views/investigations/tabs/_activity.html.slim
@@ -9,10 +9,7 @@
       = page_heading
 
     p.govuk-body
-      - if policy(@investigation).update?(user: current_user)
-        = link_to "Add activity", new_investigation_activity_path(@investigation)
-      - else
-        = link_to "Add comment", new_investigation_activity_comment_path(@investigation)
+      = link_to "Add comment", new_investigation_activity_comment_path(@investigation)
 
     hr.govuk-section-break.govuk-section-break--m
 

--- a/psd-web/app/views/investigations/tabs/_supporting_information.erb
+++ b/psd-web/app/views/investigations/tabs/_supporting_information.erb
@@ -8,9 +8,14 @@
 
     <% if policy(@investigation).update?(user: current_user) %>
       <p class="govuk-body">
-        <%= link_to "Add supporting information", new_investigation_new_path(@investigation) %>
+        <%= link_to "Add supporting information", new_investigation_activity_path(@investigation) %>
       </p>
+      <p class="govuk-body">
+        <%= link_to "Add file attachment", new_investigation_new_path(@investigation) %>
+      </p>
+
     <% end %>
+
 
     <hr class="govuk-section-break govuk-section-break--l">
   </div>

--- a/psd-web/spec/features/add_activity_entry_spec.rb
+++ b/psd-web/spec/features/add_activity_entry_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Adding an activity to a case", :with_stubbed_elasticsearch, :with
 
     visit "/cases/#{investigation.pretty_id}"
 
-    click_link "Add activity"
+    click_link "Add supporting information"
 
     expect(page).to have_content("New activity")
 

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
   before { sign_in(user) }
 
   scenario "Adding a corrective action (with validation errors)" do
-    visit "/cases/#{investigation.pretty_id}/activity"
+    visit "/cases/#{investigation.pretty_id}/supporting-information"
 
     click_link "Add supporting information"
 

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
   scenario "Adding a corrective action (with validation errors)" do
     visit "/cases/#{investigation.pretty_id}/activity"
 
-    click_link "Add activity"
+    click_link "Add supporting information"
 
     choose "Record corrective action"
 

--- a/psd-web/spec/features/add_test_results_spec.rb
+++ b/psd-web/spec/features/add_test_results_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
       sign_in(user)
       visit "/cases/#{investigation.pretty_id}/activity"
 
-      click_link "Add activity"
+      click_link "Add supporting information"
 
       expect_to_be_on_new_activity_page
 
@@ -74,7 +74,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     sign_in(other_user)
     visit "/cases/#{investigation.pretty_id}/activity"
 
-    expect(page).not_to have_link("Add activity")
+    expect(page).not_to have_link("Add supporting information")
   end
 
   def fill_in_test_result_submit_form(legislation:, date:, test_result:, file:)

--- a/psd-web/spec/features/add_test_results_spec.rb
+++ b/psd-web/spec/features/add_test_results_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
   scenario "Adding a test result (with validation errors)" do
     travel_to Date.parse("2 April 2020") do
       sign_in(user)
-      visit "/cases/#{investigation.pretty_id}/activity"
+      visit "/cases/#{investigation.pretty_id}/supporting-information"
 
       click_link "Add supporting information"
 

--- a/psd-web/spec/features/record_meeting_activity_spec.rb
+++ b/psd-web/spec/features/record_meeting_activity_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Recording a meeting on a case", :with_stubbed_elasticsearch, :wit
 
     visit "/cases/#{investigation.pretty_id}/activity"
 
-    click_link "Add activity"
+    click_link "Add supporting information"
 
     expect_to_be_on_new_activity_page
 

--- a/psd-web/spec/features/record_meeting_activity_spec.rb
+++ b/psd-web/spec/features/record_meeting_activity_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Recording a meeting on a case", :with_stubbed_elasticsearch, :wit
   scenario "Adding a meeting" do
     sign_in(user)
 
-    visit "/cases/#{investigation.pretty_id}/activity"
+    visit "/cases/#{investigation.pretty_id}/supporting-information"
 
     click_link "Add supporting information"
 

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :wi
   scenario "shows the number of recipients the alert will be sent to, including active users only" do
     visit investigation_path(investigation)
 
-    click_link "Add activity"
+    click_link "Add supporting information"
 
     choose "Send email alert about this case"
     click_button "Continue"

--- a/psd-web/test/system/alert_test.rb
+++ b/psd-web/test/system/alert_test.rb
@@ -64,7 +64,7 @@ class AlertTest < ApplicationSystemTestCase
   def go_to_new_activity_for_investigation(investigation)
     visit investigation_path(investigation)
 
-    click_link "Add activity"
+    click_link "Add supporting information"
   end
 
   def fill_in_activity_selection


### PR DESCRIPTION
Some short term fixes to enable us to deliver this feature branch before the new `Add supporting information` flow is ready.

Changes:

* Link to existing `Add activity` flow from the supporting information tab
* Add link for `Add file attachment` in addition.
* Remove `Add activity` link from `Activity` tab - now always shows `Add comment`
* Change name to `Add supporting information` on case overview tab.

Screenshot:
<img width="1432" alt="Screenshot 2020-06-15 at 10 53 22" src="https://user-images.githubusercontent.com/2204224/84644219-c942af80-aef6-11ea-906a-e1b739b1d131.png">
