### PR TITLE
Add risk assessments to case overview

### DIFF
--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -76,15 +76,29 @@ class InvestigationDecorator < ApplicationDecorator
         h.tag.p("Assessed risk: #{most_recent_risk_assessment.risk_level_description}", class: "govuk-body")
       ])
 
+      risk_assessment_href = if object.risk_assessments.size == 1
+                               h.investigation_risk_assessment_path(object.pretty_id, most_recent_risk_assessment.id)
+                             else
+                               h.investigation_supporting_information_index_path(object.pretty_id)
+                             end
+
+      risk_assessment_action = {
+        text: "View",
+        visually_hidden_text: h.pluralize(risk_assessments.size, "risk assessment"),
+        href: risk_assessment_href
+      }
+
     else
       risk_assessments_html = "No risk assessments"
+      risk_assessment_action = { text: "Add", visually_hidden_text: "risk assessement", href: h.new_investigation_risk_assessment_path(object.pretty_id) }
     end
 
     rows << {
       key: { text: "Risk assessment".pluralize(object.risk_assessments.size) },
       value: {
         text: risk_assessments_html.html_safe
-      }
+      },
+      actions: [risk_assessment_action]
     }
 
     if object.hazard_type.present?

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -63,10 +63,16 @@ class InvestigationDecorator < ApplicationDecorator
         key: { text: "Case risk level" },
         value: { text: risk_level_description },
         actions: show_actions ? risk_level_actions : []
-      },
-      object.hazard_type.present? ? { key: { text: "Hazards" }, value: { text: hazards }, actions: [] } : nil,
-      object.non_compliant_reason.present? ? { key: { text: "Compliance" }, value: { text: non_compliant_reason }, actions: [] } : nil,
-    ]
+      }]
+
+    if object.hazard_type.present?
+      rows << { key: { text: "Hazards" }, value: { text: hazards }, actions: [] }
+    end
+
+    if object.non_compliant_reason.present?
+      rows << { key: { text: "Compliance" }, value: { text: non_compliant_reason }, actions: [] }
+    end
+
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"
   end

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -137,12 +137,4 @@ private
   def should_display_received_by?
     false
   end
-
-  # def risk_level_actions
-  #   if risk_level_set?
-  #     [href: h.investigation_risk_level_path(object), text: "Change", visually_hidden_text: "risk level"]
-  #   else
-  #     [href: h.investigation_risk_level_path(object), text: "Set", visually_hidden_text: "risk level"]
-  #   end
-  # end
 end

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -8,14 +8,6 @@ class InvestigationDecorator < ApplicationDecorator
     user_title
   end
 
-  def hazard_description
-    h.simple_format(object.hazard_description)
-  end
-
-  def non_compliant_reason
-    h.simple_format(object.non_compliant_reason)
-  end
-
   def description
     h.simple_format(object.description)
   end
@@ -54,63 +46,6 @@ class InvestigationDecorator < ApplicationDecorator
     else
       "Not set"
     end
