### PR TITLE
Migration fix: superclass should be ApplicationRecord

### DIFF
--- a/db/migrate/20200501105429_rename_update_assigne_activities.rb
+++ b/db/migrate/20200501105429_rename_update_assigne_activities.rb
@@ -1,6 +1,4 @@
-# rubocop:disable Rails/ApplicationRecord
-class Activity < ActiveRecord::Base; end
-# rubocop:enable Rails/ApplicationRecord
+class Activity < ApplicationRecord; end
 
 class RenameUpdateAssigneActivities < ActiveRecord::Migration[5.2]
   def up


### PR DESCRIPTION
This fixes the following error:

```
TypeError: superclass mismatch for class Activity
```

...caused by the redefined `Activity` class having a different superclass from the one defined in `models/activity.rb`.

Not quite sure why this didn't happen before, but presumably it's related to either the Ruby or Rails upgrades.