### PR TITLE
Fix migration on team added activity

### DIFF
--- a/psd-web/db/migrate/20200724135733_convert_activity_metadata_for_teams_on_case.rb
+++ b/psd-web/db/migrate/20200724135733_convert_activity_metadata_for_teams_on_case.rb
@@ -4,7 +4,7 @@ class ConvertActivityMetadataForTeamsOnCase < ActiveRecord::Migration[5.2]
       team_name = activity.attributes["title"].match(/(.*) added to/).captures.first.strip
       team = Team.find_by!(name: team_name)
 
-      collaboration = activity.collaborations.find(type: "Collaboration::Access::Edit", collaborator_type: "Team", collaborator_id: team.id)
+      collaboration = Collaboration::Access::Edit.new(collaborator: team, investigation: activity.investigation)
 
       activity.update!(
         metadata: activity.class.build_metadata(collaboration, activity.body),


### PR DESCRIPTION
it seems when I changed the interface to `AuditActivity::Investigation::TeamAdded#build_metadata` I forgot that teams subsequently removed would not have corresponding `Collaboration::Access::Edit` records which were destroyed. This ensures we don't depend on those records.