### PR TITLE
Ensure only admin users can export cases

### DIFF
--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -16,6 +16,8 @@ class InvestigationsController < ApplicationController
                             .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
       end
       format.xlsx do
+        authorize current_user, :export_cases?
+
         @answer = search_for_investigations
         @investigations = Investigation.eager_load(
           :complainant,

--- a/psd-web/app/controllers/investigations_controller.rb
+++ b/psd-web/app/controllers/investigations_controller.rb
@@ -16,7 +16,7 @@ class InvestigationsController < ApplicationController
                             .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
       end
       format.xlsx do
-        authorize current_user, :export_cases?
+        authorize Investigation, :export?
 
         @answer = search_for_investigations
         @investigations = Investigation.eager_load(

--- a/psd-web/app/policies/investigation_policy.rb
+++ b/psd-web/app/policies/investigation_policy.rb
@@ -47,4 +47,8 @@ class InvestigationPolicy < ApplicationPolicy
   def investigation_restricted?
     !@record.is_private
   end
+
+  def export?
+    user.is_psd_admin?
+  end
 end

--- a/psd-web/app/policies/user_policy.rb
+++ b/psd-web/app/policies/user_policy.rb
@@ -1,0 +1,5 @@
+class UserPolicy < ApplicationPolicy
+  def export_cases?
+    record.is_psd_admin?
+  end
+end

--- a/psd-web/app/policies/user_policy.rb
+++ b/psd-web/app/policies/user_policy.rb
@@ -1,5 +1,0 @@
-class UserPolicy < ApplicationPolicy
-  def export_cases?
-    record.is_psd_admin?
-  end
-end

--- a/psd-web/app/views/investigations/index.html.slim
+++ b/psd-web/app/views/investigations/index.html.slim
@@ -15,7 +15,7 @@
                locals: { sorted_by: query_params[:sort_by] }
       = will_paginate @investigations
 
-      - if policy(current_user).export_cases?
+      - if policy(Investigation).export?
         = link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params)
     - else
       .govuk-heading-l[style="text-align:center"] No results

--- a/psd-web/app/views/investigations/index.html.slim
+++ b/psd-web/app/views/investigations/index.html.slim
@@ -15,7 +15,7 @@
                locals: { sorted_by: query_params[:sort_by] }
       = will_paginate @investigations
 
-      - if current_user.is_psd_admin?
+      - if policy(current_user).export_cases?
         = link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params)
     - else
       .govuk-heading-l[style="text-align:center"] No results

--- a/psd-web/app/views/searches/show.html.erb
+++ b/psd-web/app/views/searches/show.html.erb
@@ -16,9 +16,12 @@
         <%= render "investigations/case_card", investigation: investigation.decorate, sorted_by: @search.sort_by %>
       <% end %>
     <% end %>
+
     <%= will_paginate @answer.results %>
+
     <br />
-    <% if current_user.is_psd_admin? %>
+
+    <% if policy(current_user).export_cases? %>
       <%= link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params), class: "govuk-link" %>
     <% end %>
 

--- a/psd-web/app/views/searches/show.html.erb
+++ b/psd-web/app/views/searches/show.html.erb
@@ -21,7 +21,7 @@
 
     <br />
 
-    <% if policy(current_user).export_cases? %>
+    <% if policy(Investigation).export? %>
       <%= link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: export_params), class: "govuk-link" %>
     <% end %>
 

--- a/psd-web/spec/features/invite_user_spec.rb
+++ b/psd-web/spec/features/invite_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Inviting a user", :with_stubbed_mailer, :with_stubbed_elasticsear
   let(:email) { Faker::Internet.safe_email }
 
   context "when the user is not a team admin" do
-    let(:user_role) { :psd_admin }
+    let(:user_role) { :psd_user }
 
     before do
       sign_in(user)

--- a/psd-web/test/controllers/investigations_controller_test.rb
+++ b/psd-web/test/controllers/investigations_controller_test.rb
@@ -316,11 +316,6 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
     # assert response.body.index(@investigation_two.pretty_id.to_s) < response.body.index(@investigation_one.pretty_id.to_s)
   end
 
-  test "should create excel file for list of investigations" do
-    get investigations_path format: :xlsx
-    assert_response :success
-  end
-
   test "should not show private investigations to everyone" do
     create_new_private_case(@user)
     sign_out :user


### PR DESCRIPTION

## Description
This change ensures only users with the `psd_admin` role are able to download the cases export spreadsheet. This was always intended by conditionally showing the link, but the actual endpoint was not protected.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
