### PR TITLE
Edit risk assessments

### DIFF
--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -96,19 +96,12 @@ module Investigations
       @risk_assessment_form.attributes = risk_assessment_params
 
       if @risk_assessment_form.valid?
-        result = UpdateRiskAssessment.call!({
-          risk_assessment: @risk_assessment,
-          risk_level: @risk_assessment_form.risk_level,
-          custom_risk_level: @risk_assessment_form.custom_risk_level,
-          assessed_on: @risk_assessment_form.assessed_on,
-          assessed_by_team_id: @risk_assessment_form.assessed_by_team_id,
-          assessed_by_business_id: @risk_assessment_form.assessed_by_business_id,
-          assessed_by_other: @risk_assessment_form.assessed_by_other,
-          details: @risk_assessment_form.details,
-          product_ids: @risk_assessment_form.product_ids,
-          risk_assessment_file: @risk_assessment_form.risk_assessment_file,
-          user: current_user
-        })
+        result = UpdateRiskAssessment.call!(
+          @risk_assessment_form.serializable_hash.merge({
+            risk_assessment: @risk_assessment,
+            user: current_user
+          })
+        )
 
         if (result.risk_assessment.risk_level == @investigation.risk_level) && (result.risk_assessment.custom_risk_level == @investigation.custom_risk_level)
 

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -98,11 +98,19 @@ module Investigations
       if @risk_assessment_form.valid?
         result = UpdateRiskAssessment.call!(
           @risk_assessment_form.attributes.merge({
-            risk_assessment: @risk_assessment
+            risk_assessment: @risk_assessment,
+            custom_risk_level: @risk_assessment_form.custom_risk_level,
+            user: current_user
           })
         )
 
-        redirect_to investigation_risk_assessment_path(@investigation, result.risk_assessment)
+        if (result.risk_assessment.risk_level == @investigation.risk_level) && (result.risk_assessment.custom_risk_level == @investigation.custom_risk_level)
+
+          redirect_to investigation_risk_assessment_path(@investigation, result.risk_assessment)
+        else
+          redirect_to investigation_risk_assessment_update_case_risk_level_path(@investigation, result.risk_assessment)
+        end
+
       else
         @investigation = @investigation.decorate
         render :edit

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -96,13 +96,19 @@ module Investigations
       @risk_assessment_form.attributes = risk_assessment_params
 
       if @risk_assessment_form.valid?
-        result = UpdateRiskAssessment.call!(
-          @risk_assessment_form.attributes.merge({
-            risk_assessment: @risk_assessment,
-            custom_risk_level: @risk_assessment_form.custom_risk_level,
-            user: current_user
-          })
-        )
+        result = UpdateRiskAssessment.call!({
+          risk_assessment: @risk_assessment,
+          risk_level: @risk_assessment_form.risk_level,
+          custom_risk_level: @risk_assessment_form.custom_risk_level,
+          assessed_on: @risk_assessment_form.assessed_on,
+          assessed_by_team_id: @risk_assessment_form.assessed_by_team_id,
+          assessed_by_business_id: @risk_assessment_form.assessed_by_business_id,
+          assessed_by_other: @risk_assessment_form.assessed_by_other,
+          details: @risk_assessment_form.details,
+          product_ids: @risk_assessment_form.product_ids,
+          risk_assessment_file: @risk_assessment_form.risk_assessment_file,
+          user: current_user
+        })
 
         if (result.risk_assessment.risk_level == @investigation.risk_level) && (result.risk_assessment.custom_risk_level == @investigation.custom_risk_level)
 

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -72,7 +72,7 @@ module Investigations
           investigation: @investigation,
           assessed_by: assessed_by,
           product_ids: @risk_assessment.product_ids,
-          risk_assessment_file: @risk_assessment.risk_assessment_file
+          old_file: @risk_assessment.risk_assessment_file
         })
       )
 
@@ -90,7 +90,7 @@ module Investigations
       @risk_assessment_form = RiskAssessmentForm.new(
         current_user: current_user,
         investigation: @investigation,
-        risk_assessment_file: @risk_assessment.risk_assessment_file
+        old_file: @risk_assessment.risk_assessment_file
       )
 
       @risk_assessment_form.attributes = risk_assessment_params

--- a/app/decorators/audit_activity/risk_assessment/risk_assessment_updated_decorator.rb
+++ b/app/decorators/audit_activity/risk_assessment/risk_assessment_updated_decorator.rb
@@ -1,0 +1,11 @@
+class AuditActivity::RiskAssessment::RiskAssessmentUpdatedDecorator < ApplicationDecorator
+  delegate_all
+
+  def new_risk_level_description
+    if new_risk_level.present? && new_risk_level != "other"
+      I18n.t(".investigations.risk_level.show.levels.#{new_risk_level}")
+    else
+      new_custom_risk_level
+    end
+  end
+end

--- a/app/decorators/corrective_action_decorator.rb
+++ b/app/decorators/corrective_action_decorator.rb
@@ -61,6 +61,6 @@ class CorrectiveActionDecorator < ApplicationDecorator
   end
 
   def display_medium_title_text_size?
-    supporting_information_title.length > MEDIUM_TITLE_TEXT_SIZE_THRESHOLD
+    page_title.length > MEDIUM_TITLE_TEXT_SIZE_THRESHOLD
   end
 end

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -1,6 +1,7 @@
 class RiskAssessmentForm
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include ActiveModel::Serialization
 
   attribute :investigation
   attribute :current_user

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -17,6 +17,7 @@ class RiskAssessmentForm
 
   attribute :product_ids
 
+  attribute :old_file
   attribute :risk_assessment_file
 
   attribute :details
@@ -24,7 +25,7 @@ class RiskAssessmentForm
   validates :assessed_on, presence: true
   validates :risk_level, presence: true
 
