### PR TITLE
Ability to delete a team

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Style/TrailingCommaInArguments:
 Rails/HelperInstanceVariable:
   Enabled: false
 
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 6
 

--- a/Gemfile
+++ b/Gemfile
@@ -46,16 +46,19 @@ gem "wicked", "~> 1.3"
 
 gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.7.0", require: "govuk_design_system"
 
+group :development, :test do
+  gem "dotenv-rails", "~> 2.7"
+  gem "pry", "~> 0.13"
+  gem "pry-byebug", "~> 3.9"
+  gem "pry-doc", "~> 1.1"
+end
+
 group :development do
   gem "awesome_print", "~> 1.8", require: "ap"
   gem "byebug", "~> 11.1"
   gem "debase", "~> 0.2"
-  gem "dotenv-rails", "~> 2.7"
   gem "listen", "~> 3.2"
   gem "m", "~> 1.5"
-  gem "pry", "~> 0.13"
-  gem "pry-byebug", "~> 3.9"
-  gem "pry-doc", "~> 1.1"
   gem "ruby-debug-ide", "~> 0.7"
   gem "solargraph", "~> 0.39"
   gem "spring", "~> 2.1"

--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -86,7 +86,7 @@ private
   # rubocop:enable Naming/MemoizedInstanceVariableName
 
   def teams_without_access
-    Team.where.not(id: team_ids_with_access).order(:name)
+    Team.not_deleted.where.not(id: team_ids_with_access).order(:name)
   end
 
   def team_ids_with_access

--- a/app/helpers/investigations/user_filters_helper.rb
+++ b/app/helpers/investigations/user_filters_helper.rb
@@ -1,6 +1,6 @@
 module Investigations::UserFiltersHelper
   def entities
-    User.get_owners(except: current_user).decorate + Team.all_with_organisation.decorate
+    User.get_owners(except: current_user).decorate + Team.not_deleted.decorate
   end
 
   def case_owner_is(form)

--- a/app/models/audit_activity/investigation/team_added.rb
+++ b/app/models/audit_activity/investigation/team_added.rb
@@ -11,6 +11,10 @@ class AuditActivity::Investigation::TeamAdded < AuditActivity::Investigation::Ba
     }
   end
 
+  def team
+    Team.find(metadata["team"]["id"])
+  end
+
 private
 
   # This is handled by the AddTeamToCase service, but this override is required

--- a/app/models/audit_activity/investigation/team_deleted.rb
+++ b/app/models/audit_activity/investigation/team_deleted.rb
@@ -9,6 +9,10 @@ class AuditActivity::Investigation::TeamDeleted < AuditActivity::Investigation::
     }
   end
 
+  def team
+    Team.find(metadata["team"]["id"])
+  end
+
 private
 
   # This is handled by RemoveTeamFromCase, but this override is required to

--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -14,6 +14,6 @@ module Deletable
   def mark_as_deleted!
     return if deleted?
 
-    update!(deleted_at: Time.current)
+    update!(deleted_at: Time.zone.now)
   end
 end

--- a/app/models/concerns/deletable.rb
+++ b/app/models/concerns/deletable.rb
@@ -1,0 +1,19 @@
+module Deletable
+  extend ActiveSupport::Concern
+
+  included do
+    def self.not_deleted
+      where(deleted_at: nil)
+    end
+  end
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  def mark_as_deleted!
+    return if deleted?
+
+    update!(deleted_at: Time.current)
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,10 +12,6 @@ class Team < ApplicationRecord
 
   validates :name, presence: true
 
-  def self.all_with_organisation
-    all.includes(:organisation)
-  end
-
   def display_name(*)
     name
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,29 +1,19 @@
 class Team < ApplicationRecord
+  include Deletable
   include TeamCollaboratorInterface
 
   belongs_to :organisation
   has_many :users, dependent: :restrict_with_exception
 
   has_many :collaborations, dependent: :destroy, as: :collaborator
+  has_many :collaboration_accesses, class_name: "Collaboration::Access", as: :collaborator
+
+  has_many :owner_collaborations, class_name: "Collaboration::Access::OwnerTeam", as: :collaborator
 
   validates :name, presence: true
 
   def self.all_with_organisation
     all.includes(:organisation)
-  end
-
-  def self.not_deleted
-    where(deleted_at: nil)
-  end
-
-  def deleted?
-    deleted_at.present?
-  end
-
-  def mark_as_deleted!
-    return if deleted?
-
-    update!(deleted_at: Time.current)
   end
 
   def display_name(*)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,6 +12,20 @@ class Team < ApplicationRecord
     all.includes(:organisation)
   end
 
+  def self.not_deleted
+    where(deleted_at: nil)
+  end
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  def mark_as_deleted!
+    return if deleted?
+
+    update!(deleted_at: Time.current)
+  end
+
   def display_name(*)
     name
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Deletable
   include UserCollaboratorInterface
 
   INVITATION_EXPIRATION_DAYS = 14
@@ -44,10 +45,6 @@ class User < ApplicationRecord
   # and who have accepted the user declaration
   def self.active
     where(account_activated: true).not_deleted
-  end
-
-  def self.not_deleted
-    where(deleted_at: nil)
   end
 
   def self.current
@@ -107,18 +104,8 @@ class User < ApplicationRecord
     update has_viewed_introduction: true
   end
 
-  def deleted?
-    deleted_at.present?
-  end
-
   def invitation_expired?
     invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
-  end
-
-  def mark_as_deleted!
-    return if deleted?
-
-    update!(deleted_at: Time.zone.now)
   end
 
   # BEGIN: place devise overriden method calls bellow

--- a/app/services/add_team_to_case.rb
+++ b/app/services/add_team_to_case.rb
@@ -20,7 +20,7 @@ class AddTeamToCase
         create_activity_for_team_added!
       end
 
-      send_notification_email
+      send_notification_email unless context.silent
     rescue ActiveRecord::RecordNotUnique
       # Collaborator already added, so return successful but without notifying the team
       # or creating an audit log.

