### PR TITLE
Delete database when deleting review app

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -32,6 +32,7 @@ jobs:
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
         cf7 delete -f -r psd-pr-$PR_NUMBER
+        cf7 delete-service -f psd-db-pr-$PR_NUMBER
         cf7 logout
 
     - name: Deactivate Github deploy


### PR DESCRIPTION
When deleting the review app, we should also delete its associated database, now that we have a 1 to 1 mapping between review apps and databases.