-  end
-
-  def risk_and_issues_list(show_actions = false)
-    hazards = h.simple_format([hazard_type, object.hazard_description].join("\n\n"))
-    rows = [
-      {
-        key: { text: "Case risk level" },
-        value: { text: risk_level_description },
-        actions: show_actions ? risk_level_actions : []
-      }
-    ]
-
-    if risk_assessments.any?
-
-      most_recent_risk_assessment = risk_assessments.max_by(&:assessed_on)
-
-      risk_assessments_html = h.safe_join([
-        h.tag.p(h.pluralize(object.risk_assessments.size, "risk assessment"), class: "govuk-body"),
-        h.tag.p("#{object.risk_assessments.size == 1 ? 'Completed' : 'Most recent'} by #{h.risk_assessed_by(most_recent_risk_assessment)} on #{most_recent_risk_assessment.assessed_on.to_s(:govuk)}", class: "govuk-body"),
-        h.tag.p("Assessed risk: #{most_recent_risk_assessment.risk_level_description}", class: "govuk-body")
-      ])
-
-      risk_assessment_href = if object.risk_assessments.size == 1
-                               h.investigation_risk_assessment_path(object.pretty_id, most_recent_risk_assessment.id)
-                             else
-                               h.investigation_supporting_information_index_path(object.pretty_id)
-                             end
-
-      risk_assessment_action = {
-        text: "View",
-        visually_hidden_text: h.pluralize(risk_assessments.size, "risk assessment"),
-        href: risk_assessment_href
-      }
-
-    else
-      risk_assessments_html = "No risk assessments"
-      risk_assessment_action = { text: "Add", visually_hidden_text: "risk assessement", href: h.new_investigation_risk_assessment_path(object.pretty_id) }
-    end
-
-    rows << {
-      key: { text: "Risk assessment".pluralize(object.risk_assessments.size) },
-      value: {
-        text: risk_assessments_html.html_safe
-      },
-      actions: [risk_assessment_action]
-    }
-
-    if object.hazard_type.present?
-      rows << { key: { text: "Hazards" }, value: { text: hazards }, actions: [] }
-    end
-
-    if object.non_compliant_reason.present?
-      rows << { key: { text: "Compliance" }, value: { text: non_compliant_reason }, actions: [] }
-    end
-
-    rows.compact!
-    h.render "components/govuk_summary_list", rows: rows, classes: "govuk-summary-list--no-border"
   end
 
   def source_details_summary_list(view_protected_details = false)
@@ -203,11 +138,11 @@ private
     false
   end
 
-  def risk_level_actions
-    if risk_level_set?
-      [href: h.investigation_risk_level_path(object), text: "Change", visually_hidden_text: "risk level"]
-    else
-      [href: h.investigation_risk_level_path(object), text: "Set", visually_hidden_text: "risk level"]
-    end
-  end
+  # def risk_level_actions
+  #   if risk_level_set?
+  #     [href: h.investigation_risk_level_path(object), text: "Change", visually_hidden_text: "risk level"]
+  #   else
+  #     [href: h.investigation_risk_level_path(object), text: "Set", visually_hidden_text: "risk level"]
+  #   end
+  # end
 end

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -63,7 +63,29 @@ class InvestigationDecorator < ApplicationDecorator
         key: { text: "Case risk level" },
         value: { text: risk_level_description },
         actions: show_actions ? risk_level_actions : []
-      }]
+      }
+    ]
+
+    if risk_assessments.any?
+
+      most_recent_risk_assessment = risk_assessments.max_by(&:assessed_on)
+
+      risk_assessments_html = h.safe_join([
+        h.tag.p(h.pluralize(object.risk_assessments.size, "risk assessment"), class: "govuk-body"),
+        h.tag.p("#{object.risk_assessments.size == 1 ? 'Completed' : 'Most recent'} by #{h.risk_assessed_by(most_recent_risk_assessment)} on #{most_recent_risk_assessment.assessed_on.to_s(:govuk)}", class: "govuk-body"),
+        h.tag.p("Assessed risk: #{most_recent_risk_assessment.risk_level_description}", class: "govuk-body")
+      ])
+
+    else
+      risk_assessments_html = "No risk assessments"
+    end
+
+    rows << {
+      key: { text: "Risk assessment".pluralize(object.risk_assessments.size) },
+      value: {
+        text: risk_assessments_html.html_safe
+      }
+    }
 
     if object.hazard_type.present?
       rows << { key: { text: "Hazards" }, value: { text: hazards }, actions: [] }

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -290,7 +290,7 @@ module InvestigationsHelper
       }
     }
 
-    if policy(investigation).update?(user: user)
+    if policy(investigation).update?(user: user) || most_recent_risk_assessment
 
       risk_assessment_href =
         case investigation.risk_assessments.count

--- a/app/views/investigations/tabs/_overview.html.erb
+++ b/app/views/investigations/tabs/_overview.html.erb
@@ -25,7 +25,11 @@
 
     <%= govuk_hr %>
     <h2 class="govuk-heading-m"><%= "Risks and issues" %></h2>
