### PR TITLE
add view to team listing for read only teams

### DIFF
--- a/psd-web/app/models/collaboration/access.rb
+++ b/psd-web/app/models/collaboration/access.rb
@@ -5,7 +5,6 @@ class Collaboration < ApplicationRecord
 
     def self.sorted_by_team_name
       joins("INNER JOIN teams ON teams.id = collaborations.collaborator_id AND collaborations.collaborator_type = 'Team'").includes(investigation: :creator_team)
-        .where(collaborator_type: "Team")
         .order(Arel.sql("CASE collaborations.type WHEN 'Collaboration::Access::OwnerTeam' THEN 1 ELSE 2 END, teams.name"))
     end
   end

--- a/psd-web/app/models/collaboration/access.rb
+++ b/psd-web/app/models/collaboration/access.rb
@@ -4,9 +4,9 @@ class Collaboration < ApplicationRecord
     require_dependency "collaboration/access/edit"
 
     def self.sorted_by_team_name
-      includes(:collaborator, investigation: :creator_team)
+      joins("INNER JOIN teams ON teams.id = collaborations.collaborator_id AND collaborations.collaborator_type = 'Team'").includes(investigation: :creator_team)
         .where(collaborator_type: "Team")
-        .order(Arel.sql("CASE collaborations.type WHEN 'Collaboration::Access::OwnerTeam' THEN 1 ELSE 2 END"))
+        .order(Arel.sql("CASE collaborations.type WHEN 'Collaboration::Access::OwnerTeam' THEN 1 ELSE 2 END, teams.name"))
     end
   end
 end

--- a/psd-web/app/views/collaboration/access/read_onlies/_read_only.erb
+++ b/psd-web/app/views/collaboration/access/read_onlies/_read_only.erb
@@ -1,0 +1,11 @@
+<tr class="govuk-table__row">
+  <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">
+    <%= read_only.collaborator.name %>
+  </th>
+  <td class="govuk-table__cell">Read only case</td>
+  <td class="govuk-table__cell app-table__cell--align-right">
+    <% if policy(read_only.investigation).manage_collaborators? %>
+      <%= link_with_hidden_text_to "Change", "#{read_only.collaborator.name}’s permission level",  edit_investigation_collaborator_path(read_only.investigation, read_only) %>
+    <% end %>
+  </td>
+</tr>

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     transient do
       creator { create(:user) }
       read_only_teams { [] }
+      edit_access_teams { [] }
     end
 
     factory :allegation, class: "Investigation::Allegation" do
@@ -107,6 +108,15 @@ FactoryBot.define do
     after(:create) do |investigation, evaluator|
       Array.wrap(evaluator.read_only_teams).each do |read_only_team|
         investigation.read_only_collaborations.create!(collaborator: read_only_team)
+      end
+
+      Array.wrap(evaluator.edit_access_teams).each do |edit_access_team|
+        AddTeamToAnInvestigation.call!(
+          investigation: investigation,
+          current_user: investigation.creator_user,
+          include_message: false,
+          collaborator_id: edit_access_team.id
+        )
       end
     end
   end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
 
     transient do
       creator { create(:user) }
+      read_only_teams { [] }
     end
 
     factory :allegation, class: "Investigation::Allegation" do
@@ -101,6 +102,12 @@ FactoryBot.define do
     # constraints on pretty_id need to be satisfied
     before(:create) do |investigation, options|
       CreateCase.call(investigation: investigation, user: options.creator)
+    end
+
+    after(:create) do |investigation, evaluator|
+      Array.wrap(evaluator.read_only_teams).each do |read_only_team|
+        investigation.read_only_collaborations.create!(collaborator: read_only_team)
+      end
     end
   end
 end

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
   include_context "with read only team and user"
   let(:team)           { create(:team, name: "Southampton Trading Standards", team_recipient_email: "enquiries@southampton.gov.uk") }
