### PR TITLE
Draft: Simple metrics

### DIFF
--- a/psd-web/app/controllers/application_controller.rb
+++ b/psd-web/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   before_action :has_accepted_declaration
   before_action :has_viewed_introduction
   before_action :set_cache_headers
+  after_action :log_activity
 
   helper_method :nav_items, :secondary_nav_items, :previous_search_params, :current_user
 
@@ -119,5 +120,20 @@ private
 
   def render_404_page
     render "errors/not_found", status: :not_found
+  end
+
+  def log_activity
+    return unless user_signed_in?
+
+    UserActivity.create(
+      action: params[:action],
+      controller: params[:controller],
+      fullpath: request.fullpath,
+      method: request.method,
+      user_id: current_user.id,
+      team_id: current_user.team.id,
+      organisation_id: current_user.team.organisation.id,
+      payload: {}
+    )
   end
 end

--- a/psd-web/db/schema.rb
+++ b/psd-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_120007) do
+ActiveRecord::Schema.define(version: 2020_07_02_135551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -266,6 +266,19 @@ ActiveRecord::Schema.define(version: 2020_06_22_120007) do
     t.datetime "updated_at", null: false
     t.index ["investigation_id"], name: "index_tests_on_investigation_id"
     t.index ["product_id"], name: "index_tests_on_product_id"
+  end
+
+  create_table "user_activities", force: :cascade do |t|
+    t.string "action"
+    t.string "controller"
+    t.datetime "created_at", null: false
+    t.string "fullpath"
+    t.string "method"
+    t.string "organisation_id"
+    t.jsonb "payload"
+    t.string "team_id"
+    t.datetime "updated_at", null: false
+    t.string "user_id"
   end
 
   create_table "user_roles", force: :cascade do |t|


### PR DESCRIPTION
# Simple Metrics

Lot of metrics we would like to collect could be expressed as SQL query. This PR demonstrate how we could store all data we need for understanding users. Unike external tools, this approach does not have any GDPR considerations.

# Example

Given such `user_activities` table:

```
 created_at | organisation_id
------------+-----------------
 2020-06-29 | 3
 2020-06-29 | 2
 2020-06-29 | 3
 2020-06-30 | 4
 2020-06-30 | 2
 2020-06-30 | 1
 2020-07-01 | 1
 2020-07-01 | 1
 2020-07-01 | 1
```

to answer question **How many organizations are using PSD per day?** we have to do following query:

```
 select created_at::TIMESTAMP::DATE, count(distinct organisation_id) from user_activities group by  created_at::TIMESTAMP::DATE;
```
which will output
```
 created_at | count
------------+-------
 2020-06-29 |     2
 2020-06-30 |     3
 2020-07-01 |     1
```

# Next steps

- [ ] create separate database for `UserActivity` model so our main DB wont be cluttered with data
- [ ] move saving activity to worker, so there won't be any performance impact