### PR TITLE
Add buttons to case bar

### DIFF
--- a/psd-web/app/assets/stylesheets/_button.scss
+++ b/psd-web/app/assets/stylesheets/_button.scss
@@ -25,5 +25,5 @@
 .app-button--case-bar-secondary:link,
 .app-button--case-bar-secondary:visited {
   color: $govuk-text-colour;
-  background-color: #dee0e2;
+  background-color: $old-mid-grey;
 }

--- a/psd-web/app/assets/stylesheets/_button.scss
+++ b/psd-web/app/assets/stylesheets/_button.scss
@@ -21,7 +21,7 @@
 }
 
 // An alternative secondary button, for use on the case bar (which has the
-// same backgorund colour as the regular secondary button)
+// same background colour as the regular secondary button)
 .app-button--case-bar-secondary:link,
 .app-button--case-bar-secondary:visited {
   color: $govuk-text-colour;

--- a/psd-web/app/assets/stylesheets/_button.scss
+++ b/psd-web/app/assets/stylesheets/_button.scss
@@ -19,3 +19,11 @@
   min-height: auto;
   justify-content: center;
 }
+
+// An alternative secondary button, for use on the case bar (which has the
+// same backgorund colour as the regular secondary button)
+.app-button--case-bar-secondary:link,
+.app-button--case-bar-secondary:visited {
+  color: $govuk-text-colour;
+  background-color: #dee0e2;
+}

--- a/psd-web/app/assets/stylesheets/_colours.scss
+++ b/psd-web/app/assets/stylesheets/_colours.scss
@@ -2,3 +2,6 @@
 
 // Temporary colour used for badges and banners for the coronavirus (COVID-19) outbreak
 $coronavirus-colour: govuk-colour("pink");
+
+// This is used for buttons that appear on a light grey background.
+$old-mid-grey: #dee0e2;