-  let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"),name: "Bob Jones") }
+  let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"), name: "Bob Jones") }
   let(:investigation)  { create(:allegation, read_only_teams: read_only_team, creator: user) }
 
   before do
@@ -104,7 +104,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_teams_tables_to_contain([
       { team_name: "Portsmouth Trading Standards",  permission_level: "Case owner", creator: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" },
-      { team_name: "Brummy Trading Standards",    permission_level: "Read only case" }
+      { team_name: "Brummy Trading Standards", permission_level: "Read only case" }
     ])
 
     click_on "Change Southampton Trading Standards’s permission level"

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
-  let(:read_only_team) { create(:team, name: "Brummies Trading Standards") }
-  let(:read_only_user) { create(:user, :activated, has_viewed_introduction: true, team: read_only_team) }
+  include_context "with read only team and user"
   let(:team)           { create(:team, name: "Southampton Trading Standards", team_recipient_email: "enquiries@southampton.gov.uk") }
   let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"),name: "Bob Jones") }
   let(:investigation)  { create(:allegation, read_only_teams: read_only_team, creator: user) }
 
-  before { team }
+  before do
+    read_only_team.update!(name: "Brummies Trading Standards")
+    team
+  end
 
   scenario "Adding a team to a case (with validation errors)" do
     sign_in read_only_user
@@ -105,7 +107,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
       { team_name: "Brummies Trading Standards",    permission_level: "Read only case" }
     ])
 
-    click_on "Change"
+    click_on "Change Southampton Trading Standards’s permission level"
 
     expect_to_be_on_edit_case_permissions_page(case_id: investigation.pretty_id)
 

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -1,31 +1,25 @@
 require "rails_helper"
 
 RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
-  let(:user) do
-    create(
-      :user,
-      :activated,
-      team: create(:team, name: "Portsmouth Trading Standards"),
-      name: "Bob Jones"
-    )
-  end
-
-  let(:investigation) do
-    create(
-      :allegation,
-      creator: user
-    )
-  end
-
-  let(:team) do
-    create(:team, name: "Southampton Trading Standards", team_recipient_email: "enquiries@southampton.gov.uk")
-  end
+  let(:read_only_team) { create(:team) }
+  let(:read_only_user) { create(:user, team: read_only_team) }
+  let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"),name: "Bob Jones") }
+  let(:investigation)  { create(:allegation, read_only_teams: read_only_team, creator: user) }
+  let(:team)           { create(:team, name: "Southampton Trading Standards", team_recipient_email: "enquiries@southampton.gov.uk") }
 
   before do
     team
   end
 
   scenario "Adding a team to a case (with validation errors)" do
+    sign_in read_only_user
+
+    visit "/cases/#{investigation.pretty_id}"
+
+    expect(page).not_to have_link("Change teams added to the case")
+
+    sign_out
+
     sign_in user
 
     visit "/cases/#{investigation.pretty_id}"
@@ -69,8 +63,9 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_to_be_on_teams_page(case_id: investigation.pretty_id)
 
     expect_teams_tables_to_contain([
-      { team_name: "Portsmouth Trading Standards", permission_level: "Case owner", creator: true },
-      { team_name: "Southampton Trading Standards", permission_level: "Edit full case" }
+      { team_name: "Portsmouth Trading Standards",  permission_level: "Case owner", creator: true },
+      { team_name: "Southampton Trading Standards", permission_level: "Edit full case" },
+      { team_name: read_only_team.name,             permission_level: "Read only case" }
     ])
 
     notification_email = delivered_emails.last
@@ -84,7 +79,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
 
     expect_to_be_on_case_page(case_id: investigation.pretty_id)
 
-    expect(page).to have_summary_item(key: "Teams added to case", value: "Portsmouth Trading Standards Southampton Trading Standards")
+    expect(page).to have_summary_item(key: "Teams added to case", value: "Portsmouth Trading Standards Southampton Trading Standards #{read_only_team.name}")
 
     click_link "Activity"
 