--- a/app/services/change_case_owner.rb
+++ b/app/services/change_case_owner.rb
@@ -31,7 +31,7 @@ class ChangeCaseOwner
     end
 
     investigation.reload
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/services/delete_team.rb
+++ b/app/services/delete_team.rb
@@ -1,0 +1,19 @@
+class DeleteTeam
+  include Interactor
+
+  delegate :team, :new_team, :user, to: :context
+
+  def call
+    context.fail!(error: "No team supplied") unless team.is_a?(Team)
+    context.fail!(error: "No new team supplied") unless new_team.is_a?(Team)
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+    context.fail!(error: "Team already deleted") if team.deleted?
+    context.fail!(error: "New team cannot be deleted") if new_team.deleted?
+
+    ActiveRecord::Base.transaction do
+    end
+  end
+
+private
+
+end

--- a/app/services/delete_team.rb
+++ b/app/services/delete_team.rb
@@ -7,13 +7,86 @@ class DeleteTeam
     context.fail!(error: "No team supplied") unless team.is_a?(Team)
     context.fail!(error: "No new team supplied") unless new_team.is_a?(Team)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
-    context.fail!(error: "Team already deleted") if team.deleted?
-    context.fail!(error: "New team cannot be deleted") if new_team.deleted?
+    context.fail!(error: "Team cannot already be deleted") if team.deleted?
+    context.fail!(error: "New team cannot already be deleted") if new_team.deleted?
 
     ActiveRecord::Base.transaction do
+      team.mark_as_deleted!
+      team.users.update_all(team_id: new_team.id)
+      remove_team_as_owner_from_cases
+      remove_team_as_collaborator_from_cases
     end
   end
 
 private
 
+  def remove_team_as_owner_from_cases
+    team.owner_collaborations.each do |collaboration|
+      next change_case_owner(collaboration.investigation) if collaboration.investigation.owner == team # Team is the ultimate owner
+      collaboration.update!(collaborator_id: new_team.id) # User on the team is the ultimate owner
+    end
+  end
+
+  def change_case_owner(investigation)
+    ChangeCaseOwner.call!(
+      investigation: investigation,
+      owner: new_team,
+      user: user,
+      rationale: change_case_owner_rationale,
+      silent: true
+    )
+  end
+
+  def remove_team_as_collaborator_from_cases
+    team.collaboration_accesses.changeable.each do |collaboration|
+      investigation = collaboration.investigation
+      add_new_team_to_case(investigation, collaboration.class) unless new_team_already_collaborating?(investigation)
+
+      remove_team_from_case(collaboration)
+    end
+  end
+
+  def new_team_already_collaborating?(investigation)
+    investigation.collaboration_accesses.find_by(collaborator_id: new_team.id).present?
+  end
+
+  def add_new_team_to_case(investigation, collaboration_class)
+    AddTeamToCase.call!(
+      investigation: investigation,
+      team: new_team,
+      collaboration_class: collaboration_class,
+      user: user,
+      message: add_remove_team_message,
+      silent: true
+    )
+  end
+
+  def remove_team_from_case(collaboration)
+    RemoveTeamFromCase.call!(
+      collaboration: collaboration,
+      user: user,
+      message: add_remove_team_message,
+      silent: true
+    )
+  end
+
+  def change_case_owner_rationale
+    "#{team_display_name} was merged into #{new_team_display_name} by #{user_display_name}. #{team_display_name} previously owned this case."
+  end
+
+  def add_remove_team_message
+    "#{team_display_name} was merged into #{new_team_display_name} by #{user_display_name}. #{team_display_name} previously had access to this case."
+  end
+
+  def team_display_name
+    team.decorate.display_name(viewer: new_team)
+  end
+
+  def new_team_display_name
+    new_team.decorate.display_name(viewer: new_team)
+  end
+
+  def user_display_name
+    user.decorate.display_name(viewer: new_team)
+  end
 end

--- a/app/services/delete_team.rb
+++ b/app/services/delete_team.rb
@@ -23,6 +23,7 @@ private
   def remove_team_as_owner_from_cases
     team.owner_collaborations.each do |collaboration|
       next change_case_owner(collaboration) if collaboration.investigation.owner == team # Team is the ultimate owner
+
       collaboration.update!(collaborator_id: new_team.id) # User on the team is the ultimate owner
     end
   end

--- a/app/services/remove_team_from_case.rb
+++ b/app/services/remove_team_from_case.rb
@@ -13,7 +13,7 @@ class RemoveTeamFromCase
       create_audit_activity_for_team_deleted!
     end
 
-    send_notification_email
+    send_notification_email unless context.silent
   end
 
 private

--- a/app/views/investigations/ownership/_owner_form.html.slim
+++ b/app/views/investigations/ownership/_owner_form.html.slim
@@ -43,7 +43,7 @@
       render "investigations/ownership/owner_selection",
              form: form,
              key: :select_other_team,
-             items: Team.all,
+             items: Team.not_deleted,
              label: "Select other team name",
              show_all_values: true
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,9 @@ en:
     safe_and_compliant: "Product reported because it is safe and compliant."
   invite_user_to_team:
     invite_sent: "Invite sent to %{email}"
+  delete_team:
+    change_case_owner_rationale: "%{team} was merged into %{new_team} by %{user}. %{team} previously owned this case."
+    add_remove_team_message: "%{team} was merged into %{new_team} by %{user}. %{team} previously had access to this case."
   case:
     badges:
       coronavirus_related: "COVID-19 related case"

