### PR TITLE
Bugfix: remove new owner team as a collaborator if they were one

### DIFF
--- a/psd-web/app/services/change_case_owner.rb
+++ b/psd-web/app/services/change_case_owner.rb
@@ -14,6 +14,11 @@ class ChangeCaseOwner
     return if old_owner == owner
 
     ActiveRecord::Base.transaction do
+      if owner.is_a?(Team)
+        # Remove the new owner team as a collaborator if they were one.
+        investigation.edit_access_collaborations.where(editor: owner).delete_all
+      end
+
       investigation.update!(owner: owner)
       create_audit_activity_for_case_owner_changed
     end

--- a/psd-web/spec/services/change_case_owner_spec.rb
+++ b/psd-web/spec/services/change_case_owner_spec.rb
@@ -152,6 +152,22 @@ RSpec.describe ChangeCaseOwner, :with_stubbed_elasticsearch, :with_test_queue_ad
           end
         end
       end
+
+      context "when the new owner was previously a collaborator" do
+        let(:new_owner) { team }
+
+        before do
+          investigation.edit_access_collaborations.create!(
+            editor: new_owner, include_message: false,
+            added_by_user: user
+          )
+        end
+
+        it "removes the new owner as a collaborator" do
+          result
+          expect(investigation.edit_access_collaborations.where(editor: team).size).to eq(0)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
If you change the case owner to a team who were previously added to the case, they currently show up twice, once as the [new] owner and once as a team added to the case.

This fixes that to remove the team as a collaborator when they become an owner.