--- a/psd-web/spec/features/case_permissions_management_spec.rb
+++ b/psd-web/spec/features/case_permissions_management_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
   let(:investigation)  { create(:allegation, read_only_teams: read_only_team, creator: user) }
 
   before do
-    read_only_team.update!(name: "Brummies Trading Standards")
+    read_only_team.update!(name: "Brummy Trading Standards")
     team
   end
 
@@ -80,7 +80,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
 
     expect_to_be_on_case_page(case_id: investigation.pretty_id)
 
-    expect(page).to have_summary_item(key: "Teams added to case", value: "Brummies Trading Standards Portsmouth Trading Standards Southampton Trading Standards")
+    expect(page).to have_summary_item(key: "Teams added to case", value: "Brummy Trading Standards Portsmouth Trading Standards Southampton Trading Standards")
 
     click_link "Activity"
 
@@ -104,7 +104,7 @@ RSpec.feature "Case permissions management", :with_stubbed_elasticsearch, :with_
     expect_teams_tables_to_contain([
       { team_name: "Portsmouth Trading Standards",  permission_level: "Case owner", creator: true },
       { team_name: "Southampton Trading Standards", permission_level: "Edit full case" },
-      { team_name: "Brummies Trading Standards",    permission_level: "Read only case" }
+      { team_name: "Brummy Trading Standards",    permission_level: "Read only case" }
     ])
 
     click_on "Change Southampton Trading Standards’s permission level"

--- a/psd-web/spec/features/change_case_visibility_restriction_spec.rb
+++ b/psd-web/spec/features/change_case_visibility_restriction_spec.rb
@@ -1,28 +1,14 @@
 require "rails_helper"
 
 RSpec.feature "Change case restriction status", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify do
