### PR TITLE
fix corrective action show page

### DIFF
--- a/psd-web/app/controllers/investigations/corrective_actions_controller.rb
+++ b/psd-web/app/controllers/investigations/corrective_actions_controller.rb
@@ -2,6 +2,6 @@ class Investigations::CorrectiveActionsController < ApplicationController
   def show
     @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :view_non_protected_details?
-    @corrective_action = @investigation.corrective_actions.find(params[:id])
+    @corrective_action = @investigation.corrective_actions.find(params[:id]).decorate
   end
 end

--- a/psd-web/app/decorators/corrective_action_decorator.rb
+++ b/psd-web/app/decorators/corrective_action_decorator.rb
@@ -3,6 +3,8 @@ class CorrectiveActionDecorator < ApplicationDecorator
   include SupportingInformationHelper
 
   def details
+    return if object.details.blank?
+
     h.simple_format(object.details)
   end
 
@@ -20,5 +22,13 @@ class CorrectiveActionDecorator < ApplicationDecorator
 
   def show_path
     h.investigation_action_path(investigation, object)
+  end
+
+  def measure_type
+    object.measure_type&.upcase_first
+  end
+
+  def duration
+    object.duration.upcase_first
   end
 end

--- a/psd-web/app/helpers/investigations/corrective_actions_helper.rb
+++ b/psd-web/app/helpers/investigations/corrective_actions_helper.rb
@@ -1,0 +1,20 @@
+module Investigations
+  module CorrectiveActionsHelper
+    def corrective_action_summary_list_rows(corrective_action)
+      business = corrective_action.business ? link_to(corrective_action.business.trading_name, business_path(corrective_action.business)) : "Not specified"
+      rows = [
+        { key: { text: "Date of action" },      value: { text: corrective_action.date_of_activity } },
+        { key: { text: "Legislation" },         value: { text: corrective_action.legislation } },
+        { key: { text: "Product" },             value: { html: link_to(corrective_action.product.name, product_path(corrective_action.product)) } },
+        { key: { text: "Business" },            value: { html: business } },
+      ]
+
+      rows << { key: { text: "Type of action" },      value: { text: corrective_action.measure_type } } if corrective_action.measure_type.present?
+      rows << { key: { text: "Duration of measure" }, value: { text: corrective_action.duration } }
+      rows << { key: { text: "Scope" },               value: { text: corrective_action.geographic_scope } }
+      rows << { key: { text: "Other details" },       value: { text: corrective_action.details } }      if corrective_action.details.present?
+
+      rows
+    end
+  end
+end

--- a/psd-web/app/views/investigations/corrective_actions/show.html.erb
+++ b/psd-web/app/views/investigations/corrective_actions/show.html.erb
@@ -16,49 +16,11 @@
 
     <div class="app-meta-area">
       <p class="govuk-body govuk-hint">
-        Added <%= @corrective_action.created_at.to_s(:govuk) %>
+        Added <%= @corrective_action.date_added %>
       </p>
     </div>
 
-    <% rows = [
-      {
-        key: { text: "Date of action" },
-        value: { text: @corrective_action.date_decided.to_s(:govuk) }
-      },
-      {
-        key: { text: "Legislation" },
-        value: { text: @corrective_action.legislation }
-      },
-      {
-        key: { text: "Product" },
-        value: { html: link_to(@corrective_action.product.name, product_path(@corrective_action.product)) }
-      },
-      {
-        key: { text: "Business" },
-        value: { html: @corrective_action.business ? link_to(@corrective_action.business.trading_name, business_path(@corrective_action.business)) : "Not specified" }
-      },
-      {
-        key: { text: "Type of action" },
-        value: { text: @corrective_action.measure_type.upcase_first }
-      },
-      {
-        key: { text: "Duration of measure" },
-        value: { text: @corrective_action.duration.upcase_first }
-      },
-      {
-        key: { text: "Scope" },
-        value: { text: @corrective_action.geographic_scope }
-      }
-    ]
-
-    if @corrective_action.details.present?
-      rows << {
-        key: { text: "Other details" },
-        value: { text: @corrective_action.details }
-      }
-    end
-    %>
-    <%= govukSummaryList(rows: rows) %>
+    <%= govukSummaryList(rows: corrective_action_summary_list_rows(@corrective_action)) %>
   </div>
 
   <% if @corrective_action.documents.any? %>

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -63,13 +63,13 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
 
     expect_to_be_on_corrective_action_page(case_id: investigation.pretty_id)
 
-    expect(page).to have_summary_item(key: "Date of action", value: "1 May 2020")
-    expect(page).to have_summary_item(key: "Product", value: "MyBrand Washing Machine")
-    expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
-    expect(page).to have_summary_item(key: "Type of action", value: "Mandatory")
+    expect(page).to have_summary_item(key: "Date of action",      value: "1 May 2020")
+    expect(page).to have_summary_item(key: "Product",             value: "MyBrand Washing Machine")
+    expect(page).to have_summary_item(key: "Legislation",         value: "General Product Safety Regulations 2005")
+    expect(page).to have_summary_item(key: "Type of action",      value: "Mandatory")
     expect(page).to have_summary_item(key: "Duration of measure", value: "Permanent")