--- a/psd-web/app/assets/stylesheets/_identity-bar.scss
+++ b/psd-web/app/assets/stylesheets/_identity-bar.scss
@@ -1,7 +1,3 @@
-.app-identity-bar .app-identity-bar__details {
-  display: block;
-}
-
 .app-identity-bar .app-identity-bar__title {
   display: block;
   white-space: nowrap;

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -6,11 +6,14 @@ $govuk-assets-path: '~govuk-frontend/govuk/assets/';
 $hmcts-page-width: $govuk-page-width;
 $hmcts-gutter: $govuk-gutter;
 $hmcts-gutter-half: $govuk-gutter-half;
+$hmcts-images-path: '~@hmcts/frontend/assets/images/';
 @import "~@hmcts/frontend/objects/width-container";
 @import "~@hmcts/frontend/components/hmcts-badge/badge";
 @import "~@hmcts/frontend/components/hmcts-banner/banner";
 @import "~@hmcts/frontend/components/hmcts-identity-bar/identity-bar";
 @import "~@hmcts/frontend/components/hmcts-sub-navigation/sub-navigation";
+@import "~@hmcts/frontend/components/hmcts-menu/menu";
+
 
 @import "colours";
 

--- a/psd-web/app/assets/stylesheets/main.scss
+++ b/psd-web/app/assets/stylesheets/main.scss
@@ -11,8 +11,8 @@ $hmcts-images-path: '~@hmcts/frontend/assets/images/';
 @import "~@hmcts/frontend/components/hmcts-badge/badge";
 @import "~@hmcts/frontend/components/hmcts-banner/banner";
 @import "~@hmcts/frontend/components/hmcts-identity-bar/identity-bar";
-@import "~@hmcts/frontend/components/hmcts-sub-navigation/sub-navigation";
 @import "~@hmcts/frontend/components/hmcts-menu/menu";
+@import "~@hmcts/frontend/components/hmcts-sub-navigation/sub-navigation";
 
 
 @import "colours";

--- a/psd-web/app/controllers/investigations/actions_controller.rb
+++ b/psd-web/app/controllers/investigations/actions_controller.rb
@@ -1,0 +1,41 @@
+module Investigations
+  class ActionsController < ApplicationController
+    def index
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
+      @actions_form = InvestigationActionsForm.new(
+        investigation: @investigation,
+        current_user: current_user
+      )
+    end
+
+    def create
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
+      authorize @investigation, :update?
+
+      @actions_form = InvestigationActionsForm.new(
+        investigation: @investigation,
+        current_user: current_user,
+        action: params[:investigation_action]
+      )
+
+      return render(:index) if @actions_form.invalid?
+
+      redirect_to path_for_action(@actions_form.action)
+    end
+
+  private
+
+    def path_for_action(action)
+      case action
+      when "change_case_status"
+        status_investigation_path(@investigation)
+      when "reassign"
+        new_investigation_ownership_path(@investigation)
+      when "change_case_visibility"
+        visibility_investigation_path(@investigation)
+      when "send_email_alert"
+        new_investigation_alert_path(@investigation)
+      end
+    end
+  end
+end

--- a/psd-web/app/controllers/investigations/actions_controller.rb
+++ b/psd-web/app/controllers/investigations/actions_controller.rb
@@ -29,7 +29,7 @@ module Investigations
       case action
       when "change_case_status"
         status_investigation_path(@investigation)
-      when "reassign"
+      when "change_case_owner"
         new_investigation_ownership_path(@investigation)
       when "change_case_visibility"
         visibility_investigation_path(@investigation)

--- a/psd-web/app/forms/investigation_actions_form.rb
+++ b/psd-web/app/forms/investigation_actions_form.rb
@@ -1,0 +1,35 @@
+class InvestigationActionsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include Pundit
+
+  attribute :action
+  attribute :investigation
+  attribute :current_user
+
+  validates_presence_of :action
+
+  def actions
+    status_and_owner_actions.merge(email_alert_action)
+  end
+
+private
+
+  def status_and_owner_actions
+    return {} unless policy(investigation).change_owner_or_status?
+
+    {
+      change_case_status: (investigation.is_closed? ? "Reopen case" : "Close case"),
+      reassign: "Reassign this case",
+      change_case_visibility: (investigation.is_private? ? "Restrict this case" : "Unrestrict this case")
+    }
+  end
+
+  def email_alert_action
+    return {} unless policy(investigation).send_email_alert?
+
+    {
+      send_email_alert: "Send email alert"
+    }
+  end
+end

--- a/psd-web/app/forms/investigation_actions_form.rb
+++ b/psd-web/app/forms/investigation_actions_form.rb
@@ -19,9 +19,9 @@ private
     return {} unless policy(investigation).change_owner_or_status?
 
     {
-      change_case_status: (investigation.is_closed? ? "Reopen case" : "Close case"),
-      reassign: "Reassign this case",
-      change_case_visibility: (investigation.is_private? ? "Restrict this case" : "Unrestrict this case")
+      change_case_status: action_label("change_case_status.#{case_status}"),
+      reassign: action_label(:reassign),
+      change_case_visibility: action_label("change_case_visibility.#{visibility_status}")
     }
   end
 
@@ -29,7 +29,27 @@ private
     return {} unless policy(investigation).send_email_alert?
 
     {
-      send_email_alert: "Send email alert"
+      send_email_alert: action_label(:send_email_alert),
     }
+  end
+
+  def visibility_status
+    if investigation.is_private?
+      "restricted"
+    else
+      "not_restricted"
+    end
+  end
+
+  def case_status
+    if investigation.is_closed?
+      "closed"
+    else
+      "open"
+    end
+  end
+
+  def action_label(action)
+    I18n.t(action, scope: "forms.investigation_actions.actions")
   end
 end

--- a/psd-web/app/forms/investigation_actions_form.rb
+++ b/psd-web/app/forms/investigation_actions_form.rb
@@ -20,7 +20,7 @@ private
 
     {
       change_case_status: action_label("change_case_status.#{case_status}"),
-      reassign: action_label(:reassign),
+      change_case_owner: action_label(:change_case_owner),
       change_case_visibility: action_label("change_case_visibility.#{visibility_status}")
     }
   end

--- a/psd-web/app/helpers/investigations_helper.rb
+++ b/psd-web/app/helpers/investigations_helper.rb
@@ -267,13 +267,6 @@ module InvestigationsHelper
       }
     end
 