--- a/db/migrate/20200911142816_add_deleted_at_to_teams.rb
+++ b/db/migrate/20200911142816_add_deleted_at_to_teams.rb
@@ -1,0 +1,8 @@
+class AddDeletedAtToTeams < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :teams, :deleted_at, :datetime
+    add_index :teams, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_093627) do
+ActiveRecord::Schema.define(version: 2020_09_11_142816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -272,10 +272,12 @@ ActiveRecord::Schema.define(version: 2020_08_26_093627) do
 
   create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.datetime "deleted_at"
     t.string "name"
     t.uuid "organisation_id"
     t.string "team_recipient_email"
     t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_teams_on_deleted_at"
     t.index ["name"], name: "index_teams_on_name"
     t.index ["organisation_id"], name: "index_teams_on_organisation_id"
   end

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -30,4 +30,4 @@ Where `EMAIL` or `ID` is the e-mail address or ID of the user to be deleted. Tas
 cf run-task psd-web "export \$(./env/get-env-from-vcap.sh) && ID=<id> NEW_TEAM_ID=<id> EMAIL=<email address> rake team:delete" --name <task name>
 ```
 
-Case collaborations and users which belong to the team identified by `ID` will be migrated to another team identified by `NEW_TEAM`. The user identified by `EMAIL` will be attributed to the change on all relevant audit activity.
+Case collaborations and users which belong to the team identified by `ID` will be migrated to another team identified by `NEW_TEAM_ID`. The user identified by `EMAIL` will be attributed to the change on all relevant audit activity.

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -23,3 +23,11 @@ cf run-task psd-web "export \$(./env/get-env-from-vcap.sh) && ID=<user ID> rake 
 ```
 
 Where `EMAIL` or `ID` is the e-mail address or ID of the user to be deleted. Task name can be set to anything you like.
+
+## Deleting a Team
+
+```bash
+cf run-task psd-web "export \$(./env/get-env-from-vcap.sh) && ID=<id> NEW_TEAM_ID=<id> EMAIL=<email address> rake team:delete" --name <task name>
+```
+
+Case collaborations and users which belong to the team identified by `ID` will be migrated to another team identified by `NEW_TEAM`. The user identified by `EMAIL` will be attributed to the change on all relevant audit activity.

--- a/lib/tasks/delete_team.rake
+++ b/lib/tasks/delete_team.rake
@@ -1,19 +1,15 @@
 namespace :team do
-  def delete_team(team, new_team, user)
-    result = DeleteTeam.call(team: team, new_team: new_team, user: user)
-
-    raise result.error unless result.success?
-
-    puts "Team #{team.name} successfully marked as deleted."
-    puts "Users and cases assigned to #{new_team.name}"
-  end
-
   desc "Marks the given team as deleted, assigning their cases and users to another team"
   task delete: :environment do
     team = Team.find(ENV.fetch("ID", nil))
     new_team = Team.find(ENV.fetch("NEW_TEAM_ID", nil))
     user = User.find_by!(email: ENV.fetch("EMAIL", nil))
 
-    delete_team(team, new_team, user)
+    result = DeleteTeam.call(team: team, new_team: new_team, user: user)
+
+    raise result.error unless result.success?
+
+    puts "Team #{team.name} successfully marked as deleted."
+    puts "Users and cases assigned to #{new_team.name}"
   end
 end

--- a/lib/tasks/delete_team.rake
+++ b/lib/tasks/delete_team.rake
@@ -1,9 +1,9 @@
 namespace :team do
   desc "Marks the given team as deleted, assigning their cases and users to another team"
   task delete: :environment do
-    team = Team.find(ENV.fetch("ID", nil))
-    new_team = Team.find(ENV.fetch("NEW_TEAM_ID", nil))
-    user = User.find_by!(email: ENV.fetch("EMAIL", nil))
+    team = Team.find(ENV.fetch("ID"))
+    new_team = Team.find(ENV.fetch("NEW_TEAM_ID"))
+    user = User.find_by!(email: ENV.fetch("EMAIL"))
 
     result = DeleteTeam.call(team: team, new_team: new_team, user: user)
 

--- a/lib/tasks/delete_team.rake
+++ b/lib/tasks/delete_team.rake
@@ -1,0 +1,19 @@
+namespace :team do
+  def delete_team(team, new_team, user)
+    result = DeleteTeam.call(team: team, new_team: new_team, user: user)
+
+    raise result.error unless result.success?
+
+    puts "Team #{team.name} successfully marked as deleted."
+    puts "Users and cases assigned to #{new_team.name}"
+  end
+
+  desc "Marks the given team as deleted, assigning their cases and users to another team"
+  task delete: :environment do
+    team = Team.find(ENV.fetch("ID", nil))
+    new_team = Team.find(ENV.fetch("NEW_TEAM_ID", nil))
+    user = User.find_by!(email: ENV.fetch("EMAIL", nil))
+
+    delete_team(team, new_team, user)
+  end
+end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     name { Faker::TvShows::SiliconValley.company }
     team_recipient_email { "#{name.downcase.gsub(/\s/, '.')}@example.com" }
     organisation
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     organisation
 
     trait :deleted do
-      deleted_at { Time.current }
+      deleted_at { Time.zone.now }
     end
   end
 end

--- a/spec/features/add_team_to_case_spec.rb
+++ b/spec/features/add_team_to_case_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Adding a team to a case", :with_stubbed_elasticsearch, :with_stub
   let(:team)           { create(:team, name: "Southampton Trading Standards", team_recipient_email: "enquiries@southampton.gov.uk") }
   let(:user)           { create(:user, :activated, team: create(:team, name: "Portsmouth Trading Standards"), name: "Bob Jones") }
   let(:investigation)  { create(:allegation, read_only_teams: read_only_team, creator: user) }
+  let!(:deleted_team)  { create(:team, :deleted) }
 
   before do
     read_only_team.update!(name: "Birmingham Trading Standards")
@@ -45,6 +46,10 @@ RSpec.feature "Adding a team to a case", :with_stubbed_elasticsearch, :with_stub
     expect(page).to have_selector("a", text: "Select a team to add to the case")
     expect(page).to have_selector("a", text: "Select the permission level the team should have")
     expect(page).to have_selector("a", text: "Select whether you want to include a message")
+
+    # Check deleted teams are not listed
+    expect(page).to have_css("#team option[value=\"#{team.id}\"]")
+    expect(page).not_to have_css("#team option[value=\"#{deleted_team.id}\"]")
 
     select "Southampton Trading Standards", from: "Choose team"
     choose "Edit full case"

--- a/spec/features/add_team_to_case_spec.rb
+++ b/spec/features/add_team_to_case_spec.rb
@@ -48,8 +48,8 @@ RSpec.feature "Adding a team to a case", :with_stubbed_elasticsearch, :with_stub
     expect(page).to have_selector("a", text: "Select whether you want to include a message")
 
     # Check deleted teams are not listed
-    expect(page).to have_css("#team option[value=\"#{team.id}\"]")
-    expect(page).not_to have_css("#team option[value=\"#{deleted_team.id}\"]")
+    expect(page).to have_select("Choose team", with_options: [team.name])
+    expect(page).not_to have_select("Choose team", with_options: [deleted_team.name])
 
     select "Southampton Trading Standards", from: "Choose team"
     choose "Edit full case"

--- a/spec/features/change_ownership_for_investigation_spec.rb
+++ b/spec/features/change_ownership_for_investigation_spec.rb
@@ -9,15 +9,19 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
   let!(:another_inactive_user) { create(:user, :inactive, organisation: user.organisation, team: team) }
   let!(:another_active_user_another_team) { create(:user, :activated, name: "another user in another team", organisation: user.organisation, team: create(:team)) }
   let!(:another_inactive_user_another_team) { create(:user, :inactive, organisation: user.organisation, team: create(:team)) }
+  let!(:deleted_team) { create(:team, :deleted) }
 
   before do
     sign_in(user)
     visit "/cases/#{investigation.pretty_id}/assign/new"
   end
 
-  scenario "does not show inactive users" do
+  scenario "does not show inactive users or teams" do
     expect(page).to have_css("#investigation_select_team_member option[value=\"#{another_active_user.id}\"]")
     expect(page).not_to have_css("#investigation_select_team_member option[value=\"#{another_inactive_user.id}\"]")
+
+    expect(page).to have_css("#investigation_select_other_team option[value=\"#{another_active_user_another_team.team.id}\"]")
+    expect(page).not_to have_css("#investigation_select_other_team option[value=\"#{deleted_team.id}\"]")
 
     expect(page).to have_css("#investigation_select_someone_else option[value=\"#{another_active_user_another_team.id}\"]")
     expect(page).not_to have_css("#investigation_select_someone_else option[value=\"#{another_inactive_user_another_team.id}\"]")

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -19,8 +19,9 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
   let!(:serious_risk_level_investigation) { create(:allegation, creator: user, risk_level: Investigation.risk_levels[:serious]) }
   let!(:high_risk_level_investigation)    { create(:allegation, creator: user, risk_level: Investigation.risk_levels[:high]) }
 
-  let!(:another_active_user) { create(:user, :activated, organisation: user.organisation, team: team) }
-  let!(:another_inactive_user) { create(:user, :inactive, organisation: user.organisation, team: team) }
+  let!(:another_active_user)   { create(:user, :activated, organisation: user.organisation, team: team) }
+  let!(:another_inactive_user) { create(:user, :inactive,  organisation: user.organisation, team: team) }
+  let!(:other_deleted_team)    { create(:team, :deleted) }
 
   let(:restricted_case_title) { "Restricted case title" }
   let(:restricted_case_team) { create(:team, organisation: other_organisation) }
@@ -33,12 +34,18 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
     visit investigations_path
   end
 
-  scenario "selecting filters only shows other active users in the case owner and created by filters" do
+  scenario "selecting filters only shows other active users and teams in the case owner and created by filters" do
+    expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{team.id}\"]")
+    expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{other_team.id}\"]")
     expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{another_active_user.id}\"]")
     expect(page).not_to have_css("#case_owner_is_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
+    expect(page).not_to have_css("#case_owner_is_someone_else_id option[value=\"#{other_deleted_team.id}\"]")
 
+    expect(page).to have_css("#created_by_someone_else_id option[value=\"#{team.id}\"]")
+    expect(page).to have_css("#created_by_someone_else_id option[value=\"#{other_team.id}\"]")
     expect(page).to have_css("#created_by_someone_else_id option[value=\"#{another_active_user.id}\"]")
     expect(page).not_to have_css("#created_by_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
+    expect(page).not_to have_css("#created_by_someone_else_id option[value=\"#{other_deleted_team.id}\"]")
   end
 
   scenario "no filters applied shows all cases" do

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -35,17 +35,15 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
   end
 
   scenario "selecting filters only shows other active users and teams in the case owner and created by filters" do
-    expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{team.id}\"]")
-    expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{other_team.id}\"]")
-    expect(page).to have_css("#case_owner_is_someone_else_id option[value=\"#{another_active_user.id}\"]")
-    expect(page).not_to have_css("#case_owner_is_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
-    expect(page).not_to have_css("#case_owner_is_someone_else_id option[value=\"#{other_deleted_team.id}\"]")
+    within_fieldset("Case owner") do
+      expect(page).to have_select("Name", with_options: [team.name, other_team.name, another_active_user.name])
+      expect(page).not_to have_select("Name", with_options: [another_inactive_user.name, other_deleted_team.name])
+    end
 
-    expect(page).to have_css("#created_by_someone_else_id option[value=\"#{team.id}\"]")
-    expect(page).to have_css("#created_by_someone_else_id option[value=\"#{other_team.id}\"]")
-    expect(page).to have_css("#created_by_someone_else_id option[value=\"#{another_active_user.id}\"]")
-    expect(page).not_to have_css("#created_by_someone_else_id option[value=\"#{another_inactive_user.id}\"]")
-    expect(page).not_to have_css("#created_by_someone_else_id option[value=\"#{other_deleted_team.id}\"]")
+    within_fieldset("Created by") do
+      expect(page).to have_select("Name", with_options: [team.name, other_team.name, another_active_user.name])
+      expect(page).not_to have_select("Name", with_options: [another_inactive_user.name, other_deleted_team.name])
+    end
   end
 
   scenario "no filters applied shows all cases" do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,23 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Team do
-  describe ".all_with_organisation" do
-    before { create_list(:team, 3) }
-
-    let(:owners) { described_class.all_with_organisation }
-
-    it "retrieves all teams" do
-      expect(owners.length).to eq(3)
-    end
-
-    it "includes associations needed for display_name" do
-      owners.length
-      expect(lambda {
-        owners.map(&:display_name)
-      }).to not_talk_to_db
-    end
-  end
-
   describe ".get_visible_teams" do
     before do
       allow(Rails.application.config).to receive(:team_names).and_return(

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -51,4 +51,39 @@ RSpec.describe Team do
       end
     end
   end
+
+  describe ".not_deleted" do
+    it "returns only teams without deleted timestamp" do
+      create(:team, :deleted)
+      not_deleted_team = create(:team)
+
+      expect(described_class.not_deleted.to_a).to eq [not_deleted_team]
+    end
+  end
+
+  describe "#mark_as_deleted!" do
+    it "sets the team 'deleted_at' timestamp to the current time" do
+      team = create(:team)
+      freeze_time do
+        expect { team.mark_as_deleted! }.to change { team.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it "does not change the flag if was already enabled" do
+      team = create(:team, :deleted)
+      expect { team.mark_as_deleted! }.not_to change(team, :deleted_at)
+    end
+  end
+
+  describe "#deleted?" do
+    it "returns true for teams with deleted timestamp" do
+      team = create(:team, :deleted)
+      expect(team).to be_deleted
+    end
+
+    it "returns false for teams without deleted timestamp" do
+      team = create(:team)
+      expect(team).not_to be_deleted
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Team do
     it "sets the team 'deleted_at' timestamp to the current time" do
       team = create(:team)
       freeze_time do
-        expect { team.mark_as_deleted! }.to change { team.deleted_at }.from(nil).to(Time.current)
+        expect { team.mark_as_deleted! }.to change { team.deleted_at }.from(nil).to(Time.zone.now)
       end
     end
 

--- a/spec/services/add_team_to_case_spec.rb
+++ b/spec/services/add_team_to_case_spec.rb
@@ -109,6 +109,23 @@ RSpec.describe AddTeamToCase, :with_stubbed_mailer, :with_stubbed_elasticsearch 
         end
       end
 
+      context "when the silent parameter is true", :with_test_queue_adapter do
+        let(:result) do
+          described_class.call(
+            team: team,
+            message: message,
+            investigation: investigation,
+            collaboration_class: collaboration_class,
+            user: user,
+            silent: true
+          )
+        end
+
+        it "does not send any emails" do
+          expect { result }.not_to have_enqueued_mail(NotifyMailer, :team_added_to_case_email)
+        end
+      end
+
       it "adds an audit activity record", :aggregate_failures do
         result
         last_added_activity = investigation.activities.order(:id).first

--- a/spec/services/change_case_owner_spec.rb
+++ b/spec/services/change_case_owner_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe ChangeCaseOwner, :with_stubbed_elasticsearch, :with_test_queue_ad
         end
       end
 
-
       context "when the new owner is a read only team on the case" do
         let(:new_owner) { create(:team) }
 

--- a/spec/services/change_case_owner_spec.rb
+++ b/spec/services/change_case_owner_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe ChangeCaseOwner, :with_stubbed_elasticsearch, :with_test_queue_ad
         expect(result).to be_success
       end
 
+      context "when the silent parameter is true", :with_test_queue_adapter do
+        let(:result) do
+          described_class.call(
+            investigation: investigation,
+            user: user,
+            owner: new_owner,
+            rationale: rationale,
+            silent: true
+          )
+        end
+
+        it "does not send any emails" do
+          expect { result }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
+        end
+      end
+
+
       context "when the new owner is a read only team on the case" do
         let(:new_owner) { create(:team) }
 

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
     context "when a user is attributed to historic activity on a case" do
       it "retains the user attribution" do
       end
-
-      it "displays the user's new team name" do
-      end
     end
   end
 
@@ -38,43 +35,16 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
     it "transfers ownership of the case to the new team" do
     end
 
+    it "adds activity showing the case ownership changed to the new team" do
+    end
+
     it "adds activity showing the old team removed from the case" do
     end
 
     it "does not send notification e-mails" do
     end
 
-    context "when the new team is not already a collaborator on the case" do
-      it "adds activity showing the new team added to the case" do
-      end
-
-      it "retains the old team's access level to the case" do
-      end
-    end
-
-    context "when the new team is already a collaborator on the case" do
-      it "does not add activity showing the new team added to the case" do
-      end
-
-      context "when the new team has the same level of access to the case as the old team" do
-        it "does not change the new team's access level on the case" do
-        end
-      end
-
-      context "when the new team has read-only access to the case but the old team had edit access" do
-        it "does not change the new team's access level on the case" do
-        end
-      end
-
-      context "when the new team has edit access to the case but the old team had read-only access" do
-        it "does not change the new team's access level on the case" do
-        end
-      end
-
-      context "when the new team is the owner of the case" do
-        it "does not change the new team's access level on the case" do
-        end
-      end
+    it "removes the previous collaborator access from the new team" do
     end
   end
 

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
+
+  it "marks the team as deleted" do
+  end
+
+  context "when the team has users" do
+    it "migrates the users to the new team" do
+    end
+
+    it "retains the users' roles in the new team" do
+    end
+
+    it "sends a confirmation email to each affected user" do
+    end
+
+    context "when a user is attributed to historic activity on a case" do
+      it "retains the user attribution" do
+      end
+
+      it "displays the user's new team name" do
+      end
+    end
+  end
+
+  context "when the team has created a case" do
+    it "retains the team as the case creator" do
+    end
+  end
+
+  context "when a user on the team has created a case" do
+    it "retains the user as the case creator" do
+    end
+  end
+
+  context "when the team is the owner of a case" do
+    it "transfers ownership of the case to the new team" do
+    end
+
+    it "adds activity showing the old team removed from the case" do
+    end
+
+    it "does not send notification e-mails" do
+    end
+
+    context "when the new team is not already a collaborator on the case" do
+      it "adds activity showing the new team added to the case" do
+      end
+
+      it "retains the old team's access level to the case" do
+      end
+    end
+
+    context "when the new team is already a collaborator on the case" do
+      it "does not add activity showing the new team added to the case" do
+      end
+
+      context "when the new team has the same level of access to the case as the old team" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team has read-only access to the case but the old team had edit access" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team has edit access to the case but the old team had read-only access" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team is the owner of the case" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+    end
+  end
+
+  context "when a user in the team is the owner of a case" do
+    it "retains the ownership of the case with the same user in the new team" do
+    end
+
+    it "updates the owner team to the user's new team" do
+    end
+  end
+
+  context "when the team is a collaborator on a case owned by another team" do
+    it "adds activity showing the old team removed from the case" do
+    end
+
+    it "does not send notification e-mails" do
+    end
+
+    context "when the new team is not already a collaborator on the case" do
+      it "adds activity showing the new team added to the case" do
+      end
+
+      it "retains the old team's access level to the case" do
+      end
+    end
+
+    context "when the new team is already a collaborator on the case" do
+      it "does not add activity showing the new team added to the case" do
+      end
+
+      context "when the new team has the same level of access to the case as the old team" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team has read-only access to the case but the old team had edit access" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team has edit access to the case but the old team had read-only access" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+
+      context "when the new team is the owner of the case" do
+        it "does not change the new team's access level on the case" do
+        end
+      end
+    end
+  end
+end

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
 
       it "marks the team as deleted" do
         freeze_time do
-          expect { delete_team }.to change { team.deleted_at }.from(nil).to(Time.zone.now)
+          expect { delete_team }.to change(team, :deleted_at).from(nil).to(Time.zone.now)
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
       end
 
       it "retains the users' roles in the new team" do
-        expect { delete_team }.not_to change { team_user.is_team_admin? }
+        expect { delete_team }.not_to change(team_user, :is_team_admin?)
       end
 
       it "sends a confirmation email to each affected user", :aggregate_failures do
@@ -102,11 +102,11 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
 
       context "when a user on the team has created a case" do
         it "retains the user as the case creator" do
-          expect { delete_team }.not_to change { team_case.creator_user }
+          expect { delete_team }.not_to change(team_case, :creator_user)
         end
 
         it "retains the team as the case creator" do
-          expect { delete_team }.not_to change { team_case.creator_team }
+          expect { delete_team }.not_to change(team_case, :creator_team)
         end
       end
 
@@ -152,7 +152,7 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
 
       context "when a user in the team is the owner of a case" do
         it "retains the ownership of the case with the same user in the new team" do
-          expect { delete_team }.not_to change { team_case.owner }
+          expect { delete_team }.not_to change(team_case, :owner)
         end
 
         it "updates the owner team to the user's new team" do
@@ -174,7 +174,7 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
         end
 
         it "does not change the new team's access level on the case" do
-          expect { delete_team }.not_to change { new_team_case.owner_team }
+          expect { delete_team }.not_to change(new_team_case, :owner_team)
         end
 
         it "does not send notification e-mails", :with_test_queue_adapter do

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -84,15 +84,6 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
         expect { delete_team }.not_to change(team_user, :is_team_admin?)
       end
 
-      it "sends a confirmation email to each affected user", :aggregate_failures do
-        delete_team
-        mail = delivered_emails.last
-        expect(mail.recipient).to eq(team_user.email)
-        expect(mail.action_name).to eq("team_deleted")
-        expect(mail.personalization[:name]).to eq(team_user.name)
-        expect(mail.personalization[:deleting_user_name]).to eq(deleting_user.name)
-      end
-
       context "when a user is attributed to historic activity on a case" do
         it "retains the user attribution" do
           activity = team_case.activities.find_by!(type: team_case.case_created_audit_activity_class.to_s)

--- a/spec/services/delete_team_spec.rb
+++ b/spec/services/delete_team_spec.rb
@@ -6,189 +6,241 @@ RSpec.describe DeleteTeam, :with_stubbed_mailer, :with_stubbed_elasticsearch do
 
   let(:team_user) { create(:user, :activated, :team_admin, team: team, organisation: team.organisation) }
   let(:new_team_user) { create(:user, :activated, :team_admin, team: new_team, organisation: new_team.organisation) }
-  let(:deleting_user) { team_user }
+  let(:deleting_user) { create(:user) }
 
   let(:team_case) { create(:allegation, creator: team_user) }
 
-  def delete_team
-    described_class.call!(team: team, new_team: new_team, user: deleting_user)
-  end
+  describe ".call" do
+    subject(:result) { delete_team }
 
-  it "marks the team as deleted" do
-    freeze_time do
-      expect { delete_team }.to change { team.deleted_at }.from(nil).to(Time.zone.now)
-    end
-  end
-
-  it "migrates the users to the new team" do
-    expect { delete_team }.to change { team_user.team }.from(team).to(new_team)
-  end
-
-  it "retains the users' roles in the new team" do
-    expect { delete_team }.not_to change { team_user.is_team_admin? }
-  end
-
-  it "sends a confirmation email to each affected user", :aggregate_failures do
-    delete_team
-    mail = delivered_emails.last
-    expect(mail.recipient).to eq(team_user.email)
-    expect(mail.action_name).to eq("team_deleted")
-    expect(mail.personalization[:name]).to eq(team_user.name)
-    expect(mail.personalization[:deleting_user_name]).to eq(deleting_user.name)
-  end
-
-  context "when a user is attributed to historic activity on a case" do
-    it "retains the user attribution" do
-      activity = team_case.activities.find_by!(type: team_case.case_created_audit_activity_class.to_s)
-      expect { delete_team }.not_to change { activity.source.user }
-    end
-  end
-
-  context "when a user on the team has created a case" do
-    it "retains the user as the case creator" do
-      expect { delete_team }.not_to change { team_case.creator_user }
+    def delete_team
+      described_class.call(team: team, new_team: new_team, user: deleting_user)
     end
 
-    it "retains the team as the case creator" do
-      expect { delete_team }.not_to change { team_case.creator_team }
-    end
-  end
+    context "with no parameters" do
+      let(:team) { nil }
+      let(:new_team) { nil }
+      let(:deleting_user) { nil }
 
-  context "when the team is the owner of a case" do
-    before do
-      ChangeCaseOwner.call!(
-        investigation: team_case,
-        owner: team,
-        user: team_user
-      )
-    end
-
-    it "transfers ownership of the case to the new team" do
-      expect { delete_team }.to change { team_case.owner }.from(team).to(new_team)
-    end
-
-    it "adds activity showing the case ownership changed to the new team" do
-      delete_team
-      activity = team_case.activities.find_by!(type: AuditActivity::Investigation::UpdateOwner.to_s)
-      expect(activity.owner).to eq(new_team)
-    end
-
-    it "adds activity showing the old team removed from the case" do
-      delete_team
-      activity = team_case.activities.find_by!(type: AuditActivity::Investigation::TeamDeleted.to_s)
-      expect(activity.team).to eq(team)
-    end
-
-    it "does not send notification e-mails", :with_test_queue_adapter, :aggregate_failures do
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
-    end
-
-    context "when the new team was already a collaborator on the case" do
-      before do
-        AddTeamToCase.call!(
-          investigation: team_case,
-          user: team_user,
-          team: new_team,
-          collaboration_class: Collaboration::Access::ReadOnly
-        )
-      end
-
-      it "removes the previous collaborator access from the new team" do
-        expect { delete_team }.to change { team_case.teams_with_read_only_access.count }.from(1).to(0)
+      it "returns a failure" do
+        expect(result).to be_failure
       end
     end
-  end
 
-  context "when a user in the team is the owner of a case" do
-    it "retains the ownership of the case with the same user in the new team" do
-      expect { delete_team }.not_to change { team_case.owner }
+    context "with no team parameter" do
+      let(:team) { nil }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
     end
 
-    it "updates the owner team to the user's new team" do
-      expect { delete_team }.to change { team_case.owner_team }.from(team).to(new_team)
-    end
-  end
+    context "with no new_team parameter" do
+      let(:new_team) { nil }
 
-  context "when the team is a collaborator on a case owned by the new team" do
-    let(:new_team_case) { create(:allegation, creator: new_team_user, read_only_teams: [team]) }
-
-    it "removes the team from the case" do
-      expect { delete_team }.to change { new_team_case.teams_with_read_only_access }.from([team]).to([])
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
     end
 
-    it "adds activity showing the old team removed from the case" do
-      delete_team
-      activity = new_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamDeleted.to_s)
-      expect(activity.team).to eq(team)
+    context "with no user parameter" do
+      let(:deleting_user) { nil }
+
+      it "returns a failure" do
+        expect(result).to be_failure
+      end
     end
 
-    it "does not change the new team's access level on the case" do
-      expect { delete_team }.not_to change { new_team_case.owner_team }
-    end
+    context "with required parameters" do
+      let(:deleting_user) { team_user }
 
-    it "does not send notification e-mails", :with_test_queue_adapter do
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
-    end
-  end
+      context "when the team is already deleted" do
+        let(:team) { create(:team, :deleted) }
 
-  context "when the team is a collaborator on a case owned by another team" do
-    let(:other_team_case) { create(:allegation, read_only_teams: read_only_teams, edit_access_teams: edit_access_teams) }
-    let(:read_only_teams) { [team] }
-    let(:edit_access_teams) { nil }
-
-    it "adds activity showing the old team removed from the case" do
-      delete_team
-      activity = other_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamDeleted.to_s)
-      expect(activity.team).to eq(team)
-    end
-
-    it "does not send notification e-mails", :with_test_queue_adapter, :aggregate_failures do
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_added_to_case_email)
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
-      expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :case_permission_changed_for_team)
-    end
-
-    context "when the new team is not already a collaborator on the case" do
-      it "adds the new team to the case with the same access level as the old team" do
-        expect { delete_team }.to change { other_team_case.teams_with_read_only_access }.from([team]).to([new_team])
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
       end
 