-  validates :risk_assessment_file, presence: true
+  validates :risk_assessment_file, presence: true, unless: -> { old_file.present? }
 
   validates :assessed_by, presence: true
   validate :at_least_one_product_associated

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -51,6 +51,13 @@ class RiskAssessmentForm
     }
   end
 
+  # Ignore custom risk level value if risk_level isn't other
+  def custom_risk_level
+    return nil if risk_level.to_s != "other"
+
+    super
+  end
+
   def products
     investigation.products
     .pluck(:name, :id).collect do |row|

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -56,7 +56,8 @@ class RiskAssessmentForm
     .pluck(:name, :id).collect do |row|
       {
         text: row[0],
-        value: row[1]
+        value: row[1],
+        checked: product_ids.to_a.include?(row[1])
       }
     end
   end

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -80,10 +80,22 @@ class RiskAssessmentForm
       end
   end
 
+  def assessed_by_business_id
+    if assessed_by == "business"
+      super
+    end
+  end
+
   def assessed_by_team_id
     if assessed_by == "my_team"
       current_user.team_id
-    else
+    elsif assessed_by == "another_team"
+      super
+    end
+  end
+
+  def assessed_by_other
+    if assessed_by == "other"
       super
     end
   end

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -84,7 +84,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
                      errorMessage: error_message
   end
 
-  def govuk_file_upload(attribute, label:, hint: nil)
+  def govuk_file_upload(attribute, label:, hint: nil, label_classes: nil)
     # Set the form's enctype attribute to multipart/form-data so that the file
     # will get uploaded.
     self.multipart = true
@@ -104,7 +104,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
       },
       label: {
         text: label,
-        classes: "govuk-label--m"
+        classes: label_classes.to_s
       }
     )
   end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -284,7 +284,7 @@ module InvestigationsHelper
         text: t(:value_html,
                 scope: "investigations.overview.risk_assessments",
                 count: investigation.risk_assessments.count,
-                assessed_by: (most_recent_risk_assessment ? risk_assessed_by(most_recent_risk_assessment) : ""),
+                assessed_by: (most_recent_risk_assessment ? risk_assessed_by(team: most_recent_risk_assessment.assessed_by_team, business: most_recent_risk_assessment.assessed_by_business, other: most_recent_risk_assessment.assessed_by_other) : ""),
                 assessed_on: (most_recent_risk_assessment ? most_recent_risk_assessment.assessed_on.to_s(:govuk) : ""),
                 assessed_risk: (most_recent_risk_assessment ? most_recent_risk_assessment.risk_level_description : ""))
       }

--- a/app/helpers/risk_assessment_helper.rb
+++ b/app/helpers/risk_assessment_helper.rb
@@ -1,11 +1,11 @@
 module RiskAssessmentHelper
-  def risk_assessed_by(risk_assessment)
-    if risk_assessment.assessed_by_team
-      risk_assessment.assessed_by_team.name
-    elsif risk_assessment.assessed_by_business
-      link_to risk_assessment.assessed_by_business.trading_name, risk_assessment.assessed_by_business
+  def risk_assessed_by(team:, business:, other:)
+    if team
+      team.name
+    elsif business
+      link_to(business.trading_name, business)
     else
-      risk_assessment.assessed_by_other
+      other
     end
   end
 end

--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -1,6 +1,6 @@
 class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
   def self.from(*)
-    raise "Deprecated - use AddRiskAssessmentToCase.call instead"
+    raise "Deprecated - use UpdateRiskAssessment.call instead"
   end
 
   def self.build_metadata(risk_assessment:, previous_product_ids:, previous_attachment_filename:)
@@ -114,13 +114,13 @@ class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
     metadata["details"].presence
   end
 
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
-
 private
 
   def updates
     metadata["updates"]
   end
+
+  # Do not send investigation_updated mail when risk assessment updated. This
+  # overrides inherited functionality in the Activity model :(
+  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -100,16 +100,6 @@ class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
     metadata["details"].presence
   end
 
-  def assessed_by_name
-    if metadata["assessed_by_team_id"]
-      Team.find(metadata["assessed_by_team_id"])&.name
-    elsif metadata["assessed_by_business_id"]
-      Business.find(metadata["assessed_by_business_id"])&.trading_name
-    else
-      metadata["assessed_by_other"]
-    end
-  end
-
   # Do not send investigation_updated mail when test result updated. This
   # overrides inherited functionality in the Activity model :(
   def notify_relevant_users; end

--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -12,9 +12,11 @@ class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
       :assessed_by_business_id,
       :assessed_by_other,
       :details
-    ).merge({
-      product_ids: [previous_product_ids, risk_assessment.product_ids]
-    })
+    )
+
+    if previous_product_ids.sort != risk_assessment.product_ids.sort
+      updates[:product_ids] = [previous_product_ids, risk_assessment.product_ids]
+    end
 
     current_attachment_filename = risk_assessment.risk_assessment_file.filename
 

