### PR TITLE
Add content to set case risk level page

### DIFF
--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -11,7 +11,7 @@ module Investigations
     end
 
     def create
-      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
 
       authorize @investigation, :update?
 
@@ -35,14 +35,16 @@ module Investigations
           redirect_to investigation_risk_assessment_update_case_risk_level_path(@investigation, result.risk_assessment)
         end
       else
+        @investigation = @investigation.decorate
         render :new
       end
     end
 
     def show
-      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]).decorate
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
 
       @risk_assessment = @investigation.risk_assessments.find(params[:id]).decorate
+      @investigation = @investigation.decorate
     end
 
   private

--- a/app/controllers/investigations/update_case_risk_level_from_risk_assessment_controller.rb
+++ b/app/controllers/investigations/update_case_risk_level_from_risk_assessment_controller.rb
@@ -1,22 +1,28 @@
 module Investigations
   class UpdateCaseRiskLevelFromRiskAssessmentController < ApplicationController
     def show
-      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id]).decorate
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
+
       authorize @investigation, :update?
 
-      @risk_assessment = @investigation.risk_assessments.find(params[:risk_assessment_id]).decorate
+      @risk_assessment = @investigation.risk_assessments.find(params[:risk_assessment_id])
 
       @update_risk_level_from_risk_assessment_form = UpdateRiskLevelFromRiskAssessmentForm.new
+
+      @investigation = @investigation.decorate
+      @risk_assessment = @risk_assessment.decorate
     end
 
     def update
-      @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id]).decorate
+      @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
 
       authorize @investigation, :update?
 
       @risk_assessment = @investigation.risk_assessments.find(params[:risk_assessment_id]).decorate
 
       @update_risk_level_from_risk_assessment_form = UpdateRiskLevelFromRiskAssessmentForm.new(form_params)
+
+      @investigation = @investigation.decorate
 
       return render :show unless @update_risk_level_from_risk_assessment_form.valid?
 

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -1,6 +1,6 @@
 class InvestigationDecorator < ApplicationDecorator
   delegate_all
-  decorates_associations :complainant, :documents_attachments, :creator_user, :owner_user, :owner_team, :activities
+  decorates_associations :complainant, :documents_attachments, :creator_user, :owner_user, :owner_team, :activities, :risk_assessments
 
   PRODUCT_DISPLAY_LIMIT = 6
 
@@ -22,6 +22,10 @@ class InvestigationDecorator < ApplicationDecorator
 
   def display_product_summary_list?
     products.any?
+  end
+
+  def risk_assessment_risk_levels
+    risk_assessments.collect(&:risk_level_description).uniq
   end
 
   def product_summary_list

--- a/app/views/investigations/risk_level/show.html.erb
+++ b/app/views/investigations/risk_level/show.html.erb
@@ -24,7 +24,7 @@
         count: @investigation.risk_assessments.count,
         add_risk_assessment_href: new_investigation_risk_assessment_path(@investigation.pretty_id),
         supporting_information_href: investigation_supporting_information_index_path(@investigation.pretty_id),
-        risk_assessment_href: (@investigation.risk_assessments.any? ? investigation_risk_assessment_path(@investigation.pretty_id, @investigation.risk_assessments.first.id) : nil),
+        risk_assessment_href: (@investigation.risk_assessments.count == 1 ? investigation_risk_assessment_path(@investigation.pretty_id, @investigation.risk_assessments.first) : nil),
         risk_assessment_risk_levels: to_sentence(@investigation.risk_assessment_risk_levels.collect {|desc| tag.strong(desc.downcase) })
       ) %>
     </div>

--- a/app/views/investigations/risk_level/show.html.erb
+++ b/app/views/investigations/risk_level/show.html.erb
@@ -14,6 +14,21 @@
     <h1 class="govuk-heading-l">
       <%= page_heading %>
     </h1>
+
+    <p class="govuk-body">The case risk level will usually match the risk assessment.</p>
+
+    <p class="govuk-body">It can differ from risk assessments if necessary - such as when there are conflicting assessments, or where the assessment was provided by a third party.</p>
+
+    <div class="govuk-inset-text">
+      <%= t(".risk_assessment_details_for_case_html",
+        count: @investigation.risk_assessments.count,
+        add_risk_assessment_href: new_investigation_risk_assessment_path(@investigation.pretty_id),
+        supporting_information_href: investigation_supporting_information_index_path(@investigation.pretty_id),
+        risk_assessment_href: (@investigation.risk_assessments.any? ? investigation_risk_assessment_path(@investigation.pretty_id, @investigation.risk_assessments.first.id) : nil),
+        risk_assessment_risk_levels: to_sentence(@investigation.risk_assessment_risk_levels.collect {|desc| tag.strong(desc.downcase) })
+      ) %>
+    </div>
+
     <%= form_with scope: :investigation, model: @risk_level_form, url: investigation_risk_level_path(@investigation), method: :put do |form| %>
       <%= error_summary @risk_level_form.errors %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,10 @@ en:
         title:
           set: "Set case risk level"
           change: "Change case risk level"
