### PR TITLE
Prevent removal of case owner

### DIFF
--- a/psd-web/app/controllers/collaborators_controller.rb
+++ b/psd-web/app/controllers/collaborators_controller.rb
@@ -39,7 +39,7 @@ class CollaboratorsController < ApplicationController
   def edit
     authorize @investigation, :manage_collaborators?
 
-    @collaboration = @investigation.collaboration_accesses.find(params[:id])
+    @collaboration = @investigation.collaborations.edit_and_read_only.find(params[:id])
     @collaborator = @collaboration.collaborator
     @edit_form = EditInvestigationCollaboratorForm.new(permission_level: EditInvestigationCollaboratorForm::PERMISSION_LEVEL_EDIT)
   end
@@ -47,7 +47,7 @@ class CollaboratorsController < ApplicationController
   def update
     authorize @investigation, :manage_collaborators?
 
-    @collaboration = @investigation.collaboration_accesses.find(params[:id])
+    @collaboration = @investigation.collaborations.edit_and_read_only.find(params[:id])
     @collaborator = @collaboration.collaborator
     @edit_form = EditInvestigationCollaboratorForm.new(edit_params
       .merge(investigation: @investigation, team: @collaborator, user: current_user))
@@ -72,7 +72,7 @@ private
   end
 
   def team_ids_with_access
-    @investigation.edit_collaborations.where(collaborator_type: "Team").pluck(:collaborator_id)
+    @investigation.collaboration_accesses.where(collaborator_type: "Team").pluck(:collaborator_id)
   end
 
   def edit_params

--- a/psd-web/app/forms/edit_investigation_collaborator_form.rb
+++ b/psd-web/app/forms/edit_investigation_collaborator_form.rb
@@ -19,7 +19,7 @@ class EditInvestigationCollaboratorForm
 
   def save!
     if valid?
-      edit_accesses_collaboration.destroy!
+      collaboration.destroy!
       add_deletion_activity!
       schedule_delete_emails
       true
@@ -30,8 +30,8 @@ class EditInvestigationCollaboratorForm
 
 private
 
-  def edit_accesses_collaboration
-    investigation.edit_access_collaborations.find_by!(collaborator_id: team.id)
+  def collaboration
+    investigation.collaborations.edit_and_read_only.find_by!(collaborator_id: team.id)
   end
 
   def schedule_delete_emails

--- a/psd-web/app/models/collaboration.rb
+++ b/psd-web/app/models/collaboration.rb
@@ -2,6 +2,10 @@ class Collaboration < ApplicationRecord
   belongs_to :investigation
   belongs_to :collaborator, polymorphic: true
 
+  def self.edit_and_read_only
+    where(type: ["Collaboration::Access::Edit", "Collaboration::Access::ReadOnly"])
+  end
+
   def creator_team?
     investigation.creator_team == collaborator
   end

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -72,7 +72,6 @@ class Investigation < ApplicationRecord
   has_many :read_only_collaborations, class_name: "Collaboration::Access::ReadOnly"
   has_many :teams_with_read_only_access, through: :read_only_collaborations, source: :collaborator, source_type: "Team"
 
-  has_many :edit_collaborations,      class_name: "Collaboration::Access::Edit"
   has_many :collaboration_accesses,   class_name: "Collaboration::Access"
   has_many :teams_with_access, lambda {
     select("teams.*, CASE collaborations.type WHEN 'Collaboration::Access::OwnerTeam' THEN 1 ELSE 2 END").distinct.joins(:collaborations).order(Arel.sql("CASE collaborations.type WHEN 'Collaboration::Access::OwnerTeam' THEN 1 ELSE 2 END, teams.name")).references(:collaborations)

--- a/psd-web/app/services/change_case_owner.rb
+++ b/psd-web/app/services/change_case_owner.rb
@@ -21,8 +21,8 @@ class ChangeCaseOwner
       investigation.reload # force cached associations to be reloaded
 
       old_collaboration = investigation
-                            .collaboration_accesses
-                            .where(type: ["Collaboration::Access::Edit", "Collaboration::Access::ReadOnly"])
+                            .collaborations
+                            .edit_and_read_only
                             .find_by(collaborator: owner.team)
 
       (old_collaboration || owner).own!(investigation)

--- a/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
+++ b/psd-web/lib/tasks/add_case_creators_as_collaborators.rake
@@ -13,7 +13,7 @@ task add_case_creators_as_collaborators: :environment do
       count += 1
 
       puts "Adding #{creator_team.name} as a collaborator to case #{investigation.pretty_id}"
-      investigation.edit_collaborations.create!(collaborator: creator_team, added_by_user: creator_user)
+      investigation.edit_access_collaborations.create!(collaborator: creator_team, added_by_user: creator_user)
     end
   end
 

--- a/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
+++ b/psd-web/spec/forms/edit_investigation_collaborator_form_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe EditInvestigationCollaboratorForm, :with_elasticsearch, :with_stu
           end
         end
 
+        context "when collaborator is the case owner" do
+          let(:params_team) { investigation.owner_team }
+
+          it "raises exception" do
+            expect { form.save! }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
         shared_examples "unsuccessful save" do
           it "returns false" do
             expect(form.save!).to be false

--- a/psd-web/spec/requests/edit_collaborator_spec.rb
+++ b/psd-web/spec/requests/edit_collaborator_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe "Editing a collaborator for a case", type: :request, with_stubbed
     sign_in user
   end
 
+  context "when editing" do
+    context "with owner collaboration", :with_errors_rendered do
+      before do
+        get edit_investigation_collaborator_path(investigation.pretty_id, investigation.owner_team_collaboration.id)
+      end
+
+      it "responds with a 404 (not found) status" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   context "when deleting" do
     let(:permission_level) { EditInvestigationCollaboratorForm::PERMISSION_LEVEL_DELETE }
     let(:message) { "" }
@@ -53,6 +65,16 @@ RSpec.describe "Editing a collaborator for a case", type: :request, with_stubbed
       it "is not successful" do
         do_request
         expect(response).to render_template("collaborators/edit")
+      end
+    end
+
+    context "with owner collaboration", :with_errors_rendered do
+      before do
+        put investigation_collaborator_path(investigation.pretty_id, investigation.owner_team_collaboration.id), params: params
+      end
+
+      it "responds with a 404 (not found) status" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This fixes an issue I discovered when refactoring the `EditInvestigationCollaboratorForm` class. It is possible to remove the case owner due to the class inheritance of `Collaboration::Access::Owner` inheriting from `Collaboration::Access::Edit`.

This change ensures that only `Collaboration::Access::Edit` and `Collaboration::Access::Readonly` can be edited/removed.

Previously, `Collaboration::Access::ReadOnly` was not editable or removable, and teams with read-only access were still listed in the 'add collaborator' form. These small fixes are a small step in the related story to implement view-only permissions.

Also removed the duplicate `edit_collaborations` association which was already implemented as `edit_access_collaborations`.

I am in the process of refactoring `EditInvestigationCollaboratorForm` but felt it was worthwhile separating out these changes so the bug fix can be documented separately.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Has acceptance criteria been tested by a peer?
