### PR TITLE
Add Risk and Issues section to case overview page

### DIFF
--- a/psd-web/app/decorators/investigation_decorator.rb
+++ b/psd-web/app/decorators/investigation_decorator.rb
@@ -26,7 +26,6 @@ class InvestigationDecorator < ApplicationDecorator
 
   def product_summary_list
     products_details = [products.count, "product".pluralize(products.count), "added"].join(" ")
-    hazards = h.simple_format([hazard_type, object.hazard_description].join("\n\n"))
     rows = [
       category.present? ? { key: { text: "Category" }, value: { text: category }, actions: [] } : nil,
       {
@@ -34,6 +33,18 @@ class InvestigationDecorator < ApplicationDecorator
         value: { text: products_details },
         actions: [href: h.investigation_products_path(object), visually_hidden_text: "product details", text: "View"]
       },
+    ]
+    rows.compact!
+    h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"
+  end
+
+  def display_risk_and_issues_list?
+    object.hazard_type.present? || object.non_compliant_reason.present?
+  end
+
+  def risk_and_issues_list
+    hazards = h.simple_format([hazard_type, object.hazard_description].join("\n\n"))
+    rows = [
       object.hazard_type.present? ? { key: { text: "Hazards" }, value: { text: hazards }, actions: [] } : nil,
       object.non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: non_compliant_reason }, actions: [] } : nil,
     ]

--- a/psd-web/app/views/investigations/tabs/_overview.html.erb
+++ b/psd-web/app/views/investigations/tabs/_overview.html.erb
@@ -23,6 +23,12 @@
       <%= @investigation.product_summary_list %>
     <% end %>
 
+    <% if @investigation.display_risk_and_issues_list? %>
+      <%= govuk_hr %>
+      <h2 class="govuk-heading-m"><%= "Risks and issues" %></h2>
+      <%= @investigation.risk_and_issues_list %>
+    <% end %>
+
     <% if @investigation.complainant %>
       <%= govuk_hr %>
       <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.upcase_first %></h2>


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/26x7SFq8/580-3-make-risk-section-in-case-overview-page)

This section will show the case hazard and compliance information. 
When there is no hazard or compliance issue information associated to the case, the full section will be hid.

### For an OPSS case
![Screenshot from 2020-06-24 14-06-39](https://user-images.githubusercontent.com/1227578/85566214-c0a15600-b627-11ea-9421-13a32fd95149.png)

### For a TS case
![Screenshot from 2020-06-24 14-25-36](https://user-images.githubusercontent.com/1227578/85566270-d0209f00-b627-11ea-82bd-66a5ad8c8e85.png)

