### PR TITLE
Fix error when displaying activity for risk assessment updated

### DIFF
--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -43,7 +43,10 @@ class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
   end
 
   def new_assessed_on
-    updates["assessed_on"]&.second
+    date = updates["assessed_on"]&.second
+    return nil unless date
+
+    Date.parse(date)
   end
 
   def new_risk_level

--- a/spec/features/edit_a_risk_assessment_spec.rb
+++ b/spec/features/edit_a_risk_assessment_spec.rb
@@ -63,6 +63,12 @@ RSpec.feature "Editing a risk assessment on a case", :with_stubbed_elasticsearch
 
     expect(page).to have_text("new_risk_assessment.txt")
 
+    # Update the date assessed to test activity rendering
+    within_fieldset("Date of assessment") do
+      fill_in "Day", with: "10"
+      fill_in "Month", with: "2"
+    end
+
     # Update some of the fields to include a validation error
     within_fieldset("What was the risk level?") do
       choose "Other"

--- a/spec/fixtures/files/risk_assessment.txt
+++ b/spec/fixtures/files/risk_assessment.txt
@@ -1,0 +1,1 @@
+risk_assessment.txt

--- a/spec/models/audit_activity/risk_assessment/risk_assessment_updated_spec.rb
+++ b/spec/models/audit_activity/risk_assessment/risk_assessment_updated_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentUpdated, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_antivirus do
+  subject(:activity) { investigation.reload.activities.first }
+
+  let(:investigation) { create(:allegation, :with_products, creator: user) }
+  let(:user) { create(:user) }
+  let(:date) { Time.zone.today }
+  let(:new_date) { Time.zone.today - 10.days }
+  let(:file) { fixture_file_upload(file_fixture("risk_assessment.txt")) }
+  let(:risk_assessment) do
+    AddRiskAssessmentToCase.call!(
+      investigation: investigation,
+      user: user,
+      assessed_on: date,
+      assessed_by_team_id: user.team.id,
+      risk_level: "high",
+      details: "Test",
+      product_ids: investigation.product_ids,
+      risk_assessment_file: file
+    ).risk_assessment
+  end
+
+  before do
+    UpdateRiskAssessment.call!(
+      risk_assessment: risk_assessment,
+      user: user,
+      assessed_on: new_date,
+      assessed_by_team_id: user.team.id,
+      risk_level: "serious",
+      details: "Test 2",
+      product_ids: investigation.product_ids
+    )
+  end
+
+  describe "#new_assessed_on" do
+    context "when the date has changed" do
+      it "returns a Date object" do
+        expect(activity.new_assessed_on).to be_a(Date)
+      end
+
+      it "returns the new date" do
+        expect(activity.new_assessed_on).to eq(new_date)
+      end
+    end
+
+    context "when the date has not changed" do
+      let(:new_date) { date }
+
+      it "returns nil" do
+        expect(activity.new_assessed_on).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Zx9Q2pIm/724-edit-risk-assessment-leave-activity-tab-in-error-state

## Description
This fixes [an exception](https://sentry.io/organizations/beis/issues/1858324804/?environment=staging&project=1329381&query=is%3Aunresolved) when displaying the audit activity for an updated risk assessment where the assessed on date had changed. The view was expecting a `Date` object but the model was returning a `String`.

Generally we are missing unit test coverage on this activity model which needs further backfilling. I've added unit tests for the relevant method, and modified the feature spec to test changing the date as well.

Steps to reproduce:

1. Add a risk assessment to a case
1. Edit the risk assessment and change the assessed on date
1. Go to the case activity page