### PR TITLE
Show a label against the case creator in the case teams list

### DIFF
--- a/psd-web/app/assets/stylesheets/text.scss
+++ b/psd-web/app/assets/stylesheets/text.scss
@@ -72,3 +72,9 @@ h6 {
     margin-top: 8px; // to match padding on large buttons
   }
 }
+
+.app-body--table-heading-supplementary {
+  color: $govuk-secondary-text-colour;
+  display: block;
+  margin-top: 8px;
+}

--- a/psd-web/app/views/collaborators/index.html.erb
+++ b/psd-web/app/views/collaborators/index.html.erb
@@ -29,14 +29,26 @@
       <tbody class="govuk-table__body">
         <% if @investigation.owner_team %>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= @investigation.owner_team.name %></th>
+            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+              <%= @investigation.owner_team.name %>
+              <% if @investigation.creator_team == @investigation.owner_team %>
+                <br>
+                <span class="app-body--table-heading-supplementary">Case creator</span>
+              <% end %>
+            </th>
             <td class="govuk-table__cell"><span class="hmcts-badge hmcts-badge--grey">Case owner</span></td>
             <td class="govuk-table__cell"></td>
           </tr>
         <% end %>
         <% @teams.each do |team| %>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><%= team.name %></th>
+            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+              <%= team.name %>
+              <% if @investigation.creator_team == team %>
+                <br>
+                <span class="govuk-body govuk-hint">Case creator</span>
+              <% end %>
+            </th>
             <td class="govuk-table__cell">Edit full case</td>
             <td class="govuk-table__cell app-table__cell--align-right">
               <% if policy(@investigation).manage_collaborators? %>

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
   let(:investigation) do
     create(
       :allegation,
-      owner: user
+      owner: user,
+      creator: user
     )
   end
 
@@ -35,7 +36,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner" }
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true }
     ])
 
     click_link "Add a team to the case"
@@ -69,7 +70,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner" },
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" }
     ])
 
@@ -106,7 +107,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner" },
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" }
     ])
 
@@ -150,7 +151,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner" }
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true }
     ])
 
     expect_teams_tables_not_to_contain([

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true }
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", creator: true }
     ])
 
     click_link "Add a team to the case"
@@ -70,7 +70,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true },
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", creator: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" }
     ])
 
@@ -107,7 +107,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true },
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", creator: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" }
     ])
 
@@ -151,7 +151,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", owner: true }
+      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", creator: true }
     ])
 
     expect_teams_tables_not_to_contain([

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -346,7 +346,7 @@ module PageExpectations
         row_heading = page.find("th", text: expected_team[:team_name])
         expect(row_heading).to have_sibling("td", text: expected_team[:permission_level])
 
-        if expected_team[:owner]
+        if expected_team[:creator]
           expect(row_heading).to have_text("Case creator")
         end
       end

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -345,6 +345,10 @@ module PageExpectations
       expected_teams.each do |expected_team|
         row_heading = page.find("th", text: expected_team[:team_name])
         expect(row_heading).to have_sibling("td", text: expected_team[:permission_level])
+
+        if expected_team[:owner]
+          expect(row_heading).to have_text("Case creator")
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/cX8VzwTD/532-2-show-label-for-case-creator-if-on-teams-list

## Description
Shows a label next to the case owner in the teams list for a case.

<img width="831" alt="Screenshot 2020-06-22 at 11 46 57" src="https://user-images.githubusercontent.com/408371/85279311-218d2a80-b47e-11ea-92b7-bf4f2490686c.png">


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
