### PR TITLE
Render custom 404 page if the route is invalid

### DIFF
--- a/psd-web/app/controllers/application_controller.rb
+++ b/psd-web/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :nav_items, :secondary_nav_items, :previous_search_params, :current_user
 
+  rescue_from ActionController::RoutingError, with: :render_404_page
   rescue_from Wicked::Wizard::InvalidStepError, with: :render_404_page
 
   def set_current_user


### PR DESCRIPTION
This makes sure we render our 404 page rather than a 500 page if there's a routing error.