-      it "adds activity showing the new team added to the case" do
+      context "when the new team is already deleted" do
+        let(:new_team) { create(:team, :deleted) }
+
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+
+      it "marks the team as deleted" do
+        freeze_time do
+          expect { delete_team }.to change { team.deleted_at }.from(nil).to(Time.zone.now)
+        end
+      end
+
+      it "migrates the users to the new team" do
+        expect { delete_team }.to change { team_user.reload.team }.from(team).to(new_team)
+      end
+
+      it "retains the users' roles in the new team" do
+        expect { delete_team }.not_to change { team_user.is_team_admin? }
+      end
+
+      it "sends a confirmation email to each affected user", :aggregate_failures do
         delete_team
-        activity = other_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamAdded.to_s)
-        expect(activity.team).to eq(new_team)
-      end
-    end
-
-    context "when the new team is already a collaborator on the case" do
-      let(:read_only_teams) { [team, new_team] }
-
-      it "does not add activity showing the new team added to the case" do
-        expect { delete_team }.not_to change { other_team_case.activities.where(type: AuditActivity::Investigation::TeamAdded.to_s).count }
+        mail = delivered_emails.last
+        expect(mail.recipient).to eq(team_user.email)
+        expect(mail.action_name).to eq("team_deleted")
+        expect(mail.personalization[:name]).to eq(team_user.name)
+        expect(mail.personalization[:deleting_user_name]).to eq(deleting_user.name)
       end
 