--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -1,0 +1,122 @@
+class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
+  def self.from(*)
+    raise "Deprecated - use AddRiskAssessmentToCase.call instead"
+  end
+
+  def self.build_metadata(risk_assessment:, previous_product_ids:)
+    {
+      risk_assessment_id: risk_assessment.id,
+      updates: risk_assessment.previous_changes.slice(
+        :assessed_on,
+        :risk_level,
+        :custom_risk_level,
+        :assessed_by_team_id,
+        :assessed_by_business_id,
+        :assessed_by_other,
+        :details
+      ).merge({
+        product_ids: [previous_product_ids, risk_assessment.product_ids]
+      })
+    }
+  end
+
+  def risk_level_changed?
+    new_risk_level || new_custom_risk_level
+  end
+
+  def assessed_by_changed?
+    new_assessed_by_team_id || new_assessed_by_business_id || new_assessed_by_other
+  end
+
+  def products_changed?
+    new_product_ids
+  end
+
+  def new_assessed_on
+    updates["assessed_on"]&.second
+  end
+
+  def new_risk_level
+    updates["risk_level"]&.second
+  end
+
+  def new_assessed_by_team
+    if new_assessed_by_team_id
+      Team.find(new_assessed_by_team_id)
+    end
+  end
+
+  def new_assessed_by_business
+    if new_assessed_by_business_id
+      Business.find(new_assessed_by_business_id)
+    end
+  end
+
+  def new_assessed_by_team_id
+    updates["assessed_by_team_id"]&.second
+  end
+
+  def new_assessed_by_business_id
+    updates["assessed_by_business_id"]&.second
+  end
+
+  def new_assessed_by_other
+    updates["assessed_by_other"]&.second
+  end
+
+  def new_custom_risk_level
+    updates["custom_risk_level"]&.second
+  end
+
+  def new_product_ids
+    updates["product_ids"]&.second
+  end
+
+  def new_products
+    Product.find(new_product_ids)
+  end
+
+  def new_details
+    updates["details"]&.second
+  end
+
+  def risk_assessment_id
+    metadata["risk_assessment_id"]
+  end
+
+  def title(_)
+    "Risk assessment edited"
+  end
+
+  def subtitle_slug
+    "Edited"
+  end
+
+  def products_assessed
+    Product.find(metadata["product_ids"])
+  end
+
+  def further_details
+    metadata["details"].presence
+  end
+
+  def assessed_by_name
+    if metadata["assessed_by_team_id"]
+      Team.find(metadata["assessed_by_team_id"])&.name
+    elsif metadata["assessed_by_business_id"]
+      Business.find(metadata["assessed_by_business_id"])&.trading_name
+    else
+      metadata["assessed_by_other"]
+    end
+  end
+
+  # Do not send investigation_updated mail when test result updated. This
+  # overrides inherited functionality in the Activity model :(
+  def notify_relevant_users; end
+
+private
+
+  def updates
+    metadata["updates"]
+  end
+end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -6,7 +6,6 @@ class UpdateRiskAssessment
 
   delegate :investigation, to: :risk_assessment
 
-
   def call
     @previous_product_ids = risk_assessment.product_ids
     ActiveRecord::Base.transaction do

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -25,7 +25,7 @@ class UpdateRiskAssessment
         product_ids: product_ids
       }
 
-      if risk_assessment_file != risk_assessment.risk_assessment_file
+      if risk_assessment_file && (risk_assessment_file != risk_assessment.risk_assessment_file)
         risk_assessment.risk_assessment_file.detach
         risk_assessment.risk_assessment_file.attach(risk_assessment_file)
       end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -1,0 +1,21 @@
+class UpdateRiskAssessment
+  include Interactor
+
+  delegate :risk_assessment, :user, :assessed_on, :risk_level, :custom_risk_level,
+           :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :details, :product_ids, :risk_assessment_file, to: :context
+
+  def call
+    ActiveRecord::Base.transaction do
+      risk_assessment.update!({
+        assessed_on: assessed_on,
+        risk_level: risk_level,
+        custom_risk_level: custom_risk_level.presence,
+        assessed_by_team_id: assessed_by_team_id.presence,
+        assessed_by_business_id: assessed_by_business_id.presence,
+        assessed_by_other: assessed_by_other.presence,
+        details: details,
+        product_ids: product_ids
+      })
+    end
+  end
+end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -5,6 +5,7 @@ class UpdateRiskAssessment
            :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :details, :product_ids, :risk_assessment_file, to: :context
 
   def call
+    @previous_product_ids = risk_assessment.product_ids
     ActiveRecord::Base.transaction do
       risk_assessment.update!({
         assessed_on: assessed_on,
@@ -16,6 +17,26 @@ class UpdateRiskAssessment
         details: details,
         product_ids: product_ids
       })
+      create_audit_activity
     end
+  end
+
+private
+
+  def create_audit_activity
+    AuditActivity::RiskAssessment::RiskAssessmentUpdated.create!(
+      source: UserSource.new(user: user),
+      investigation: risk_assessment.investigation,
+      metadata: audit_activity_metadata,
+      title: nil,
+      body: nil
+    )
+  end
+
+  def audit_activity_metadata
+    AuditActivity::RiskAssessment::RiskAssessmentUpdated.build_metadata(
+      risk_assessment: risk_assessment,
+      previous_product_ids: @previous_product_ids
+    )
   end
 end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -25,8 +25,9 @@ class UpdateRiskAssessment
         product_ids: product_ids
       }
 
-      if risk_assessment_file
-        risk_assessment.risk_assessment_file = risk_assessment_file
+      if risk_assessment_file != risk_assessment.risk_assessment_file
+        risk_assessment.risk_assessment_file.detach
+        risk_assessment.risk_assessment_file.attach(risk_assessment_file)
       end
 
       break if no_changes?

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -4,6 +4,9 @@ class UpdateRiskAssessment
   delegate :risk_assessment, :user, :assessed_on, :risk_level, :custom_risk_level,
            :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :details, :product_ids, :risk_assessment_file, to: :context
 
+  delegate :investigation, to: :risk_assessment
+
+
   def call
     @previous_product_ids = risk_assessment.product_ids
     ActiveRecord::Base.transaction do
@@ -18,6 +21,7 @@ class UpdateRiskAssessment
         product_ids: product_ids
       })
       create_audit_activity
+      send_notification_email
     end
   end
 