-  let(:user) do
-    create(
-      :user,
-      :activated,
-      team: create(:team, name: "Portsmouth Trading Standards"),
-      name: "Bob Jones"
-    )
-  end
+  let(:user) { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"), name: "Bob Jones") }
 
   let(:case_id) { investigation.pretty_id }
 
-  before do
-    sign_in(user)
-  end
+  before { sign_in(user) }
 
   context "when the user is the owner of the case" do
-    let(:investigation) do
-      create(
-        :allegation,
-        creator: user
-      )
-    end
+    let(:investigation) { create(:allegation, creator: user) }
 
     scenario "user can change the restriction status of the case" do
       visit "/cases/#{case_id}"
@@ -44,13 +30,22 @@ RSpec.feature "Change case restriction status", :with_stubbed_elasticsearch, :wi
     end
   end
 
-  context "when the user is not the case owner" do
-    let(:investigation) do
-      create(
-        :allegation,
-        creator: create(:user)
-      )
+  context "when the user has read only access" do
+    include_context "with read only team and user"
+    let(:user) { read_only_user }
+    let(:investigation) { create(:allegation, :with_complainant, :restricted, creator: create(:user), read_only_teams: read_only_team) }
+
+    it "the can view restricted details" do
+      visit "/cases/#{case_id}"
+
+      expect_to_be_on_case_page(case_id: case_id)
+      expect(page).to have_summary_item(key: "Contact details", value: /#{Regexp.escape(investigation.complainant.name)}/)
+      expect(page).to have_summary_item(key: "Case restriction", value: "Restricted")
     end
+  end
+
+  context "when the user is not the case owner" do
+    let(:investigation) { create(:allegation, creator: create(:user)) }
 
     scenario "user can’t change the restriction status of the case" do
       visit "/cases/#{case_id}"

--- a/psd-web/spec/features/collaborations_spec.rb
+++ b/psd-web/spec/features/collaborations_spec.rb
@@ -1,17 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "Collaborations", :with_stubbed_elasticsearch, :with_stubbed_mailer do
-  let(:owner_team) { create :team }
-  let(:user) { create :user, :activated, has_viewed_introduction: true, team: owner_team }
-  let(:editor_team) { create :team, name: "editor" }
-  let(:read_only_team) { create :team, name: "read only"}
-  let(:investigation) { create(:allegation, creator: user) }
+  let(:owner_team)     { create :team }
+  let(:user)           { create :user, :activated, has_viewed_introduction: true, team: owner_team }
+  let(:editor_team)    { create :team, name: "editor" }
+  let(:read_only_team) { create :team, name: "read only" }
+  let(:investigation)  { create(:allegation, creator: user, read_only_teams: read_only_team, edit_access_teams: editor_team) }
 
-  before do
-    sign_in user
-    AddTeamToAnInvestigation.call!(investigation: investigation, current_user: user, include_message: false, collaborator_id: editor_team.id)
-    investigation.read_only_collaborations.create!(collaborator: read_only_team)
-  end
+  before { sign_in user }
 
   it "lists all the teams" do
     visit "/cases/#{investigation.pretty_id}/teams"

--- a/psd-web/spec/features/collaborations_spec.rb
+++ b/psd-web/spec/features/collaborations_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Collaborations", :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  let(:owner_team) { create :team }
+  let(:user) { create :user, :activated, has_viewed_introduction: true, team: owner_team }
+  let(:editor_team) { create :team, name: "editor" }
+  let(:read_only_team) { create :team, name: "read only"}
+  let(:investigation) { create(:allegation, creator: user) }
+
+  before do
+    sign_in user
+    AddTeamToAnInvestigation.call!(investigation: investigation, current_user: user, include_message: false, collaborator_id: editor_team.id)
+    investigation.read_only_collaborations.create!(collaborator: read_only_team)
+  end
+
+  it "lists all the teams" do
+    visit "/cases/#{investigation.pretty_id}/teams"
+
+    expect(page).to have_css("table tbody tr:nth-child(1) th:nth-child(1)", text: "#{owner_team.name} Case creator")
+    expect(page).to have_css("table tbody tr:nth-child(1) td:nth-child(2)", text: "Case owner")
+
+    expect(page).to have_css("table tbody tr:nth-child(2) th:nth-child(1)", text: editor_team.name)
+    expect(page).to have_css("table tbody tr:nth-child(2) td:nth-child(2)", text: "Edit full case")
+
+    expect(page).to have_css("table tbody tr:nth-child(3) th:nth-child(1)", text: read_only_team.name)
+    expect(page).to have_css("table tbody tr:nth-child(3) td:nth-child(2)", text: "Read only case")
+  end
+end

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -1,6 +1,4 @@
 require "rails_helper"
-
-# rubocop:disable RSpec/MultipleExpectations
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   include_context "with read only team and user"
   let(:user)           { create(:user, :activated, has_viewed_introduction: true) }
@@ -52,4 +50,3 @@ RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :wit
     end
   end
 end
-# rubocop:enable RSpec/MultipleExpectations

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -2,46 +2,32 @@ require "rails_helper"
 
 # rubocop:disable RSpec/MultipleExpectations
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
-  let(:investigation) { create(:allegation, :with_document, creator: user) }
+  let(:read_only_team) { create(:team) }
+  let(:read_only_user) { create(:user, :activated, has_viewed_introduction: true, team: read_only_team) }
+  let(:user)           { create(:user, :activated, has_viewed_introduction: true) }
+  let(:investigation)  { create(:allegation, :with_document, creator: user, read_only_teams: read_only_team) }
 
   include_context "with all types of supporting information"
 
   context "when the team from the user viewing the information owns the investigation" do
-    before { sign_in user }
-
     scenario "listing supporting information" do
+      sign_in read_only_user
+
       visit "/cases/#{investigation.pretty_id}"
 
       click_on "Supporting information (6)"
 
-      within page.first("table") do
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: email.supporting_information_title)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondenceEmail")
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: email.date_of_activity)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: email.date_added)
+      expect_to_view_supporting_information_table
 
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: phone_call.supporting_information_title)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondencePhone call")
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: phone_call.date_of_activity)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: phone_call.date_added)
+      sign_out
 
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: meeting.supporting_information_title)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondenceMeeting")
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: meeting.date_of_activity)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: meeting.date_added)
+      sign_in user
 
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: corrective_action.supporting_information_title)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.supporting_information_type)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.date_of_activity)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.date_added)
+      visit "/cases/#{investigation.pretty_id}"
 
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: test_result.supporting_information_title)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.supporting_information_type)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_of_activity)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_added)
-        expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_added)
-      end
+      click_on "Supporting information (6)"
+
+      expect_to_view_supporting_information_table
 
       select "Title", from: "sort_by"
       click_on "Sort"

