### PR TITLE
Remove OPSS and creator/owner org users ability to view restricted cases where they are not a collaborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2020-06-19
 - Added case owner team and removed complainant details from cases export spreadsheet.
+- Only teams added to a case can now view restricted cases
 
 ## 2020-06-17
 - Only teams added to a case can now view correspondence or attachment details.

--- a/psd-web/app/models/source.rb
+++ b/psd-web/app/models/source.rb
@@ -8,8 +8,4 @@ class Source < ApplicationRecord
   def created_by
     "Created by #{show}, #{created_at.strftime('%d/%m/%Y')}"
   end
-
-  def user_has_gdpr_access?(*)
-    true
-  end
 end

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -58,8 +58,8 @@ class User < ApplicationRecord
     RequestStore.store[:current_user] = user
   end
 
-  def has_gdpr_access?(other_user)
-    other_user.organisation == organisation
+  def in_same_team_as?(user)
+    team == user.team
   end
 
   def name

--- a/psd-web/app/models/user_source.rb
+++ b/psd-web/app/models/user_source.rb
@@ -4,8 +4,4 @@ class UserSource < Source
   def show(viewer = nil)
     user.present? ? user.decorate.display_name(viewer: viewer) : "anonymous"
   end
-
-  def user_has_gdpr_access?(user)
-    user.organisation == self.user&.organisation
-  end
 end

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -33,9 +33,7 @@ class InvestigationPolicy < ApplicationPolicy
     return true unless private
 
     # Has the user's team been added to the case as a collaborator?
-    return true if @record.teams_with_access.include?(user.team)
-
-    false
+    @record.teams_with_access.include?(user.team)
   end
 
   def view_protected_details?(user: @user)

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -31,12 +31,9 @@ class InvestigationPolicy < ApplicationPolicy
   # with businesses.
   def view_non_protected_details?(user: @user, private: @record.is_private)
     return true unless private
-    return true if user.is_opss?
-    return true if @record.owner.present? && (@record.owner&.organisation == user.organisation)
-    return true if @record.creator_user&.has_gdpr_access?(user)
 
     # Has the user's team been added to the case as a collaborator?
-    return true if @record.teams_with_edit_access.include?(user.team)
+    return true if @record.teams_with_access.include?(user.team)
 
     false
   end

--- a/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
+++ b/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   let(:other_organisation) { create(:organisation) }
   let(:other_team) { create(:team, organisation: other_organisation) }
   let(:other_user) { create(:user, :activated, organisation: other_organisation, team: other_team) }
+  let(:other_user_same_org) { create(:user, :activated, organisation: users_organisation, team: other_team_from_the_same_organisation) }
 
   before do
     sign_in user
@@ -25,11 +26,7 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
   end
 
   context "when another team from the same organisation is the case owner" do
-    let(:investigation) { create(:allegation, is_private: true, creator: user) }
-
-    before do
-      ChangeCaseOwner.call!(investigation: investigation, user: user, owner: other_team_from_the_same_organisation)
-    end
+    let(:investigation) { create(:allegation, is_private: true, creator: other_user_same_org) }
 
     it "displays an forbidden message" do
       expect(response).to have_http_status(:forbidden)

--- a/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
+++ b/psd-web/spec/requests/investigations/viewing_a_restricted_case_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
       ChangeCaseOwner.call!(investigation: investigation, user: user, owner: other_team_from_the_same_organisation)
     end
 
-    it "renders the page" do
-      expect(response).to have_http_status(:ok)
+    it "displays an forbidden message" do
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/1N8vvk4x/533-2-remove-opss-blanket-ability-to-view-restricted-cases

## Description
This removes a user's ability to view a restricted case when their team was not added to the case. Currently a user can view it if they are an OPSS user, or they are in the same organisation as the owner or original creator of the case.

The test coverage for viewing a restricted case was incomplete and didn't cover most of those scenarios; therefore I didn't need to change the tests too much. The current test coverage now accurately reflects the behaviour as implemented.

⚠️ **DO NOT MERGE**: We need to communicate this change to affected users first. Will work with @tobyhughes on this.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Has acceptance criteria been tested by a peer?
- [x] Has the CHANGELOG been updated? (If change is worth telling users about.)