@@ -26,7 +30,7 @@ private
   def create_audit_activity
     AuditActivity::RiskAssessment::RiskAssessmentUpdated.create!(
       source: UserSource.new(user: user),
-      investigation: risk_assessment.investigation,
+      investigation: investigation,
       metadata: audit_activity_metadata,
       title: nil,
       body: nil
@@ -38,5 +42,26 @@ private
       risk_assessment: risk_assessment,
       previous_product_ids: @previous_product_ids
     )
+  end
+
+  def send_notification_email
+    entities_to_notify.each do |recipient|
+      email = recipient.is_a?(Team) ? recipient.team_recipient_email : recipient.email
+
+      NotifyMailer.investigation_updated(
+        investigation.pretty_id,
+        recipient.name,
+        email,
+        "#{context.activity.source.show(recipient)} edited a corrective action on the #{investigation.case_type}.",
+        "Risk assessment edited for #{investigation.case_type.upcase_first}"
+      ).deliver_later
+    end
+  end
+
+  def entities_to_notify
+    return [] if user == investigation.owner_user
+    return [investigation.owner_user, investigation.owner_team].compact if investigation.owner_team.email?
+
+    investigation.owner_team.users.active.where.not(id: user.id)
   end
 end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -11,6 +11,8 @@ class UpdateRiskAssessment
     context.fail!(error: "No user supplied") unless user.is_a?(User)
 
     @previous_product_ids = risk_assessment.product_ids
+    @previous_attachment_filename = risk_assessment.risk_assessment_file.filename
+
     ActiveRecord::Base.transaction do
       risk_assessment.attributes = {
         assessed_on: assessed_on,
@@ -22,6 +24,10 @@ class UpdateRiskAssessment
         details: details,
         product_ids: product_ids
       }
+
+      if risk_assessment_file
+        risk_assessment.risk_assessment_file = risk_assessment_file
+      end
 
       break if no_changes?
 
@@ -55,7 +61,8 @@ private
   def audit_activity_metadata
     AuditActivity::RiskAssessment::RiskAssessmentUpdated.build_metadata(
       risk_assessment: risk_assessment,
-      previous_product_ids: @previous_product_ids
+      previous_product_ids: @previous_product_ids,
+      previous_attachment_filename: @previous_attachment_filename
     )
   end
 

--- a/app/views/investigations/activities/risk_assessment/_risk_assessment_updated.html.erb
+++ b/app/views/investigations/activities/risk_assessment/_risk_assessment_updated.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-body">
+
+  <p>Changes:</p>
+
+  <% if activity.new_assessed_on %>
+    Date of assessment: <b><%= activity.new_assessed_on.to_s(:govuk) %></b><br>
+  <% end %>
+
+  <% if activity.risk_level_changed? %>
+    Risk level: <b><%= activity.new_risk_level_description %></b><br>
+  <% end %>
+
+  <% if activity.assessed_by_changed? %>
+    Assessed by: <b><%= risk_assessed_by(team: activity.new_assessed_by_team, business: activity.new_assessed_by_business, other: activity.new_assessed_by_other) %></b><br>
+  <% end %>
+
+  <% if activity.products_changed? %>
+    <%= "Product".pluralize(activity.new_products.count) %> assessed: <b><%= to_sentence(activity.new_products.collect {|p| link_to(p.name, p) }) %></b><br>
+  <% end %>
+
+  <% if activity.new_details %>
+    Further details: <b><%= activity.new_details %></b><br>
+  <% end %>
+</div>
+
+<%= link_to "View risk assessment", investigation_risk_assessment_path(activity.investigation, activity.risk_assessment_id) %>

--- a/app/views/investigations/activities/risk_assessment/_risk_assessment_updated.html.erb
+++ b/app/views/investigations/activities/risk_assessment/_risk_assessment_updated.html.erb
@@ -18,6 +18,10 @@
     <%= "Product".pluralize(activity.new_products.count) %> assessed: <b><%= to_sentence(activity.new_products.collect {|p| link_to(p.name, p) }) %></b><br>
   <% end %>
 
+  <% if activity.new_filename %>
+    Attached: <b><%= activity.new_filename %></b><br>
+  <% end %>
+
   <% if activity.new_details %>
     Further details: <b><%= activity.new_details %></b><br>
   <% end %>