-      context "when the new team has the same level of access to the case as the old team" do
-        it "does not change the new team's access level on the case" do
-          expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: team.id).count }
+      context "when a user is attributed to historic activity on a case" do
+        it "retains the user attribution" do
+          activity = team_case.activities.find_by!(type: team_case.case_created_audit_activity_class.to_s)
+          expect { delete_team }.not_to change { activity.source.user }
         end
       end
 
-      context "when the new team has read-only access to the case but the old team had edit access" do
-        let(:read_only_teams) { [new_team] }
-        let(:edit_access_teams) { [team] }
+      context "when a user on the team has created a case" do
+        it "retains the user as the case creator" do
+          expect { delete_team }.not_to change { team_case.creator_user }
+        end
 
-        it "does not change the new team's access level on the case" do
-          expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: team.id).count }
+        it "retains the team as the case creator" do
+          expect { delete_team }.not_to change { team_case.creator_team }
         end
       end
 
-      context "when the new team has edit access to the case but the old team had read-only access" do
+      context "when the team is the owner of a case" do
+        before do
+          ChangeCaseOwner.call!(
+            investigation: team_case,
+            owner: team,
+            user: team_user
+          )
+        end
+
+        it "transfers ownership of the case to the new team" do
+          expect { delete_team }.to change { team_case.reload.owner }.from(team).to(new_team)
+        end
+
+        it "adds activity showing the case ownership changed to the new team" do
+          delete_team
+          activity = team_case.activities.find_by!(type: AuditActivity::Investigation::UpdateOwner.to_s)
+          expect(activity.owner).to eq(new_team)
+        end
+
+        it "does not send notification e-mails", :with_test_queue_adapter, :aggregate_failures do
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :investigation_updated)
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
+        end
+
+        context "when the new team was already a collaborator on the case" do
+          before do
+            AddTeamToCase.call!(
+              investigation: team_case,
+              user: team_user,
+              team: new_team,
+              collaboration_class: Collaboration::Access::ReadOnly
+            )
+          end
+
+          it "removes the previous collaborator access from the new team" do
+            expect { delete_team }.to change { team_case.teams_with_read_only_access.count }.from(1).to(0)
+          end
+        end
+      end
+
+      context "when a user in the team is the owner of a case" do
+        it "retains the ownership of the case with the same user in the new team" do
+          expect { delete_team }.not_to change { team_case.owner }
+        end
+
+        it "updates the owner team to the user's new team" do
+          expect { delete_team }.to change { team_case.reload.owner_team }.from(team).to(new_team)
+        end
+      end
+
+      context "when the team is a collaborator on a case owned by the new team" do
+        let!(:new_team_case) { create(:allegation, creator: new_team_user, read_only_teams: [team]) }
+
+        it "removes the team from the case" do
+          expect { delete_team }.to change { new_team_case.reload.teams_with_read_only_access }.from([team]).to([])
+        end
+
+        it "adds activity showing the old team removed from the case" do
+          delete_team
+          activity = new_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamDeleted.to_s)
+          expect(activity.team).to eq(team)
+        end
+
+        it "does not change the new team's access level on the case" do
+          expect { delete_team }.not_to change { new_team_case.owner_team }
+        end
+
+        it "does not send notification e-mails", :with_test_queue_adapter do
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
+        end
+      end
+
+      context "when the team is a collaborator on a case owned by another team" do
+        let!(:other_team_case) { create(:allegation, read_only_teams: read_only_teams, edit_access_teams: edit_access_teams) }
         let(:read_only_teams) { [team] }
