### PR TITLE
add a custom ActiveModel::Type::GovUKDate

### DIFF
--- a/psd-web/app/forms/risk_assessment_form.rb
+++ b/psd-web/app/forms/risk_assessment_form.rb
@@ -5,7 +5,7 @@ class RiskAssessmentForm
   attribute :investigation
   attribute :current_user
 
-  attribute :assessed_on
+  attribute :assessed_on, :govuk_date
   attribute :risk_level
   attribute :custom_risk_level
 
@@ -85,14 +85,6 @@ class RiskAssessmentForm
     else
       super
     end
-  end
-
-  # Expects either a date object, or a hash containing
-  # year, month and day, for example:
-  #
-  # {year: "2019", month: "01", day: "20"}
-  def assessed_on=(assessed_on)
-    super(DateParser.new(assessed_on).date)
   end
 
 private

--- a/psd-web/app/models/date_parser.rb
+++ b/psd-web/app/models/date_parser.rb
@@ -11,26 +11,24 @@ class DateParser
   def date
     return nil if @date.nil?
     return @date if @date.is_a?(Date)
-    return nil if @date[:year].blank? && @date[:month].blank? && @date[:day].blank?
 
-    if numeric?(@date[:year]) && numeric?(@date[:month]) && numeric?(@date[:day])
-      begin
-        Date.new(@date[:year].to_i, @date[:month].to_i, @date[:day].to_i)
-      rescue ArgumentError, RangeError
-        struct_from_hash
-      end
-    else
+    date_values = @date.values_at(:year, :month, :day).map do |date_part|
+      Integer(date_part)
+    rescue StandardError
+      nil
+    end
+
+    return nil if date_values.any?(&:blank?)
+    return struct_from_hash if date_values.any?(&:blank?)
+
+    begin
+      Date.new(*date_values)
+    rescue ArgumentError, RangeError
       struct_from_hash
     end
   end
 
 private
-
-  # Checks that the string contains only digits (once leading/trailing whitespace is snipped)
-  # as otherwise `to_i` can return expected results, eg `"2??9".to_i == 2`
-  def numeric?(string)
-    string.to_s.strip.scan(/^[\d]+$/).any?
-  end
 
   def struct_from_hash
     OpenStruct.new(year: @date[:year], month: @date[:month], day: @date[:day])

--- a/psd-web/app/models/date_parser.rb
+++ b/psd-web/app/models/date_parser.rb
@@ -18,7 +18,7 @@ class DateParser
       nil
     end
 
-    return nil if date_values.any?(&:blank?)
+    return nil if date_values.all?(&:blank?)
     return struct_from_hash if date_values.any?(&:blank?)
 
     begin

--- a/psd-web/config/initializers/active_model_type.rb
+++ b/psd-web/config/initializers/active_model_type.rb
@@ -1,2 +1,2 @@
-require 'active_model/types/govuk_date'
+require "active_model/types/govuk_date"
 ActiveModel::Type.register(:govuk_date, ActiveModel::Types::GovUKDate)

--- a/psd-web/config/initializers/active_model_type.rb
+++ b/psd-web/config/initializers/active_model_type.rb
@@ -1,0 +1,2 @@
+require 'active_model/types/govuk_date'
+ActiveModel::Type.register(:govuk_date, ActiveModel::Types::GovUKDate)

--- a/psd-web/lib/active_model/types/govuk_date.rb
+++ b/psd-web/lib/active_model/types/govuk_date.rb
@@ -1,0 +1,9 @@
+module ActiveModel
+  module Types
+    class GovUKDate < ActiveRecord::Type::Value
+      def cast(value)
+        DateParser.new(value).date
+      end
+    end
+  end
+end


### PR DESCRIPTION
## add a custom ActiveModel::Type::GovUKDate

This makes it simpler to add the govuk date coming from the govuk multiple input form.

now in form object just declare the type in at the attribute level:

```ruby
class AFormWithAGovUKDate
  attribute :date_receive, :govuk_date
end
```