--- a/app/views/investigations/risk_assessments/_fields.html.erb
+++ b/app/views/investigations/risk_assessments/_fields.html.erb
@@ -1,0 +1,93 @@
+<%= form.govuk_date_input :assessed_on, legend: "Date of assessment", hint: "For example, 31 1 2020" %>
+
+<%- custom = capture do %>
+  <%= form.govuk_input :custom_risk_level,
+    label: "Other risk level",
+    label_classes: "govuk-visually-hidden",
+    classes: "govuk-input--width-20"
+  %>
+<% end %>
+
+<% radio_items = (Investigation.risk_levels.keys - ["other"]).map do |level|
+    { text: t("investigations.risk_level.show.levels.#{level}"), value: level }
+   end
+   radio_items.push(text: "Other", value: "other", conditional: { html: custom })
+%>
+
+<%= form.govuk_radios :risk_level,
+  legend: "What was the risk level?",
+  items: radio_items
+%>
+
+
+<%- teams_html = capture do %>
+  <%= form.govuk_select :assessed_by_team_id, label: "Choose team", items: risk_assessment_form.other_teams %>
+<% end %>
+
+<%- businesses_html = capture do %>
+  <%= form.govuk_select :assessed_by_business_id,
+    label: "Choose business",
+    hint: safe_join(["If the business isn’t listed, you should ", link_to("add it to the case", new_investigation_business_path(@investigation)), " first."]),
+    items: risk_assessment_form.businesses %>
+<% end %>
+
+<%- someone_else_html = capture do %>
+  <%= form.govuk_input :assessed_by_other, label: "Organisation name" %>
+<% end %>
+
+<% assessed_by_radio_items = []
+
+  assessed_by_radio_items.push(text: current_user.team.name, value: :my_team)
+  assessed_by_radio_items.push(text: "Another team or market surveilance authority", value: :another_team, conditional: { html: teams_html })
+  assessed_by_radio_items.push(text: "A business related to the case", value: :business, conditional: { html: businesses_html }) unless risk_assessment_form.businesses.length == 1
+  assessed_by_radio_items.push(text: "Someone else", value: :other, conditional: { html: someone_else_html })
+
+%>
+
+<%= form.govuk_radios :assessed_by,
+  legend: "Who completed the assessment?",
+  items: assessed_by_radio_items
+%>
+
+<% if risk_assessment_form.products.length > 1 %>
+  <%= form.govuk_checkboxes :product_ids,
+    legend: "Which products were assessed?",
+    hint: "You must choose at least one. Only products already added to the case are listed.",
+    items: risk_assessment_form.products
+  %>
+<% else %>
+
+  <h2 class="govuk-heading-m">Product assessed</h2>
+
+  <p class="govuk-body"><%= risk_assessment_form.products.first[:text] %></p>
+
+  <%= form.fields_for :product_ids do |field| %>
+    <%= field.hidden_field nil, value: risk_assessment_form.products.first[:value] %>
+  <% end %>
+<% end %>
+
+<% if form.object.risk_assessment_file&.attached? %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Upload the risk assessment</legend>
+    <p id="current-attachment-details">
+      Currently selected file:
+      <%= link_to form.object.risk_assessment_file.filename, form.object.risk_assessment_file.blob, target: "_blank", rel: 'noopener' %>
+    </p>
+
+    <%= govukDetails(summaryText: "Replace this file") do %>
+      <%= form.govuk_file_upload :risk_assessment_file,
+        label: "Select file",
+        label_classes: "govuk-label--s"
+      %>
+    <% end %>
+  </fieldset>
+<% else %>
+  <%= form.govuk_file_upload :risk_assessment_file,
+    label: "Upload the risk assessment",
+    label_classes: "govuk-label--m"
+  %>
+<% end %>
+
+<%= form.govuk_text_area :details,
+  label: "Further details (optional)"
+%>

--- a/app/views/investigations/risk_assessments/_fields.html.erb
+++ b/app/views/investigations/risk_assessments/_fields.html.erb
@@ -66,12 +66,12 @@
   <% end %>
 <% end %>
 
-<% if form.object.risk_assessment_file&.attached? %>
+<% if form.object.old_file.present? %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Upload the risk assessment</legend>
     <p id="current-attachment-details">
       Currently selected file:
-      <%= link_to form.object.risk_assessment_file.filename, form.object.risk_assessment_file.blob, target: "_blank", rel: 'noopener' %>
+      <%= link_to form.object.old_file.filename, form.object.old_file.blob, target: "_blank", rel: 'noopener' %>
     </p>
 
     <%= govukDetails(summaryText: "Replace this file") do %>

--- a/app/views/investigations/risk_assessments/edit.html.erb
+++ b/app/views/investigations/risk_assessments/edit.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
+      <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
 
         <%= error_summary @risk_assessment_form.errors %>
         <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
@@ -21,7 +21,7 @@
 
         <%= render "fields", form: form, risk_assessment_form: @risk_assessment_form %>
 
-        <%= govukButton(text: "Add risk assessment") %>
+        <%= govukButton(text: "Update risk assessment") %>
       <% end %>
 
     </div>

