### PR TITLE
Fix webpacker deprecation warning

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['app/assets']
+  additional_paths: ['app/assets']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
After the last upgrade webpacker started logging a deprecation warning:

`The resolved_paths option has been deprecated. Use additional_paths instead.`
