### PR TITLE
Fix bug when deleting a team

### DIFF
--- a/app/services/delete_team.rb
+++ b/app/services/delete_team.rb
@@ -40,6 +40,7 @@ private
 
   # In this case we want to retain the user as the owner, but change the OwnerTeam collaboration.
   def change_case_ownership_when_owner_is_user_on_team(collaboration)
+    collaboration.investigation.collaboration_accesses.changeable.where(collaborator: new_team).destroy_all
     collaboration.update!(collaborator_id: new_team.id)
 
     metadata = update_owner_activity_class.build_metadata(new_team, change_case_owner_rationale)


### PR DESCRIPTION
https://trello.com/c/FRRtOhuq/668-8-absorb-opss-product-safety-enforcement-into-opss-enforcement

## Description
Adds a test and fix for a scenario where a user on the team to be deleted is the owner of a case, and the new team is already a collaborator on that case.

We do already have a similar inverse method [Collaboration::Access::OwnerTeam#swap_to_edit_access!](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/app/models/collaboration/access/owner_team.rb#L4). I did consider adding a similar method to `Collaboration::Access::Edit` however normally we would expect any other owner collaborations to be destroyed. In this instance we want to keep the `OwnerUser` as-is and only change the `OwnerTeam`. I felt this was too specific to be useful outside of this service and might be confusing or misleading if implemented in the model.