--- a/app/views/investigations/risk_assessments/edit.html.erb
+++ b/app/views/investigations/risk_assessments/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_heading =  "Add risk assessment" %>
+<% page_heading =  "Edit risk assessment" %>
 <%= page_title page_heading, errors: @risk_assessment_form.errors.any? %>
 <% content_for :back_link do %>
   <%= govukBackLink(

--- a/app/views/investigations/risk_assessments/show.html.erb
+++ b/app/views/investigations/risk_assessments/show.html.erb
@@ -43,7 +43,7 @@
             text: "Assessed by"
           },
           value: {
-            text: risk_assessed_by(@risk_assessment)
+            text: risk_assessed_by(team: @risk_assessment.assessed_by_team, business: @risk_assessment.assessed_by_business, other: @risk_assessment.assessed_by_other)
           }
         },
         {

--- a/app/views/investigations/risk_assessments/show.html.erb
+++ b/app/views/investigations/risk_assessments/show.html.erb
@@ -69,6 +69,10 @@
       <% end %>
 
     <%= govukSummaryList(rows: rows) %>
+
+    <% if policy(@investigation).update? %>
+      <p class="govuk-body"><%= link_to "Edit risk assessment", edit_investigation_risk_assessment_path(@investigation, @risk_assessment), class: "govuk-link" %></p>
+    <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m">Attachment</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
       resource :comment, only: %i[create new]
     end
 
-    resources :risk_assessments, controller: "investigations/risk_assessments", path: "risk-assessments", only: %i[new create show] do
+    resources :risk_assessments, controller: "investigations/risk_assessments", path: "risk-assessments", only: %i[new create show edit update] do
       resource :update_case_risk_level, only: %i[show update], path: "update-case-risk-level", controller: "investigations/update_case_risk_level_from_risk_assessment"
     end
 

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -63,6 +63,12 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
     expect(page).to have_text("You must choose at least one product")
     expect(page).to have_text("You must upload the risk assessment")
 
+    attach_file "Upload the risk assessment", risk_assessment_file
+
+    click_button "Add risk assessment"
+
+    expect(page).not_to have_text("You must upload the risk assessment")
+
     within_fieldset("Date of assessment") do
       fill_in("Day", with: "3")
       fill_in("Month", with: "4")

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
-  let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/new_risk_assessment.txt") }
+  let(:risk_assessment_file_path) { Rails.root + "test/fixtures/files/new_risk_assessment.txt" }
+  let(:risk_assessment_file) { Rack::Test::UploadedFile.new(risk_assessment_file_path) }
 
   let(:user) { create(:user, :activated, name: "Joe Bloggs") }
   let(:teddy_bear) { create(:product, name: "Teddy Bear") }
@@ -73,6 +74,11 @@ RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch
 
     within_fieldset("Which products were assessed?") do
       uncheck "Teddy Bear"
+    end
+
+    within_fieldset("Upload the risk assessment") do
+      find("span", text: "Replace this file").click
+      attach_file "Select file", risk_assessment_file_path
     end
 
     click_button "Update risk assessment"

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
+  let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/new_risk_assessment.txt") }
+
+  let(:user) { create(:user, :activated) }
+  let(:teddy_bear) { create(:product, name: "Teddy Bear") }
+  let(:doll) { create(:product, name: "Doll") }
+
+  let(:investigation) { create(:allegation, creator: user, products: [teddy_bear, doll]) }
+
+  let(:team) { create(:team, name: "MyCouncil Trading Standards") }
+
+  let!(:risk_assessment) do
+    create(:risk_assessment,
+           investigation: investigation,
+           assessed_on: Date.parse("2020-01-02"),
+           assessed_by_team: team,
+           risk_level: :serious,
+           products: [teddy_bear],
+           risk_assessment_file: risk_assessment_file)
+  end
+
+  scenario "Editing a risk assessment (with validation errors)" do
+    sign_in(user)
+    visit "/cases/#{investigation.pretty_id}"
+
+    click_link "View risk assessment"
+
+    expect_to_be_on_risk_assessement_for_a_case_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
+
+    click_link "Edit risk assessment"
+
+    expect_to_be_on_edit_risk_assessement_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
+
+    # Expect page to be pre-filled with existing values
+    within_fieldset("Date of assessment") do
+      expect(page).to have_field("Day", with: "2")
+      expect(page).to have_field("Month", with: "1")
+      expect(page).to have_field("Year", with: "2020")
+    end
+
+    within_fieldset("What was the risk level?") do
+      expect(page).to have_checked_field("Serious risk")
+    end
+
+    within_fieldset("Who completed the assessment?") do
+      expect(page).to have_checked_field("Another team or market surveilance authority")
+
+      expect(page).to have_select("Choose team", selected: "MyCouncil Trading Standards")
+    end
+
+    within_fieldset("Which products were assessed?") do
+      expect(page).to have_checked_field("Teddy Bear")
+      expect(page).to have_unchecked_field("Doll")
+    end
+
+    expect(page).to have_text("new_risk_assessment.txt")
+  end
+end

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -3,11 +3,16 @@ require "rails_helper"
 RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
   let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/new_risk_assessment.txt") }
 
-  let(:user) { create(:user, :activated) }
+  let(:user) { create(:user, :activated, name: "Joe Bloggs") }
   let(:teddy_bear) { create(:product, name: "Teddy Bear") }
   let(:doll) { create(:product, name: "Doll") }
 
-  let(:investigation) { create(:allegation, creator: user, products: [teddy_bear, doll]) }
+  let(:investigation) do
+    create(:allegation,
+           creator: user,
+           risk_level: :serious,
+           products: [teddy_bear, doll])
+  end
 
   let(:team) { create(:team, name: "MyCouncil Trading Standards") }
 
@@ -93,10 +98,33 @@ RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch
 
     click_button "Update risk assessment"
 
+    expect_to_be_on_update_case_risk_level_from_risk_assessment_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_content("The risk assessment says the level of risk is medium-high risk.")
+
+    within_fieldset("Would you like to match the case risk level to the risk assessment level?") do
+      choose("Yes, set the case risk level to medium-high risk")
+    end
+
+    click_button "Set risk level"
+
     expect_to_be_on_risk_assessement_for_a_case_page(case_id: investigation.pretty_id, risk_assessment_id: risk_assessment.id)
 
     expect(page).to have_summary_item(key: "Risk level",          value: "Medium-high risk")
     expect(page).to have_summary_item(key: "Assessed by",         value: "RiskAssessmentsRUs")
     expect(page).to have_summary_item(key: "Product assessed",    value: "Doll")
+
+    click_link "Back to allegation"
+    expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
+
+    click_link "Activity"
+    expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_content("Risk assessment edited")
+    expect(page).to have_content("Edited by Joe Bloggs")
+    expect(page).to have_content("Changes:")
+    expect(page).to have_content("Risk level: Medium-high risk")
+    expect(page).to have_content("Assessed by: RiskAssessmentsRUs")
+    expect(page).to have_content("Product assessed: Doll")
   end
 end

--- a/spec/forms/risk_assessment_form_spec.rb
+++ b/spec/forms/risk_assessment_form_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
   let(:custom_risk_level) { "" }
   let(:product_ids) { [create(:product).id] }
   let(:details) { "" }
+  let(:old_file) { nil }
   let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/test_result.txt") }
 
   let(:form) do
@@ -29,6 +30,7 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
       risk_level: risk_level,
       custom_risk_level: custom_risk_level,
       product_ids: product_ids,
+      old_file: old_file,
       risk_assessment_file: risk_assessment_file,
       details: details
     )
@@ -196,6 +198,24 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
 
       it "is not valid" do
         expect(form).not_to be_valid
