### PR TITLE
Use isolated database for each review app

### DIFF
--- a/.github/workflows/overrides/ add_supporting_information_flow .env
+++ b/.github/workflows/overrides/ add_supporting_information_flow .env
@@ -1,1 +1,0 @@
-export DB_NAME= add_supporting_information_flow

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -54,7 +54,7 @@ jobs:
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
         export APP_NAME=psd-pr-$PR_NUMBER
-        export DB_NAME=psd-db-$BRANCH
+        export DB_NAME=psd-db-pr-$PR_NUMBER
         echo "Deploying review app. If fails, use command below to deploy manually:"
         echo "DB_NAME=$DB_NAME APP_NAME=$APP_NAME /psd-web/deploy-review.sh"
 

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -53,19 +53,10 @@ jobs:
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
-        export DB_VERSION=`cat psd-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
         export APP_NAME=psd-pr-$PR_NUMBER
-        export DB_NAME=psd-db-$DB_VERSION
+        export DB_NAME=psd-db-$BRANCH
         echo "Deploying review app. If fails, use command below to deploy manually:"
         echo "DB_NAME=$DB_NAME APP_NAME=$APP_NAME /psd-web/deploy-review.sh"
-        OVERRIDES_FILE=".github/workflows/overrides/$BRANCH.env"
-        if [ -f "$OVERRIDES_FILE" ]; then
-            echo "Using overrides:"
-            cat $OVERRIDES_FILE
-            source $OVERRIDES_FILE
-        else
-            echo "No overrides file $OVERRIDES_FILE. Using default variables."
-        fi
 
         ./psd-web/deploy-review.sh
         cf7 logout

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -17,8 +17,7 @@ By default, the database is shared, but it can be overriden by setting the `DB_N
 
 #### Custom environment variables in review application
 
-Variables used by `psd-web/deploy-review.sh` can be overriden. Especially changing `$DB_NAME` can be usefull.
-To do so, create `.github/workflows/overrides/branch-name.env` file, where branch-name is name of branch used for PR. Define variables in this file:
+Variables used by `psd-web/deploy-review.sh` can be overriden. To do so, create `.github/workflows/overrides/branch-name.env` file, where branch-name is name of branch used for PR. Define variables in this file:
 
 ```
 export DB_NAME=psd-db-custom-db


### PR DESCRIPTION

## Description
Following discussion with the team it was agreed we would change the default behaviour for review apps to use a new isolated database instance. This will increase the time needed to deploy a branch for the first time, but will help resolve issues with data changes in different branches. I have retained the override functionality so that if needed, a shared database instance could be used if one was created or maintained. It also allows us to continue overriding other variables as needed.
