### PR TITLE
Fix rake task: Skip cases with no creator team

### DIFF
--- a/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
+++ b/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
@@ -3,6 +3,8 @@ task add_case_creators_as_collaborators: :environment do
   count = 0
   Investigation.find_each do |investigation|
     creator_team = investigation.creator_team
+    next unless creator_team
+
     creator_user = investigation.creator_user
     owner_team = investigation.owner_team
     teams_with_access = investigation.teams_with_access


### PR DESCRIPTION
In theory all cases should have a creator, but this doesn't always seem to be true, at least on staging.