### PR TITLE
Update data migration to use new collaborator data model

### DIFF
--- a/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
+++ b/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
@@ -2,16 +2,17 @@ desc "Add case creators as collaborators (if not assignee)"
 task add_case_creators_as_collaborators: :environment do
   count = 0
   Investigation.find_each do |investigation|
-    creator = investigation.source.user
-    creator_team = creator.team
-    assignee_team = investigation.assignee_team
-    collaborator_teams = investigation.teams
 
-    if creator_team != assignee_team && !collaborator_teams.include?(creator_team)
+    creator_team = investigation.creator_team
+    creator_user = investigation.creator_user
+    owner_team = investigation.owner_team
+    teams_with_access = investigation.teams_with_access
+
+    if creator_team != owner_team && !teams_with_access.include?(creator_team)
       count += 1
 
       puts "Adding #{creator_team.name} as a collaborator to case #{investigation.pretty_id}"
-      investigation.collaborators.create!(team: creator_team, added_by_user: creator, include_message: false)
+      investigation.edit_collaborations.create!(collaborator: creator_team, added_by_user: creator_user, include_message: false)
     end
   end
 

--- a/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
+++ b/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
@@ -2,7 +2,6 @@ desc "Add case creators as collaborators (if not assignee)"
 task add_case_creators_as_collaborators: :environment do
   count = 0
   Investigation.find_each do |investigation|
-
     creator_team = investigation.creator_team
     creator_user = investigation.creator_user
     owner_team = investigation.owner_team


### PR DESCRIPTION
This updates the data migration task to use the new model for collaborator records.

The data migration adds the team who created the case to the case with edit access, if they’re not currently a collaborator on the case (eg because the owner has been reassigned to another team).