+      end
+    end
+
+    context "with no risk_assessment_file" do
+      let(:risk_assessment_file) { nil }
+
+      context "when old_file is not present" do
+        it "is not valid" do
+          expect(form).not_to be_valid
+        end
+      end
+
+      context "when old_file is present" do
+        let(:old_file) { Rack::Test::UploadedFile.new("test/fixtures/files/test_result.txt") }
+
+        it "is valid" do
+          expect(form).to be_valid
+        end
       end
     end
   end

--- a/spec/forms/risk_assessment_form_spec.rb
+++ b/spec/forms/risk_assessment_form_spec.rb
@@ -199,4 +199,86 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
       end
     end
   end
+
+  describe "attributes" do
+    describe "#custom_risk_level" do
+      let(:custom_risk_level) { "Medium risk" }
+
+      context "when risk_level is set to :other" do
+        let(:risk_level) { :other }
+
+        it "returns the value set" do
+          expect(form.custom_risk_level).to eq "Medium risk"
+        end
+      end
+
+      context "when risk_level is not set to :other" do
+        let(:risk_level) { :serious }
+
+        it "always returns nil" do
+          expect(form.custom_risk_level).to be nil
+        end
+      end
+    end
+
+    describe "#assessed_by_business_id" do
+      let(:assessed_by_business_id) { "123" }
+
+      context "when assessed_by is set to 'business'" do
+        let(:assessed_by) { "business" }
+
+        it "returns the value set" do
+          expect(form.assessed_by_business_id).to eq "123"
+        end
+      end
+
+      context "when assessed_by is set another option" do
+        let(:assessed_by) { "my_team" }
+
+        it "always returns nil" do
+          expect(form.assessed_by_business_id).to be nil
+        end
+      end
+    end
+
+    describe "#assessed_by_team_id" do
+      let(:assessed_by_team_id) { "123" }
+
+      context "when assessed_by is set to 'another_team'" do
+        let(:assessed_by) { "another_team" }
+
+        it "returns the value set" do
+          expect(form.assessed_by_team_id).to eq "123"
+        end
+      end
+
+      context "when assessed_by is set another option" do
+        let(:assessed_by) { "business" }
+
+        it "always returns nil" do
+          expect(form.assessed_by_team_id).to be nil
+        end
+      end
+    end
+
+    describe "#assessed_by_other" do
+      let(:assessed_by_other) { "Another Org Ltd" }
+
+      context "when assessed_by is set to 'other'" do
+        let(:assessed_by) { "other" }
+
+        it "returns the value set" do
+          expect(form.assessed_by_other).to eq "Another Org Ltd"
+        end
+      end
+
+      context "when assessed_by is set another option" do
+        let(:assessed_by) { "business" }
+
+        it "always returns nil" do
+          expect(form.assessed_by_other).to be nil
+        end
+      end
+    end
+  end
 end

--- a/spec/services/update_risk_assessment_spec.rb
+++ b/spec/services/update_risk_assessment_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_antivirus, :with_test_queue_adapter do
+  let(:product1) { create(:product) }
+  let(:product2) { create(:product) }
+  let(:team) { create(:team, name: "Team 2") }
+  let(:user) { create(:user, name: "User 2", team: team) }
+
+  let(:investigation) { create(:allegation) }
+
+  let(:risk_assessment) do
+    create(:risk_assessment,
+           investigation: investigation,
+           assessed_on: Date.parse("2019-01-01"),
+           risk_level: :low,
+           custom_risk_level: nil,
+           assessed_by_team: user.team,
+           assessed_by_business: nil,
+           assessed_by_other: nil,
+           details: "More details",
+           products: [product1])
+  end
+
+  describe ".call" do
+    context "with no parameters" do
+      let(:result) { described_class.call }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with no user parameter" do
+      let(:result) { described_class.call(risk_assessment: risk_assessment) }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with no risk_assessment parameter" do
+      let(:result) { described_class.call(user: user) }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with the required parameters" do
+      let(:update_risk_assessment) do
+        described_class.call(
+          risk_assessment: risk_assessment,
+          user: user,
+          assessed_on: assessed_on,
+          risk_level: risk_level,
+          custom_risk_level: custom_risk_level,
+          assessed_by_team_id: assessed_by_team_id,
+          assessed_by_business_id: assessed_by_business_id,
+          assessed_by_other: assessed_by_other,
+          details: details,
+          product_ids: product_ids
+        )
+      end
+
+      context "when no changes have been made" do
+        let(:assessed_on) { Date.parse("2019-01-01") }
+        let(:risk_level) { :low }
+        let(:custom_risk_level) { nil }
+        let(:assessed_by_team_id) { user.team.id }
+        let(:assessed_by_business_id) { nil }
+        let(:assessed_by_other) { nil }
+        let(:details) { "More details" }
+        let(:product_ids) { [product1.id] }
+
+        let(:updated_at) { 1.hour.ago }
+
+        before do
+          # Have to do this after setup as attaching the document also updates the
+          # updated_at timestamp
+          risk_assessment.update_column(:updated_at, updated_at)
+        end
+
+        it "does not generate an activity entry" do
+          update_risk_assessment
+
+          expect(risk_assessment.investigation.activities.where(type: AuditActivity::RiskAssessment::RiskAssessmentUpdated.to_s)).to eq []
+        end
+
+        it "does not send any case updated emails" do
+          expect { update_risk_assessment }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
+        end
+      end
+
+      context "when changes have been made" do
+        let(:assessed_on) { Date.parse("2020-01-02") }
+        let(:risk_level) { :serious }
+        let(:custom_risk_level) { nil }
+        let(:assessed_by_team_id) { nil }
+        let(:assessed_by_business_id) { nil }
+        let(:assessed_by_other) { "OtherBusiness Ltd" }
+        let(:details) { "Updated details" }
+        let(:product_ids) { [product2.id] }
+
+        it "updates the risk assessment", :aggregate_failures do
+          update_risk_assessment
+
+          expect(risk_assessment.assessed_on).to eq(Date.parse("2020-01-02"))
+          expect(risk_assessment.risk_level).to eq("serious")
+          expect(risk_assessment.assessed_by_team).to be nil
+          expect(risk_assessment.assessed_by_business).to be nil
+          expect(risk_assessment.assessed_by_other).to eq("OtherBusiness Ltd")
+          expect(risk_assessment.details).to eq("Updated details")
+        end
+
+        it "updates the products associated with the risk assessment" do
+          update_risk_assessment
+
+          expect(risk_assessment.products).to eq([product2])
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it "creates an activity entry" do
+          update_risk_assessment
+
+          activity_entry = risk_assessment.investigation.activities.where(type: AuditActivity::RiskAssessment::RiskAssessmentUpdated.to_s).order(:created_at).last
+
+          expect(activity_entry.metadata).to eql({
+            "risk_assessment_id" => risk_assessment.id,
+            "updates" => {
+              "assessed_by_other" => [nil, "OtherBusiness Ltd"],
+              "assessed_by_team_id" => [user.team.id, nil],
+              "assessed_on" => %w[2019-01-01 2020-01-02],
+              "details" => ["More details", "Updated details"],
+              "product_ids" => [[product1.id], [product2.id]],
+              "risk_level" => %w[low serious]
+            }
+          })
+        end
+        # rubocop:enable RSpec/ExampleLength
+
+        it "sends a notification email to the case owner" do
+          expect { update_risk_assessment }.to have_enqueued_mail(NotifyMailer, :investigation_updated).with(
+            risk_assessment.investigation.pretty_id,
+            investigation.owner_user.name,
+            investigation.owner_user.email,
+            "User 2 (Team 2) edited a risk assessment on the allegation.",
+            "Risk assessment edited for Allegation"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/update_risk_assessment_spec.rb
+++ b/spec/services/update_risk_assessment_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_
            assessed_by_business: nil,
            assessed_by_other: nil,
            details: "More details",
+           risk_assessment_file: Rack::Test::UploadedFile.new("test/fixtures/files/old_risk_assessment.txt"),
            products: [product1])
   end
 