+        risk_assessment_details_for_case_html:
+          zero: This case does not have a risk assessment. You may want to <a class="govuk-link" href="%{add_risk_assessment_href}">add a risk assessment</a> before setting the case risk level.
+          one: This case has <a class="govuk-link" href="%{risk_assessment_href}">1 risk assessment</a> added, assessing the risk as %{risk_assessment_risk_levels}.
+          other:  This case has <a class="govuk-link" href="%{supporting_information_href}">%{count} risk assessments</a> added, assessing the risk as %{risk_assessment_risk_levels}.
         submit_button: "Set risk level"
         legend: "Case risk level"
         levels:

--- a/spec/factories/risk_assessments.rb
+++ b/spec/factories/risk_assessments.rb
@@ -1,13 +1,14 @@
 FactoryBot.define do
   factory :risk_assessment do
-    investigation_id { 1 }
+    investigation { association :allegation }
     assessed_on { "2020-07-20" }
     risk_level { "" }
-    completed_by_team_id { "MyText" }
-    completed_by_business_id { 1 }
-    completed_by_other { "MyText" }
+    assessed_by_team { association :team }
+    assessed_by_business { nil }
+    assessed_by_other { nil }
     details { "MyText" }
-    added_by_user_id { "MyText" }
-    added_by_team_id { "MyText" }
+    products { [build(:product)] }
+    added_by_user { association :user }
+    added_by_team { association :team }
   end
 end

--- a/spec/features/set_investigation_risk_level_spec.rb
+++ b/spec/features/set_investigation_risk_level_spec.rb
@@ -2,6 +2,21 @@ require "rails_helper"
 
 RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer do
   let!(:investigation) { create(:allegation, edit_access_teams: [team_with_access]) }
+
+  let!(:investigation_with_serious_risk_assessment) do
+    create(:allegation, edit_access_teams: [team_with_access], risk_assessments: [
+      create(:risk_assessment, risk_level: "serious")
+    ])
+  end
+
+  let!(:investigation_with_multiple_risk_assessments) do
+    create(:allegation, edit_access_teams: [team_with_access], risk_assessments: [
+      create(:risk_assessment, risk_level: "serious"),
+      create(:risk_assessment, risk_level: "high"),
+      create(:risk_assessment, risk_level: "other", custom_risk_level: "urgent")
+    ])
+  end
+
   let(:creator_team) { investigation.creator_user.team }
   let(:team_with_access) { create(:team, name: "Team with access", team_recipient_email: nil) }
   let(:user) { create(:user, :activated, has_viewed_introduction: true, team: team_with_access) }
@@ -20,7 +35,7 @@ RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticse
     end
   end
 
-  scenario "Setting risk level for an investigation" do
+  scenario "Setting risk level for an investigation with no risk assessments added" do
     visit "/cases/#{investigation.pretty_id}"
 
     # Set risk level for first time
@@ -28,6 +43,9 @@ RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticse
     click_set_risk_level_link
 
     expect_to_be_on_set_risk_level_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_text("This case does not have a risk assessment. You may want to add a risk assessment before setting the case risk level.")
+
     choose "Medium risk"
     click_button "Set risk level"
 
@@ -47,6 +65,18 @@ RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticse
       name: creator_team.name,
       verb_with_level: "set to medium risk",
     )
+  end
+
+  scenario "Setting risk level on a case with an existing 'serious' risk assessment" do
+    visit "/cases/#{investigation_with_serious_risk_assessment.pretty_id}/edit-risk-level"
+
+    expect(page).to have_content("This case has 1 risk assessment added, assessing the risk as serious risk.")
+  end
+
+  scenario "Setting risk level on a case with multiple risk assessments" do
+    visit "/cases/#{investigation_with_multiple_risk_assessments.pretty_id}/edit-risk-level"
+
+    expect(page).to have_content("This case has 3 risk assessments added, assessing the risk as serious risk, high risk and urgent.")
   end
 
   scenario "Changing risk level for an investigation" do


### PR DESCRIPTION
This adds some additional content to the "Set case risk level" page to remind users about any risk assessments that have been added to the case, and their risk levels.

## Screenshots

### When there are no risk assessments added to the case

<img width="822" alt="Screenshot 2020-08-14 at 11 56 21" src="https://user-images.githubusercontent.com/30665/90242599-3c986d00-de25-11ea-85bb-3d5c842bb38e.png">

### When there is one risk assessment added to the case

<img width="768" alt="Screenshot 2020-08-14 at 11 57 23" src="https://user-images.githubusercontent.com/30665/90242658-53d75a80-de25-11ea-8bd0-5d75928c0482.png">

### When there is more than one risk assessments added to the case

<img width="806" alt="Screenshot 2020-08-14 at 11 58 02" src="https://user-images.githubusercontent.com/30665/90242707-6a7db180-de25-11ea-8348-12319ae4b5b6.png">


https://trello.com/c/wOCDXNxu/605-2-add-risk-assessment-content-to-case-risk-level-page