-    expect(page).to have_summary_item(key: "Scope", value: "National")
-    expect(page).to have_summary_item(key: "Other details", value: "Urgent action following consumer reports")
+    expect(page).to have_summary_item(key: "Scope",               value: "National")
+    expect(page).to have_summary_item(key: "Other details",       value: "Urgent action following consumer reports")
 
     expect(page).to have_link("old_risk_assessment.txt")
   end

--- a/psd-web/spec/features/case_images_tab_spec.rb
+++ b/psd-web/spec/features/case_images_tab_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Manage Images", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
-  let(:investigation) { create(:investigation, owner: user.team) }
+  let(:investigation) { create(:allegation, owner: user.team) }
   let(:file)          { Rails.root + "test/fixtures/files/testImage.png" }
   let(:title)         { Faker::Lorem.sentence }
   let(:description)   { Faker::Lorem.paragraph }

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
-  let(:investigation) { create(:investigation, :with_document, owner: user.team) }
+  let(:investigation) { create(:allegation, :with_document, owner: user.team) }
 
   include_context "with all types of supporting information"
 

--- a/psd-web/spec/helpers/investigations/corrective_actions_helper_spec.rb
+++ b/psd-web/spec/helpers/investigations/corrective_actions_helper_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Investigations::CorrectiveActionsHelper, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  describe "#corrective_action_summary_list_rows" do
+    let(:business)          { create(:business) }
+    let(:corrective_action) { create(:corrective_action, date_decided: 2.weeks.ago, business: business).decorate }
+
+    let(:expected_rows) do
+      [
+        { key: { text: "Date of action" }, value: { text: corrective_action.date_of_activity } },
+        { key: { text: "Legislation" }, value: { text: corrective_action.legislation } },
+        { key: { text: "Product" }, value: { html: helper.link_to(corrective_action.product.name, helper.product_path(corrective_action.product)) } },
+        { key: { text: "Business" }, value: { html: helper.link_to(corrective_action.business.trading_name, helper.business_path(corrective_action.business)) } },
+        { key: { text: "Type of action" }, value: { text: corrective_action.measure_type.upcase_first } },
+        { key: { text: "Duration of measure" }, value: { text: corrective_action.duration.upcase_first } },
+        { key: { text: "Scope" }, value: { text: corrective_action.geographic_scope } }
+      ]
+    end
+
+    context "when all details are presents" do
+      it "displays every rows" do
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(*expected_rows)
+      end
+    end
+
+    context "when no business is present" do
+      let(:business) { nil }
+
+      it "does not link to the business" do
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).to include(key: { text: "Business" }, value: { html: "Not specified" })
+      end
+    end
+
+    context "when no measure_type" do
+      before { corrective_action.measure_type = nil }
+
+      it "does not show the type of action" do
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).not_to include(key: { text: "Type of action" }, value: { text: nil })
+      end
+    end
+
+    context "when no details" do
+      before { corrective_action.details = nil }
+
+      it "does not show the type of action" do
+        expect(helper.corrective_action_summary_list_rows(corrective_action)).not_to include(key: { text: "Other details" }, value: { text: nil })
+      end
+    end
+  end
+end

--- a/psd-web/spec/models/corrective_action_spec.rb
+++ b/psd-web/spec/models/corrective_action_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe CorrectiveAction, :with_stubbed_elasticsearch, :with_stubbed_mail
 
   describe "#create_audit_activity", :with_stubbed_mailer do
     # The audit activity requires pretty_id to be set on the Investigation
-    let(:investigation) { create(:investigation) }
+    let(:investigation) { create(:allegation) }
 
     it "creates an activity" do
       expect { corrective_action.save }.to change { AuditActivity::CorrectiveAction::Add.count }.by(1)

--- a/psd-web/spec/models/investigation_spec.rb
+++ b/psd-web/spec/models/investigation_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_notify do
   describe "supporting information" do
     let(:user)                                    { create(:user, :activated, has_viewed_introduction: true) }
-    let(:investigation)                           { create(:investigation, owner: user.team) }
+    let(:investigation)                           { create(:allegation, owner: user.team) }
     let(:generic_supporting_information_filename) { "a generic supporting information" }
     let(:generic_image_filename)                  { "a generic image" }
     let(:image) { Rails.root.join("test/fixtures/files/testImage.png") }


### PR DESCRIPTION
## CHANGES:

Ensure that when `CorrectiveAction#measure_type` is `nil` it does not blow up.

1. cleaned up `CorrectiveActionController#show` view by using already existing methods  from the corresponding decorator and added a couple more
2. used a helper to construct the summary list and added test coverage.