@@ -58,7 +59,8 @@ RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_
           assessed_by_business_id: assessed_by_business_id,
           assessed_by_other: assessed_by_other,
           details: details,
-          product_ids: product_ids
+          product_ids: product_ids,
+          risk_assessment_file: risk_assessment_file
         )
       end
 
@@ -71,7 +73,7 @@ RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_
         let(:assessed_by_other) { nil }
         let(:details) { "More details" }
         let(:product_ids) { [product1.id] }
-
+        let(:risk_assessment_file) { nil }
         let(:updated_at) { 1.hour.ago }
 
         before do
@@ -100,6 +102,7 @@ RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_
         let(:assessed_by_other) { "OtherBusiness Ltd" }
         let(:details) { "Updated details" }
         let(:product_ids) { [product2.id] }
+        let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/new_risk_assessment.txt") }
 
         it "updates the risk assessment", :aggregate_failures do
           update_risk_assessment
@@ -131,8 +134,9 @@ RSpec.describe UpdateRiskAssessment, :with_stubbed_elasticsearch, :with_stubbed_
               "assessed_by_team_id" => [user.team.id, nil],
               "assessed_on" => %w[2019-01-01 2020-01-02],
               "details" => ["More details", "Updated details"],
+              "filename" => ["old_risk_assessment.txt", "new_risk_assessment.txt"],
               "product_ids" => [[product1.id], [product2.id]],
-              "risk_level" => %w[low serious]
+              "risk_level" => %w[low serious],
             }
           })
         end

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -524,8 +524,16 @@ module PageExpectations
     expect_page_to_have_h1("Add risk assessment")
   end
 
-  def expect_to_be_on_risk_assessement_for_a_case_page(case_id:)
-    expect(page).to have_current_path(/\/cases\/#{case_id}\/risk\-assessments\/\d+/)
+  def expect_to_be_on_risk_assessement_for_a_case_page(case_id:, risk_assessment_id: nil)
+    if risk_assessment_id
+      expect(page).to have_current_path("/cases/#{case_id}/risk-assessments/#{risk_assessment_id}")
+    else
+      expect(page).to have_current_path(/\/cases\/#{case_id}\/risk\-assessments\/\d+/)
+    end
+  end
+
+  def expect_to_be_on_edit_risk_assessement_page(case_id:, risk_assessment_id:)
+    expect(page).to have_current_path("/cases/#{case_id}/risk-assessments/#{risk_assessment_id}/edit")
   end
 
   def expect_to_be_on_update_case_risk_level_from_risk_assessment_page(case_id:, risk_assessment_id: nil)


### PR DESCRIPTION
This adds ability to edit and update risk assessments.

The form is identical to the "Add risk assessment" form, except for the title, and the file upload, which is contained within a "Replace this file" reveal link.

Upon updating, if the risk level is not the same as the case risk level, the user will be prompted to set (or change) the case risk level.

An activity timeline entry is generated, and notification emails are sent, if any of the of the fields are changed (but not if the form is saved with no changes).

Trello card: https://trello.com/c/BDKhRWce/582-5-edit-risk-assessment

## Screenshots

### Risk assessment page showing new 'Edit' link

<img width="1208" alt="Screenshot 2020-08-24 at 16 39 34" src="https://user-images.githubusercontent.com/30665/91065933-f911e000-e628-11ea-94b2-58b952dec73c.png">

### Edit risk assessment form

![edit-page](https://user-images.githubusercontent.com/30665/91065966-016a1b00-e629-11ea-94e0-6ba9000323af.png)
