### PR TITLE
WIP: Fix ordering search results by created_at date

### DIFF
--- a/spec/models/investigation_elasticsearch_spec.rb
+++ b/spec/models/investigation_elasticsearch_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Investigation, :with_elasticsearch, :with_stubbed_mailer, :with_stubbed_notify do
+  describe ".full_search" do
+    context "when sorting by created_at" do
+      let(:dates) do
+        [Time.zone.now,
+         Time.zone.now - 2.hours,
+         Time.zone.now - 1.hour]
+      end
+      let(:expected_order) { dates.sort.reverse }
+      let(:sorting_params) do
+        { created_at: "desc" }
+      end
+      let(:query) { ElasticsearchQuery.new(nil, {}, sorting_params) }
+      let(:result) { described_class.full_search(query) }
+
+      before do
+        dates.each { |created_at| create(:allegation, created_at: created_at) }
+        described_class.__elasticsearch__.import force: true, refresh: :wait
+      end
+
+      it "lists cases correctly sorted" do
+        investigations = Investigation.eager_load(
+          :complainant,
+          :creator_user
+        ).where(id: result.results.map(&:_id))
+
+        expect(investigations.map {|i| i.created_at}).to eq(expected_order)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/1UONIGDB/757-investigate-indexing-on-most-recently-created-sort

## Description
Can reproduce the issue - failing test created.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