-    <%= @investigation.risk_and_issues_list(policy(@investigation).update?) %>
+
+    <%= govukSummaryList(
+      classes: "govuk-summary-list--no-border app-summary-list--actions-on-own-line",
+      rows: risks_and_issues_rows(@investigation, current_user)
+    ) %>
 
     <% if @investigation.complainant %>
       <%= govuk_hr %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,39 @@ en:
       title: "Title"
 
   investigations:
+    overview:
+      case_risk_level:
+        key: Case risk level
+        action:
+          change: Change
+          set: Set
+        visually_hidden_text: risk level
+      risk_assessments:
+        key:
+          one: Risk assessment
+          other: Risk assessments
+        value_html:
+          zero: No risk assessments
+          one: |
+            <p class="govuk-body">1 risk assessment</p>
+            <p class="govuk-body">Completed by %{assessed_by} on %{assessed_on}</p>
+            <p class="govuk-body">Assessed risk: %{assessed_risk}</p>
+          other: |
+            <p class="govuk-body">%{count} risk assessments</p>
+            <p class="govuk-body">Most recent by %{assessed_by} on %{assessed_on}</p>
+            <p class="govuk-body">Assessed risk: %{assessed_risk}</p>
+        action:
+          zero: Add
+          one: View
+          other: View
+        visually_hidden_text:
+          zero: risk assessment
+          one: risk aseessment
+          other: risk assessments
+      hazards:
+        key: Hazards
+      compliance:
+        key: Compliance
     coronavirus_related:
       show:
         title: "Is the case related to the coronavirus outbreak?"

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -40,53 +40,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
     end
   end
 