-        let(:edit_access_teams) { [new_team] }
+        let(:edit_access_teams) { nil }
 
-        it "does not change the new team's access level on the case" do
-          expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: team.id).count }
+        it "adds activity showing the old team removed from the case" do
+          delete_team
+          activity = other_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamDeleted.to_s)
+          expect(activity.team).to eq(team)
+        end
+
+        it "does not send notification e-mails", :with_test_queue_adapter, :aggregate_failures do
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_added_to_case_email)
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
+          expect { delete_team }.not_to have_enqueued_mail(NotifyMailer, :case_permission_changed_for_team)
+        end
+
+        context "when the new team is not already a collaborator on the case" do
+          it "adds the new team to the case with the same access level as the old team" do
+            expect { delete_team }.to change { other_team_case.reload.teams_with_read_only_access }.from([team]).to([new_team])
+          end
+
+          it "adds activity showing the new team added to the case" do
+            delete_team
+            activity = other_team_case.activities.find_by!(type: AuditActivity::Investigation::TeamAdded.to_s)
+            expect(activity.team).to eq(new_team)
+          end
+        end
+
+        context "when the new team is already a collaborator on the case" do
+          let(:read_only_teams) { [team, new_team] }
+
+          it "does not add activity showing the new team added to the case" do
+            expect { delete_team }.not_to change { other_team_case.activities.where(type: AuditActivity::Investigation::TeamAdded.to_s).count }
+          end
+
+          context "when the new team has the same level of access to the case as the old team" do
+            it "does not change the new team's access level on the case" do
+              expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: new_team.id).count }
+            end
+          end
+
+          context "when the new team has read-only access to the case but the old team had edit access" do
+            let(:read_only_teams) { [new_team] }
+            let(:edit_access_teams) { [team] }
+
+            it "does not change the new team's access level on the case" do
+              expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: new_team.id).count }
+            end
+          end
+
+          context "when the new team has edit access to the case but the old team had read-only access" do
+            let(:read_only_teams) { [team] }
+            let(:edit_access_teams) { [new_team] }
+
+            it "does not change the new team's access level on the case" do
+              expect { delete_team }.not_to change { other_team_case.teams_with_read_only_access.where(id: new_team.id).count }
+            end
+          end
         end
       end
     end

