### PR TITLE
Move back link within one-half column

### DIFF
--- a/app/views/investigations/risk_level/show.html.erb
+++ b/app/views/investigations/risk_level/show.html.erb
@@ -1,6 +1,6 @@
 <% page_heading = @investigation.risk_level_set? ? t(".title.change") : t(".title.set") %>
 <% page_title page_heading, errors: @risk_level_form.errors.any? %>
-<% content_for :after_header do %>
+<% content_for :back_link do %>
   <%= govukBackLink(
     text: "Back to #{@investigation.pretty_description.downcase}",
     href: investigation_path(@investigation)


### PR DESCRIPTION
This allows the case tags to appear alongside it on the right.

## Before

> <img width="1218" alt="Screenshot 2020-08-14 at 15 46 35" src="https://user-images.githubusercontent.com/30665/90261978-9872ee00-de45-11ea-96c1-904dd60fc741.png">

## After

> <img width="1224" alt="Screenshot 2020-08-14 at 15 46 53" src="https://user-images.githubusercontent.com/30665/90261996-9f016580-de45-11ea-874b-e7f324cfb406.png">
