### PR TITLE
Fix HTML in project description on case created activity

### DIFF
--- a/psd-web/app/controllers/investigations/project_controller.rb
+++ b/psd-web/app/controllers/investigations/project_controller.rb
@@ -59,7 +59,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation::Project.new(investigation_params.merge(owner: current_user)).decorate
+    @investigation = Investigation::Project.new(investigation_params.merge(owner: current_user))
   end
 
   def coronavirus_form_params

--- a/psd-web/app/views/investigations/project/project_details.html.slim
+++ b/psd-web/app/views/investigations/project/project_details.html.slim
@@ -1,7 +1,7 @@
-= page_title "New project", errors: @investigation.object.errors.any?
+= page_title "New project", errors: @investigation.errors.any?
 - content_for :after_header do
   = link_to "Back to cases", investigations_path(previous_search_params), class: "govuk-back-link"
-= form_with(model: @investigation.object, scope: :investigation, url: wizard_path, method: :put) do |form|
+= form_with(model: @investigation, scope: :investigation, url: wizard_path, method: :put) do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary",

--- a/psd-web/spec/features/create_project_spec.rb
+++ b/psd-web/spec/features/create_project_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Creating project", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  context "when login as an OPSS user" do
+  context "when logged in as an OPSS user" do
     let(:title) { Faker::Lorem.sentence }
     let(:summary) { Faker::Lorem.paragraph }
 
@@ -46,6 +46,17 @@ RSpec.feature "Creating project", :with_stubbed_elasticsearch, :with_stubbed_ant
       expect(page).to have_css("p", text: summary)
       expect(page.find("dt", text: "Coronavirus related"))
         .to have_sibling("dd", text: "Coronavirus related case")
+
+      click_on "Activity"
+      expect_details_on_activity_page(title, summary)
+    end
+
+    def expect_details_on_activity_page(title, summary)
+      within ".govuk-list" do
+        expect(page).to have_css("h3",           text: "Project logged: #{title}")
+        expect(page).to have_css("p.govuk-body", text: "Case is related to the coronavirus outbreak.")
+        expect(page).to have_css("p.govuk-body", text: summary, exact_text: true)
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/St4Ek73j/642-html-tag-p-showing-up-in-activity-logs-for-opss-projects

## Description
Fixes HTML `<p>` tags in the description of the audit activity for project created.

This was caused by what I believe to be unnecessary use of `decorate` on the investigation before it's created. None of the other creation flows use this, and the corresponding feature spec did not check the activity page, so it was not spotted.

I've improved the feature spec to check the activity page.

I have checked on production and the last project was created in April, before metadata was introduced. Therefore there are no affected cases on production, so no data migration is needed to fix anything.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?
