### PR TITLE
Apply layout fixes from #709 to restricted attachments too

### DIFF
--- a/psd-web/app/views/documents/_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_generic_document_card.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row govuk-!-padding-bottom-4">
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <div class="app-generic-attachment__thumbnail">
       <% if document.metadata["safe"] %>
         <%= document_placeholder(document) %>

--- a/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
+++ b/psd-web/app/views/documents/_restricted_generic_document_card.html.erb
@@ -1,13 +1,16 @@
-<div class="govuk-grid-row govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-one-quarter">
-    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: true %>
+<div class="govuk-grid-row govuk-!-padding-bottom-4">
+
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="app-generic-attachment__thumbnail">
+      <%= document_placeholder(document) %>
+    </div>
+
+    <div class="app-generic-attachment__metadata">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t("supporting_information.restricted_generic.title") %></h2>
+      <span class="govuk-hint govuk-!-font-size-16">
+        <%= formatted_file_updated_date(document) %>
+      </span>
+    </div>
   </div>
 
-  <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t("supporting_information.restricted_generic.title") %></h2>
-    <span class="govuk-hint govuk-!-font-size-16">
-      <%= formatted_file_updated_date(document) %>
-    </span>
-
-  </div>
 </div>


### PR DESCRIPTION
This applies the layout fixes I did in #709 to generic restricted attachments.

After:
<img width="1047" alt="Screenshot 2020-06-17 at 12 00 25" src="https://user-images.githubusercontent.com/2204224/84890336-2d4dab00-b092-11ea-8e49-0756540834e2.png">

Before:
<img width="925" alt="Screenshot 2020-06-17 at 12 00 36" src="https://user-images.githubusercontent.com/2204224/84890463-5a9a5900-b092-11ea-901d-67f088e9938c.png">
