### PR TITLE
Fix typo in migration

### DIFF
--- a/psd-web/db/migrate/20200616142120_rename_edit_access_to_access_edit.rb
+++ b/psd-web/db/migrate/20200616142120_rename_edit_access_to_access_edit.rb
@@ -1,5 +1,5 @@
 class RenameEditAccessToAccessEdit < ActiveRecord::Migration[5.2]
   def change
-    Collaboration.where(type: "Collaboration::EditAcess").update_all(type: "Collaboration::Access::Edit")
+    Collaboration.where(type: "Collaboration::EditAccess").update_all(type: "Collaboration::Access::Edit")
   end
 end


### PR DESCRIPTION
## Description
Fixes a typo in a migration file which has caused a few issues locally and deploying onto staging. I have cleaned up the data manually on staging and production so it's not going to run again, but I'd recommend running it locally again to prevent errors.