### PR TITLE
Allow all users to view case images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## 2020-06-26
 – Added the ability to edit test results.
 - Added a case bar which always shows which case you are viewing across all case pages.
+- Fixed a bug where case images were only viewable if your team (or another team in your organisation) was added to a case.
 
 ## 2020-06-22
 - Moved link for adding meetings, phone calls, emails, test results and corrective actions from the case

--- a/psd-web/app/models/audit_activity/document/base.rb
+++ b/psd-web/app/models/audit_activity/document/base.rb
@@ -23,6 +23,6 @@ class AuditActivity::Document::Base < AuditActivity::Base
   def restricted_title(_user); end
 
   def can_display_all_data?(user)
-    Pundit.policy(user, investigation).view_protected_details?
+    attached_image? || Pundit.policy(user, investigation).view_protected_details?
   end
 end

--- a/psd-web/app/views/documents/_document_card.html.erb
+++ b/psd-web/app/views/documents/_document_card.html.erb
@@ -1,37 +1,31 @@
 <%
-  restricted = parent.is_a?(Investigation) && !policy(parent).view_protected_details?
-  title = restricted ? "Attachment restricted" : document.title
   safe = document.metadata["safe"]
   document = document.decorate
 %>
 
 <div class="govuk-grid-row govuk-!-padding-bottom-6">
   <div class="govuk-grid-column-one-quarter">
-    <%= render "documents/document_preview", document: document, dimensions: "300x200", restricted: restricted %>
+    <%= render "documents/document_preview", document: document, dimensions: "300x200" %>
   </div>
 
   <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= title %></h2>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= document.title %></h2>
     <span class="govuk-hint govuk-!-font-size-16">
       <%= formatted_file_updated_date(document) %>
     </span>
 
-    <% if restricted %>
-      <p class="govuk-body govuk-hint"><%= t("case.protected_details", data_type: "case attachments") %></p>
-    <% else %>
-      <p class="govuk-body"><%= document.description %></p>
+    <p class="govuk-body"><%= document.description %></p>
 
-      <% if safe %>
-        <%= link_with_hidden_text_to "View #{pretty_type_description(document)}",
-           "(#{title}, opens in a new window)",
-           document,
-           class: "govuk-link app-block-link govuk-!-margin-right-3",
-           target: '_blank',
-           rel: 'noopener' %>
+    <% if safe %>
+      <%= link_with_hidden_text_to "View #{pretty_type_description(document)}",
+         "(#{document.title}, opens in a new window)",
+         document,
+         class: "govuk-link app-block-link govuk-!-margin-right-3",
+         target: '_blank',
+         rel: 'noopener' %>
 
-        <% if !parent.is_a?(Investigation) || policy(parent).update?(user: current_user) %>
-          <%= render "documents/document_card_links", document: document, parent: parent %>
-        <% end %>
+      <% if !parent.is_a?(Investigation) || policy(parent).update?(user: current_user) %>
+        <%= render "documents/document_card_links", document: document, parent: parent %>
       <% end %>
     <% end %>
   </div>

--- a/psd-web/app/views/documents/_document_preview.html.erb
+++ b/psd-web/app/views/documents/_document_preview.html.erb
@@ -9,9 +9,7 @@
 %>
 
 <div class="app-document-preview <%= class_name %>">
-  <% if local_assigns[:restricted] %>
-    <%= document_placeholder(document) %>
-  <% elsif document.metadata["safe"] %>
+  <% if document.metadata["safe"] %>
     <% if document.image? %>
       <div class="<%= image_class %>">
         <% if hide_link %>

--- a/psd-web/spec/features/case_images_tab_spec.rb
+++ b/psd-web/spec/features/case_images_tab_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Manage Images", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
+  let(:other_user_different_org) { create(:user, :activated) }
+
   let(:investigation) { create(:allegation, owner: user.team) }
   let(:file)          { Rails.root + "test/fixtures/files/testImage.png" }
   let(:title)         { Faker::Lorem.sentence }
@@ -26,7 +28,21 @@ RSpec.feature "Manage Images", :with_stubbed_elasticsearch, :with_stubbed_antivi
 
     expect_to_be_on_images_page
 
-    expect_case_attachments_page_to_show_entered_information
+    expect_case_images_page_to_show_entered_information
+
+    click_link "Activity"
+
+    expect_case_activity_page_to_show_entered_information
+
+    # Test that another user in a different organisation can see case images
+    sign_out
+
+    sign_in(other_user_different_org)
+
+    visit "/cases/#{investigation.pretty_id}/images"
+    expect_to_be_on_images_page
+
+    expect_case_images_page_to_show_entered_information
 
     click_link "Activity"
 
@@ -76,7 +92,7 @@ RSpec.feature "Manage Images", :with_stubbed_elasticsearch, :with_stubbed_antivi
     expect(item).to have_selector("p", text: description)
   end
 
-  def expect_case_attachments_page_to_show_entered_information
+  def expect_case_images_page_to_show_entered_information
     expect(page).to have_selector("h2", text: title)
     expect(page).to have_selector("p", text: description)
   end


### PR DESCRIPTION
https://trello.com/c/PZ79IE49/634-images-are-not-supposed-to-be-restricted-for-outside-team-members

## Description
Fixes a bug where users on teams not added to the case can't view case images.

The affected template is now only used on case images and business attachments, so there is no need for any access control on the template. Access to restricted cases is already guarded by the controller.

There were no specific tests for this functionality so it was not necessary to modify any existing tests. I don't think we need to add a specific test that the images are visible - generally we only need to add specific tests for things which the user shouldn't be able to see. I added a test for the activity timeline as the behaviour is different depending on whether the attachment is an image or not.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Has acceptance criteria been tested by a peer?