--- a/psd-web/spec/features/supporting_information_tab_spec.rb
+++ b/psd-web/spec/features/supporting_information_tab_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 # rubocop:disable RSpec/MultipleExpectations
 RSpec.feature "Manage supporting information", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
-  let(:read_only_team) { create(:team) }
-  let(:read_only_user) { create(:user, :activated, has_viewed_introduction: true, team: read_only_team) }
+  include_context "with read only team and user"
   let(:user)           { create(:user, :activated, has_viewed_introduction: true) }
   let(:investigation)  { create(:allegation, :with_document, creator: user, read_only_teams: read_only_team) }
 

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -49,6 +49,36 @@ module PageExpectations
     expect(page).to have_link("Back", href: "/cases/#{investigation.pretty_id}/supporting-information")
   end
 
+  def expect_to_view_supporting_information_table
+    within page.first("table") do
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: email.supporting_information_title)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondenceEmail")
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: email.date_of_activity)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: email.date_added)
+
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: phone_call.supporting_information_title)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondencePhone call")
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: phone_call.date_of_activity)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: phone_call.date_added)
+
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: meeting.supporting_information_title)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: "CorrespondenceMeeting")
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: meeting.date_of_activity)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: meeting.date_added)
+
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: corrective_action.supporting_information_title)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.supporting_information_type)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.date_of_activity)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: corrective_action.date_added)
+
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell a", text: test_result.supporting_information_title)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.supporting_information_type)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_of_activity)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_added)
+      expect(page).to have_css("tr.govuk-table__row td.govuk-table__cell", text: test_result.date_added)
+    end
+  end
+
   def expect_to_be_on_enter_image_details_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
     expect(page).to have_selector("h3", text: "Image details")

--- a/psd-web/spec/support/shared_contexts/read_only_team_and_user.rb
+++ b/psd-web/spec/support/shared_contexts/read_only_team_and_user.rb
@@ -1,0 +1,4 @@
+RSpec.shared_context "with read only team and user" do
+  let(:read_only_team) { create(:team) }
+  let(:read_only_user) { create(:user, :activated, has_viewed_introduction: true, team: read_only_team) }
+end


### PR DESCRIPTION
## CHANGES:
This PR adds a few more test to verify that a team with read only access can view all the details of a case but not edit them.

## Test scenarios:
- [x] 1. Validate only case owner/team can update the collaborator team permissions(existing anyway)
- [x] 4. Validate when view permissions is given to a team, then team can view full case, view activities (correspondences, test results, corrective actions), view contact source information in case overview and activity page
- [x] 5. Validate when a team added with view only permission to a restricted case then team should still be able to see the case details.
- [x] 6. Validate when view permission is given, teams added to the case can view source contact information in search results
- [x] 7. Validate when permissions changed from Edit to view, then it should restrict edit permissions accordingly
- [x] 8. Validate when permissions changed from View to Edit, then it should allow edit permissions accordingly


## Test scenari for next PR 
- [ ] 2. Validate when view permission is given to a team, then activity is logged with details and time stamp.
- [ ] 3. Validate when a team is added with view permission then email notification is sent to team (content as given by Ed).

for testing:
I've added `OPSS Operational support unit` to this case https://psd-pr-753.london.cloudapps.digital/cases/2006-0017 as read only access