--- a/spec/services/remove_team_from_case_spec.rb
+++ b/spec/services/remove_team_from_case_spec.rb
@@ -81,6 +81,21 @@ RSpec.describe RemoveTeamFromCase, :with_stubbed_mailer, :with_stubbed_elasticse
         end
       end
 
+      context "when the silent parameter is true", :with_test_queue_adapter do
+        let(:result) do
+          described_class.call(
+            collaboration: collaboration,
+            message: message,
+            user: user,
+            silent: true
+          )
+        end
+
+        it "does not send any emails" do
+          expect { result }.not_to have_enqueued_mail(NotifyMailer, :team_deleted_from_case_email)
+        end
+      end
+
       it "adds an audit activity record", :aggregate_failures do
         result
         last_added_activity = investigation.activities.order(:id).first


### PR DESCRIPTION
https://trello.com/c/FRRtOhuq/668-5-absorb-opss-product-safety-enforcement-into-opss-enforcement

## Description
This allows us to delete a team from service.

When a team is deleted:

- all users on that team are transferred to another designated team. Any users that own a case retain ownership. All user roles are transferred to the new team
- all case collaborations for that team are transferred to another designated team. If the team owns any cases, the designated team will inherit ownership.
- audit activity is generated as normal - except when a user on the deleted team is the owner of a case. In this event we add an extra activity showing the team ownership has changed
- no emails are sent
- the team will no longer be in the filter cases list
- the team will no longer appear in the list to transfer case ownership
- the team will no longer appear in the list to add a team to the case

In our initial use case this process would ordinarily generate many hundreds of emails to the affected users. This implementation suppresses those emails. This could be made optional in a future iteration.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [x] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