-    if policy(investigation).send_email_alert?(user: user)
-      activity_actions[:items] << {
-        href: new_investigation_alert_path(investigation),
-        text: "Send email alert"
-      }
-    end
-
     if policy(investigation).change_owner_or_status?(user: user)
       status_actions[:items] << {
         href: status_investigation_path(investigation),

--- a/psd-web/app/helpers/investigations_helper.rb
+++ b/psd-web/app/helpers/investigations_helper.rb
@@ -265,11 +265,6 @@ module InvestigationsHelper
         text: "Change",
         visuallyHiddenText: "coronavirus status"
       }
-    else
-      activity_actions[:items] << {
-        href: new_investigation_activity_comment_path(investigation),
-        text: "Add comment"
-      }
     end
 
     if policy(investigation).send_email_alert?(user: user)

--- a/psd-web/app/views/investigations/_pages_top.html.erb
+++ b/psd-web/app/views/investigations/_pages_top.html.erb
@@ -9,7 +9,19 @@
         <div class="hmcts-identity-bar__menu">
           <div class="hmcts-menu">
             <div class="hmcts-menu__wrapper">
-              <%= govukButton(text: "Add new", href: new_investigation_supporting_information_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+
+              <% if policy(investigation).update? %>
+                <%= govukButton(text: "Add new", href: new_investigation_supporting_information_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+              <% else %>
+                <%= govukButton(text: "Add comment", href: new_investigation_activity_comment_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+              <% end %>
+
+
+              <% if policy(investigation).change_owner_or_status? %>
+                <%= govukButton(text: "Actions", href: investigation_actions_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+              <% elsif policy(investigation).send_email_alert? %>
+                <%= govukButton(text: "Send email alert", href: new_investigation_alert_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+              <% end %>
             </div>
           </div>
         </div>

--- a/psd-web/app/views/investigations/_pages_top.html.erb
+++ b/psd-web/app/views/investigations/_pages_top.html.erb
@@ -4,6 +4,17 @@
       <div class="hmcts-identity-bar__details app-identity-bar__details">
         <span class="hmcts-identity-bar__title app-identity-bar__title"><span class="app-identity-bar__case-id"><%= investigation.pretty_id %></span> <%= investigation.decorate.title %></span>
       </div>
+
+      <div class="hmcts-identity-bar__actions">
+        <div class="hmcts-identity-bar__menu">
+          <div class="hmcts-menu">
+            <div class="hmcts-menu__wrapper">
+              <%= govukButton(text: "Add new", href: new_investigation_supporting_information_path(investigation), classes: "hmcts-menu__item app-button--case-bar-secondary") %>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
 <% end %>

--- a/psd-web/app/views/investigations/actions/index.html.erb
+++ b/psd-web/app/views/investigations/actions/index.html.erb
@@ -1,0 +1,30 @@
+<% page_heading = "Select an action" %>
+<% page_title(page_heading, errors: @actions_form.errors.any?) %>
+<% content_for :back_link do %>
+  <%= govukBackLink(
+    text: "Back to #{@investigation.pretty_description.downcase}",
+    href: investigation_path(@investigation)
+  ) %>
+<% end %>
+
+<%= render "investigations/pages_top", investigation: @investigation %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= error_summary @actions_form.errors %>
+    <%= form_with local: true, url: investigation_actions_path(@investigation) do |form| %>
+      <%= render "form_components/govuk_radios",
+        form: form,
+        key: :investigation_action,
+        items: radio_items_from_hash(@actions_form.actions),
+        fieldset: {
+        legend: {
+          text: page_heading,
+          classes: "govuk-fieldset__legend--l",
+          isPageHeading: true
+        }
+      } %>
+      <%= govukButton(text: "Continue") %>
+    <% end %>
+  </div>
+</div>

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -134,6 +134,18 @@ en:
       email_address:
         invalid: "Enter an email address in the correct format, like name@example.com"
 
+  forms:
+    investigation_actions:
+      actions:
+        reassign: "Reassign this case"
+        change_case_status:
+          open: "Close case"
+          closed: "Reopen case"
+        change_case_visibility:
+          restricted: "Unrestrict this case"
+          not_restricted: "Restrict this case"
+        send_email_alert: "Send email alert"
+
   activemodel:
     errors:
       models:
@@ -146,6 +158,10 @@ en:
           attributes:
             type:
               blank: "Select the type of correspondence you’re adding"
+        investigation_actions_form:
+          attributes:
+            action:
+              blank: "Select an action"
         edit_investigation_collaborator_form:
           attributes:
             include_message:

--- a/psd-web/config/locales/en.yml
+++ b/psd-web/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
   forms:
     investigation_actions:
       actions:
-        reassign: "Reassign this case"
+        change_case_owner: "Change case owner"
         change_case_status:
           open: "Close case"
           closed: "Reopen case"

--- a/psd-web/config/routes.rb
+++ b/psd-web/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
     resources :images, controller: "investigations/images", only: %i[index], path: "images"
     resources :supporting_information, controller: "investigations/supporting_information", path: "supporting-information", as: :supporting_information, only: %i[index new create]
 
+    resources :actions, controller: "investigations/actions", path: "actions", as: :actions, only: %i[index create]
+
     resource :activity, controller: "investigations/activities", only: %i[show create] do
       resource :comment, only: %i[create new]
     end

--- a/psd-web/spec/factories/investigations.rb
+++ b/psd-web/spec/factories/investigations.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
       is_private { true }
     end
 
+    trait :closed do
+      is_closed { true }
+    end
+
     # We need to do this before rather than after create because database
     # constraints on pretty_id need to be satisfied
     before(:create) do |investigation, options|

--- a/psd-web/spec/features/add_corrective_action_spec.rb
+++ b/psd-web/spec/features/add_corrective_action_spec.rb
@@ -18,9 +18,10 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
   before { sign_in(user) }
 
   scenario "Adding a corrective action (with validation errors)" do
-    visit "/cases/#{investigation.pretty_id}/supporting-information"
+    visit "/cases/#{investigation.pretty_id}"
 
-    click_link "Add supporting information"
+    click_link "Add new"
+    expect_to_be_on_add_supporting_information_page
 
     choose "Corrective action"
 

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -19,7 +19,14 @@ RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :wi
   scenario "Sending an alert about a case to 2 active users" do
     visit investigation_path(investigation)
 
-    click_link "Send email alert"
+    click_link "Actions"
+    expect_to_be_on_case_actions_page(case_id: investigation.pretty_id)
+
+    within_fieldset "Select an action" do
+      choose "Send email alert"
+    end
+    click_button "Continue"
+
     click_link "Compose new alert"
 
     expect_to_be_on_compose_alert_for_case_page(case_id: investigation.pretty_id)

--- a/psd-web/spec/features/send_alert_spec.rb
+++ b/psd-web/spec/features/send_alert_spec.rb
@@ -80,7 +80,13 @@ RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :wi
   scenario "Being unable to send an alert about a restricted case" do
     visit investigation_path(restricted_investigation)
 
-    click_link "Send email alert"
+    click_link "Actions"
+    expect_to_be_on_case_actions_page(case_id: restricted_investigation.pretty_id)
+
+    within_fieldset "Select an action" do
+      choose "Send email alert"
+    end
+    click_button "Continue"
 
     expect_to_be_on_about_alerts_page(case_id: restricted_investigation.pretty_id)
     expect(page).to have_text("Email alerts can only be sent for cases that are not restricted. To send an alert about this case you need to unrestrict it.")

--- a/psd-web/spec/forms/investigation_actions_form_spec.rb
+++ b/psd-web/spec/forms/investigation_actions_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
       it "contains three possible actions" do
         expect(form.actions).to eq({
           change_case_status: "Close case",
-          reassign: "Reassign this case",
+          change_case_owner: "Change case owner",
           change_case_visibility: "Restrict this case"
         })
       end
@@ -45,7 +45,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
       it "contains three actions with alternative labels" do
         expect(form.actions).to eq({
           change_case_status: "Reopen case",
-          reassign: "Reassign this case",
+          change_case_owner: "Change case owner",
           change_case_visibility: "Unrestrict this case"
         })
       end
@@ -59,7 +59,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
       it "contains four possible actions" do
         expect(form.actions).to eq({
           change_case_status: "Close case",
-          reassign: "Reassign this case",
+          change_case_owner: "Change case owner",
           change_case_visibility: "Restrict this case",
           send_email_alert: "Send email alert"
         })

--- a/psd-web/spec/forms/investigation_actions_form_spec.rb
+++ b/psd-web/spec/forms/investigation_actions_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
   describe "#actions" do
     context "when the user is the owner of the investigation but not an OPSS user" do
       let(:user) { create(:user, :activated) }
-      let(:investigation) { create(:allegation, owner_team: user.team, owner_user: nil) }
+      let(:investigation) { create(:allegation, creator: user) }
       let(:form) { described_class.new(investigation: investigation, current_user: user) }
 
       it "contains three possible actions" do
@@ -37,8 +37,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
     context "when the case is closed and restricted" do
       let(:user) { create(:user, :activated) }
       let(:investigation) do
-        create(:allegation, :restricted, :closed,
-               owner_team: user.team, owner_user: nil)
+        create(:allegation, :restricted, :closed, creator: user)
       end
       let(:form) { described_class.new(investigation: investigation, current_user: user) }
 
@@ -53,7 +52,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
 
     context "when the user is the owner of the investigation and is an OPSS user" do
       let(:user) { create(:user, :activated, :opss_user) }
-      let(:investigation) { create(:allegation, owner_team: user.team, owner_user: nil) }
+      let(:investigation) { create(:allegation, creator: user) }
       let(:form) { described_class.new(investigation: investigation, current_user: user) }
 
       it "contains four possible actions" do

--- a/psd-web/spec/forms/investigation_actions_form_spec.rb
+++ b/psd-web/spec/forms/investigation_actions_form_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  describe "validations" do
+    context "when an action has been set" do
+      let(:form) { described_class.new(action: "change_case_status") }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when no action has been set" do
+      let(:form) { described_class.new(action: nil) }
+
+      it "is not valid" do
+        expect(form).not_to be_valid
+      end
+    end
+  end
+
+  describe "#actions" do
+    context "when the user is the owner of the investigation but not an OPSS user" do
+      let(:user) { create(:user, :activated) }
+      let(:investigation) { create(:allegation, owner_team: user.team, owner_user: nil) }
+      let(:form) { described_class.new(investigation: investigation, current_user: user) }
+
+      it "contains three possible actions" do
+        expect(form.actions).to eq({
+          change_case_status: "Close case",
+          reassign: "Reassign this case",
+          change_case_visibility: "Restrict this case"
+        })
+      end
+    end
+
+    context "when the case is closed and restricted" do
+      let(:user) { create(:user, :activated) }
+      let(:investigation) do
+        create(:allegation, :restricted, :closed,
+               owner_team: user.team, owner_user: nil)
+      end
+      let(:form) { described_class.new(investigation: investigation, current_user: user) }
+
+      it "contains three actions with alternative labels" do
+        expect(form.actions).to eq({
+          change_case_status: "Reopen case",
+          reassign: "Reassign this case",
+          change_case_visibility: "Unrestrict this case"
+        })
+      end
+    end
+
+    context "when the user is the owner of the investigation and is an OPSS user" do
+      let(:user) { create(:user, :activated, :opss_user) }
+      let(:investigation) { create(:allegation, owner_team: user.team, owner_user: nil) }
+      let(:form) { described_class.new(investigation: investigation, current_user: user) }
+
+      it "contains four possible actions" do
+        expect(form.actions).to eq({
+          change_case_status: "Close case",
+          reassign: "Reassign this case",
+          change_case_visibility: "Restrict this case",
+          send_email_alert: "Send email alert"
+        })
+      end
+    end
+
+    context "when the user is not involved with the investigation but is an OPSS user" do
+      let(:user) { create(:user, :activated, :opss_user) }
+      let(:investigation) { create(:allegation) }
+      let(:form) { described_class.new(investigation: investigation, current_user: user) }
+
+      it "contains only the 'send email alert' action" do
+        expect(form.actions).to eq({ send_email_alert: "Send email alert" })
+      end
+    end
+
+    context "when the user is not involved with the investigation and is not an OPSS user" do
+      let(:user) { create(:user, :activated) }
+      let(:investigation) { create(:allegation) }
+      let(:form) { described_class.new(investigation: investigation, current_user: user) }
+
+      it "contains no actions" do
+        expect(form.actions).to eq({})
+      end
+    end
+  end
+end

--- a/psd-web/spec/support/features/page_expectations.rb
+++ b/psd-web/spec/support/features/page_expectations.rb
@@ -89,6 +89,11 @@ module PageExpectations
     expect(page).to have_selector("h1", text: "What type of information are you adding?")
   end
 
+  def expect_to_be_on_case_actions_page(case_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/actions")
+    expect(page).to have_selector("h1", text: "Select an action")
+  end
+
   def expect_to_be_on_add_correspondence_page
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/correspondence/new")
     expect(page).to have_selector("h1", text: "What type of correspondence are you adding?")

--- a/psd-web/test/controllers/investigations/products_controller_test.rb
+++ b/psd-web/test/controllers/investigations/products_controller_test.rb
@@ -10,6 +10,9 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
       added_by_user: users(:southampton)
     )
     @investigation.creator_user = users(:southampton)
+    @investigation.create_owner_team_collaboration!(
+      collaborator: teams(:southampton_team)
+    )
     @product = products(:iphone)
     @product.source = sources(:product_iphone)
   end

--- a/psd-web/test/system/alert_test.rb
+++ b/psd-web/test/system/alert_test.rb
@@ -62,9 +62,7 @@ class AlertTest < ApplicationSystemTestCase
   end
 
   def go_to_new_alert_for_investigation(investigation)
-    visit investigation_path(investigation)
-
-    click_link "Send email alert"
+    visit new_investigation_alert_path(investigation)
   end
 
   def fill_in_compose_alert(alert)


### PR DESCRIPTION
This adds some contextual buttons to the case bar. 

The content and destination of these buttons varies according to the status of the case, and the role of the user’s team in relation to it.

A future story will enhance buttons with javascript to a dropdown menu, avoiding the need to visit the second page.

## Case bar screenshots

### 1. User’s team is the owner of the case
 
<img width="1088" alt="Screenshot 2020-07-02 at 11 11 33" src="https://user-images.githubusercontent.com/30665/86348111-1e045b00-bc57-11ea-8537-b24ff3829bb2.png">

### 2. User’s team is not involved with the case at all

<img width="1088" alt="Screenshot 2020-07-02 at 11 11 43" src="https://user-images.githubusercontent.com/30665/86348181-35434880-bc57-11ea-993b-194b102370f7.png">

### 3. User’s team is not involved with the case at all, but user is from OPSS and can send email alerts

<img width="1088" alt="Screenshot 2020-07-02 at 11 12 02" src="https://user-images.githubusercontent.com/30665/86348228-45f3be80-bc57-11ea-826f-457cf54cac58.png">

### 4. User’s team has been added to the case (but isn't the owner)

<img width="1088" alt="Screenshot 2020-07-02 at 11 14 33" src="https://user-images.githubusercontent.com/30665/86348346-776c8a00-bc57-11ea-8a5e-25fbb362e076.png">

### 5. User’s team has been added to the case (but isn't the owner), and user is from OPSS so can send email alerts

<img width="1088" alt="Screenshot 2020-07-02 at 11 14 27" src="https://user-images.githubusercontent.com/30665/86348282-5f950600-bc57-11ea-90e1-a0d4a1bb9718.png">

## New actions page

### 1. User is not from OPSS

<img width="1000" alt="Screenshot 2020-07-02 at 11 32 16" src="https://user-images.githubusercontent.com/30665/86348615-cd413200-bc57-11ea-8f72-7195be88269b.png">

### 2. User is from OPSS

<img width="1000" alt="Screenshot 2020-07-02 at 11 32 43" src="https://user-images.githubusercontent.com/30665/86348642-d6320380-bc57-11ea-98c6-f9403a82311d.png">
