### PR TITLE
Fix error caused when trying to create a project

### DIFF
--- a/psd-web/app/controllers/investigations/project_controller.rb
+++ b/psd-web/app/controllers/investigations/project_controller.rb
@@ -15,7 +15,7 @@ class Investigations::ProjectController < ApplicationController
 
   # GET /xxx/new
   def new
-    session.delete :investigation
+    session.delete model_key
     redirect_to wizard_path(steps.first)
   end
 
@@ -33,7 +33,7 @@ class Investigations::ProjectController < ApplicationController
   def update
     return render_wizard unless @investigation.valid?(step)
 
-    session[:investigation] = @investigation.attributes
+    session[model_key] = @investigation.attributes
 
     if step == steps.last
       create
@@ -45,7 +45,7 @@ class Investigations::ProjectController < ApplicationController
 private
 
   def investigation_session_params
-    session[:investigation] || {}
+    session[model_key] || {}
   end
 
   def investigation_params
@@ -68,5 +68,9 @@ private
 
   def validate_coronavirus_related_form
     return render_wizard unless assigns_coronavirus_related_from_form(@investigation, @coronavirus_related_form)
+  end
+
+  def model_key
+    :project
   end
 end


### PR DESCRIPTION
## Description
This fixes errors caused by `Invalid single-table inheritance type: Investigation::Allegation is not a subclass of Investigation::Project` when attempting to create a project as an OPSS user.

The reason this was happening is because the session key used to store user input in the wizard was shared with that on the Trading Standards creation flow. So if you had previously accessed the Trading Standards creation flow on your browser (regardless of whether this was a different user account or if you completed or abandoned the creation flow) it would fail when accessing the create project flow.

Although the session key was cleared on the `new` action this was too late for the `before_filter :set_investigation`.

The create project flow controller does not inherit from `Investigations::CreationFlowController` unlike allegation and enquiry, which is why the problem was not present on those types of cases.

The fix is to use a unique session key for projects as we do on other types.

There is no test needed for this as it is an edge case and no real users would ever have access to both Trading Standards and OPSS creation flows.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