-  describe "#risk_and_issues_list" do
-    let(:risk_and_issues_list) { decorated_investigation.risk_and_issues_list }
-
-    it "displays the hazard type" do
-      expect(risk_and_issues_list).to summarise("Hazards", text: /#{Regexp.escape(investigation.hazard_type)}/)
-    end
-
-    it "displays the hazard description" do
-      expect(risk_and_issues_list).to summarise("Hazards", text: /#{Regexp.escape(investigation.hazard_description)}/)
-    end
-
-    it "displays the compliance reason" do
-      expect(risk_and_issues_list).to summarise("Compliance", text: /#{Regexp.escape(investigation.non_compliant_reason)}/)
-    end
-
-    it "displays the text associated to the risk level" do
-      expect(risk_and_issues_list).to summarise("Case risk level", text: "Serious risk")
-    end
-
-    context "without hazard_type" do
-      let(:risk_and_issues_list) { Capybara.string(decorated_investigation.risk_and_issues_list) }
-
-      before do
-        investigation.hazard_type = nil
-        investigation.hazard_description = nil
-      end
-
-      it { expect(risk_and_issues_list).not_to have_css("dt.govuk-summary-list__key", text: "Hazards") }
-    end
-
-    context "without non_compliant_reason" do
-      let(:risk_and_issues_list) { Capybara.string(decorated_investigation.risk_and_issues_list) }
-
-      before { investigation.non_compliant_reason = nil }
-
-      it { expect(risk_and_issues_list).not_to have_css("dt.govuk-summary-list__key", text: "Compliance") }
-    end
-
-    context "without risk level" do
-      let(:risk_level) { nil }
-
-      it "displays risk level as not set" do
-        expect(risk_and_issues_list).to summarise("Case risk level", text: "Not set")
-      end
-    end
-  end
-
   describe "#risk_level_description" do
     let(:risk_level_description) { decorated_investigation.risk_level_description }
 
@@ -172,10 +125,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
     }
   end
 
-  describe "#hazard_description" do
-    include_examples "a formated text", :investigation, :hazard_description
-  end
-
   describe "#source_details_summary_list" do
     let(:view_protected_details) { true }
     let(:source_details_summary_list) { decorated_investigation.source_details_summary_list(view_protected_details) }
@@ -219,10 +168,6 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
     def expect_to_display_protect_details_message
       expect(source_details_summary_list).to summarise("Contact details", text: /Only teams added to the case can view allegation contact details/)
     end
-  end
-
-  describe "#non_compliant_reason" do
-    include_examples "a formated text", :investigation, :non_compliant_reason
   end
 
   describe "#description" do

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -38,7 +38,13 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
   scenario "Adding a risk assessment to a case with a multiple products (with validation errors)" do
     sign_in(user)
 
-    visit "/cases/#{investigation.pretty_id}/supporting-information"
+    visit "/cases/#{investigation.pretty_id}"
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_summary_item(key: "Risk assessments", value: "No risk assessments")
+
+    click_link "Supporting information"
+    expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
 
     click_link "Add new"
     expect_to_be_on_add_supporting_information_page
@@ -116,6 +122,11 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
 
     expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
 
+    click_link "Overview"
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_summary_item(key: "Risk assessment", value: "1 risk assessment\nCompleted by MyCouncil Trading Standards on 3 April 2020\nAssessed risk: Serious risk")
+
     click_link "Activity"
     expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
 
@@ -188,6 +199,11 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
     click_link "Back to allegation"
 
     expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
+
+    click_link "Overview"
+    expect_to_be_on_case_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_summary_item(key: "Risk assessment", value: "1 risk assessment\nCompleted by OtherCouncil Trading Standards on 3 April 2020\nAssessed risk: Medium-high risk")
 
     click_link "Activity"
     expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -43,14 +43,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
 
     expect(page).to have_summary_item(key: "Risk assessments", value: "No risk assessments")
 
-    click_link "Supporting information"
-    expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
-
-    click_link "Add new"
-    expect_to_be_on_add_supporting_information_page
-
-    choose "Risk assessment"
-    click_button "Continue"
+    click_link "Add risk assessment"
 
     expect_to_be_on_add_risk_assessment_for_a_case_page(case_id: investigation.pretty_id)
 

--- a/spec/features/set_investigation_risk_level_spec.rb
+++ b/spec/features/set_investigation_risk_level_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticse
 
     scenario "they cannot set the risk level for the case" do
       visit "/cases/#{investigation.pretty_id}"
-      expect(risk_level_actions_in_overview).not_to have_link(text: "Set")
+      expect(page).not_to have_link("Set risk level")
     end
   end
 
@@ -165,16 +165,11 @@ RSpec.feature "Setting risk level for an investigation", :with_stubbed_elasticse
     expect(find_field("Low risk")).to be_checked
   end
 
-  def risk_level_actions_in_overview
-    page.find("dt", text: "Case risk level", exact_text: true)
-        .sibling("dd", class: "govuk-summary-list__actions")
-  end
-
   def click_change_risk_level_link
-    risk_level_actions_in_overview.click_link "Change"
+    click_link "Change risk level"
   end
 
   def click_set_risk_level_link
-    risk_level_actions_in_overview.click_link "Set"
+    click_link "Set risk level"
   end
 end


### PR DESCRIPTION
This update adds detail about any risk assessments added to the case to the Overview tab, within the "Risks and issues" section.

Trello card: https://trello.com/c/4A9l6dvg/635-2-add-risk-assessment-to-overview-risk-section

## Implementation notes

I refactored the `risk_and_issues_list` decorator method to a `risks_and_issues_rows` helper method, to avoid generating HTML from the decorator, and to be more consistent with the existing `about_the_case_rows` helper method. Some of the conditions were also delegated to the locale file lookup using the pluralization feature (where the `count` value is used to map to different keys).

## Screenshots

### No risk assessments added

Links to the "Add risk assessment" flow (if you have permission to do so)

> <img width="831" alt="Screenshot 2020-08-19 at 11 44 04" src="https://user-images.githubusercontent.com/30665/90625537-a6dc5380-e211-11ea-9c3e-335a7ae3b0ac.png">

### 1 risk assessment added

Links direct to the risk assessment.

> <img width="812" alt="Screenshot 2020-08-19 at 11 45 26" src="https://user-images.githubusercontent.com/30665/90625566-b0fe5200-e211-11ea-89a9-79f54a6a3ff5.png">

### More than 1 risk assessments added

Summarises the most recent risk assessment, links to the supporting information page.

> <img width="825" alt="Screenshot 2020-08-19 at 11 44 18" src="https://user-images.githubusercontent.com/30665/90625592-bbb8e700-e211-11ea-8e11-07bc4a0620ca.png">
