### PR TITLE
Fix case ordering caused by default_scope override

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -19,10 +19,7 @@ class InvestigationsController < ApplicationController
         authorize Investigation, :export?
 
         @answer = search_for_investigations
-        @investigations = Investigation.eager_load(
-          :complainant,
-          :creator_user
-        ).where(id: @answer.results.map(&:_id))
+        @investigations = @answer.records(includes: %i[complainant creator_user])
 
         @activity_counts = Activity.group(:investigation_id).count
         @business_counts = InvestigationBusiness.unscoped.group(:investigation_id).count

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -38,8 +38,6 @@ class Investigation < ApplicationRecord
   after_update :create_audit_activity_for_status,
                :create_audit_activity_for_visibility
 
-  default_scope { order(updated_at: :desc) }
-
   has_many :investigation_products, dependent: :destroy
   has_many :products, through: :investigation_products
 

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -212,7 +212,7 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
 
   describe "sorting" do
     let(:default_filtered_cases) { Investigation.where(is_closed: false) }
-    let(:case_ids) { default_filtered_cases.order(updated_at: :desc) }
+    let(:cases) { default_filtered_cases.order(updated_at: :desc) }
 
     def select_sorting_option(option)
       within_fieldset("Sort by") { choose(option) }
@@ -221,7 +221,7 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
 
     context "with no sort by option selected" do
       it "shows results by most recently updated" do
-        expect(page).to list_cases_in_order(case_ids)
+        expect(page).to list_cases_in_order(cases)
       end
     end
 
@@ -229,27 +229,27 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
       before { select_sorting_option("Most recently updated") }
 
       it "shows results by most recently updated" do
-        expect(page).to list_cases_in_order(case_ids)
+        expect(page).to list_cases_in_order(cases)
       end
     end
 
     context "with sort by least recently updated option selected" do
-      let(:case_ids) { default_filtered_cases.order(updated_at: :asc) }
+      let(:cases) { default_filtered_cases.order(updated_at: :asc) }
 
       before { select_sorting_option("Least recently updated") }
 
       it "shows results by least recently updated" do
-        expect(page).to list_cases_in_order(case_ids)
+        expect(page).to list_cases_in_order(cases)
       end
     end
 
     context "with sort by most recently created option selected" do
-      let(:case_ids) { default_filtered_cases.order(created_at: :desc) }
+      let(:cases) { default_filtered_cases.order(created_at: :desc) }
 
       before { select_sorting_option("Most recently created") }
 
       it "shows results by most recently created" do
-        expect(page).to list_cases_in_order(case_ids)
+        expect(page).to list_cases_in_order(cases)
       end
     end
   end

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
   let!(:restricted_case) { create(:allegation, creator: restricted_case_team_user, is_private: true, description: restricted_case_title).decorate }
 
   before do
+    other_team_investigation.touch # Tests sort order
     Investigation.import refresh: :wait_for
     sign_in(user)
     visit investigations_path
@@ -207,5 +208,49 @@ RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type:
     click_on "Search"
 
     expect(page).not_to have_link(restricted_case.title, href: "/cases/#{restricted_case.pretty_id}")
+  end
+
+  describe "sorting" do
+    let(:default_filtered_cases) { Investigation.where(is_closed: false) }
+    let(:case_ids) { default_filtered_cases.order(updated_at: :desc) }
+
+    def select_sorting_option(option)
+      within_fieldset("Sort by") { choose(option) }
+      click_button "Apply filters"
+    end
+
+    context "with no sort by option selected" do
+      it "shows results by most recently updated" do
+        expect(page).to list_cases_in_order(case_ids)
+      end
+    end
+
+    context "with sort by most recently updated option selected" do
+      before { select_sorting_option("Most recently updated") }
+
+      it "shows results by most recently updated" do
+        expect(page).to list_cases_in_order(case_ids)
+      end
+    end
+
+    context "with sort by least recently updated option selected" do
+      let(:case_ids) { default_filtered_cases.order(updated_at: :asc) }
+
+      before { select_sorting_option("Least recently updated") }
+
+      it "shows results by least recently updated" do
+        expect(page).to list_cases_in_order(case_ids)
+      end
+    end
+
+    context "with sort by most recently created option selected" do
+      let(:case_ids) { default_filtered_cases.order(created_at: :desc) }
+
+      before { select_sorting_option("Most recently created") }
+
+      it "shows results by most recently created" do
+        expect(page).to list_cases_in_order(case_ids)
+      end
+    end
   end
 end

--- a/spec/support/case_list_matcher.rb
+++ b/spec/support/case_list_matcher.rb
@@ -3,3 +3,11 @@ RSpec::Matchers.define :have_listed_case do |pretty_id|
     element.has_selector?(".psd-case-card", text: pretty_id)
   end
 end
+
+RSpec::Matchers.define :list_cases_in_order do |expected_cases|
+  match do |element|
+    pattern = /(Allegation|Project|Enquiry): (\d{4}-\d{4})/
+    page_case_ids = element.all(".psd-case-card span", text: pattern).map(&:text).map { |t| t.match(pattern).captures.last }
+    page_case_ids == expected_cases.map(&:pretty_id)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/1UONIGDB/757-investigate-indexing-on-most-recently-created-sort

## Description
Fixes case ordering on the case list pages. This affected the ordering of all results within a page, forcing them to be reordered by `updated_at` regardless of relevance or other sort options selected. Usage of `default_scope` is generally discouraged because of gotchas like this, and in fact was redundant anyway because of the implementation of search in the controller.

I added some tests around case sorting and fixed the export controller action so that it ordered correctly, removing some redundant code.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)
