### PR TITLE
Refactor owner form

### DIFF
--- a/app/controllers/investigations/ownership_controller.rb
+++ b/app/controllers/investigations/ownership_controller.rb
@@ -7,6 +7,9 @@ class Investigations::OwnershipController < ApplicationController
 
   def show
     @potential_owner = form.owner&.decorate
+
+    get_potential_assignees if step == :"select-owner"
+
     render_wizard
   end
 
@@ -68,5 +71,13 @@ private
 
   def form
     @form ||= ChangeCaseOwnerForm.new(form_params)
+  end
+
+  def get_potential_assignees
+    @selectable_users = [@investigation.owner_user&.object, current_user].uniq.compact
+    @team_members = User.get_team_members(user: current_user)
+    @selectable_teams = [current_user.team, Team.get_visible_teams(current_user), @investigation.owner_team&.object].flatten.uniq.compact
+    @other_teams = Team.not_deleted
+    @other_users = User.active
   end
 end

--- a/app/controllers/investigations/ownership_controller.rb
+++ b/app/controllers/investigations/ownership_controller.rb
@@ -75,7 +75,7 @@ private
 
   def get_potential_assignees
     @selectable_users = [@investigation.owner_user&.object, current_user].uniq.compact
-    @team_members = User.get_team_members(user: current_user)
+    @team_members = current_user.team.users.active
     @selectable_teams = [current_user.team, Team.get_visible_teams(current_user), @investigation.owner_team&.object].flatten.uniq.compact
     @other_teams = Team.not_deleted
     @other_users = User.active

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -114,8 +114,4 @@ private
   def build_breadcrumbs
     @breadcrumbs = build_breadcrumb_structure
   end
-
-  def set_suggested_previous_owners
-    @suggested_previous_owners = suggested_previous_owners(@investigation)
-  end
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -246,13 +246,6 @@ module InvestigationsHelper
     [team.id] + team.users.map(&:id)
   end
 
-  def suggested_previous_owners(investigation)
-    all_past_owners = investigation.past_owners
-    return [] if all_past_owners.empty? || all_past_owners == [current_user]
-
-    all_past_owners || []
-  end
-
   def risks_and_issues_rows(investigation, user)
     risk_level_row = {
       key: {

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -136,26 +136,9 @@ class Investigation < ApplicationRecord
     is_closed? ? "Closed" : "Open"
   end
 
-  def important_owner_people
-    people = [].to_set
-    people << owner if owner.is_a? User
-    people << User.current
-    people
-  end
-
   def past_owners
     activities = AuditActivity::Investigation::UpdateOwner.where(investigation_id: id)
     activities.map(&:owner)
-  end
-
-  def important_owner_teams
-    teams = [User.current.team].to_set
-
-    Team.get_visible_teams(User.current).each do |team|
-      teams << team
-    end
-    teams << owner if owner.is_a? Team
-    teams
   end
 
   def enquiry?

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -136,11 +136,6 @@ class Investigation < ApplicationRecord
     is_closed? ? "Closed" : "Open"
   end
 
-  def past_owners
-    activities = AuditActivity::Investigation::UpdateOwner.where(investigation_id: id)
-    activities.map(&:owner)
-  end
-
   def enquiry?
     is_a?(Investigation::Enquiry)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,14 +88,6 @@ class User < ApplicationRecord
     active.where.not(id: user_ids_to_exclude).eager_load(:organisation, :team)
   end
 
-  def self.get_team_members(user:)
-    users = [].to_set
-    user.team.users.active.find_each do |team_member|
-      users << team_member
-    end
-    users
-  end
-
   def has_viewed_introduction!
     update has_viewed_introduction: true
   end

--- a/app/views/investigations/ownership/_owner_form.html.erb
+++ b/app/views/investigations/ownership/_owner_form.html.erb
@@ -22,19 +22,6 @@
                value: "someone_in_your_team",
                conditional: { html: someone_in_your_team } %>
 
-  <% if @suggested_previous_owners.present? %>
-    <% previous_owners = capture do %>
-      <%= render "investigations/ownership/owner_selection",
-               form: form,
-               key: :select_previous_owner,
-               items: @suggested_previous_owners,
-               label: "Select previously assigned person or team",
-               show_all_values: true
-      %>
-    <% end %>
-    <% items.push text: "Previously assigned", value: "previous_owners", conditional: { html: previous_owners } %>
-  <% end %>
-
   <% items.push divider: "Teams" %>
 
   <%

--- a/app/views/investigations/ownership/_owner_form.html.erb
+++ b/app/views/investigations/ownership/_owner_form.html.erb
@@ -2,15 +2,17 @@
   <%= render "form_components/govuk_error_summary", form: form %>
   <%= yield %>
 
-  <% items = investigation.important_owner_people.map do |user|
-    { text: user.decorate.display_name(viewer: current_user), value: user.id, checked: investigation.owner == user }
-  end %>
+  <%
+    items = @selectable_users.map do |user|
+      { text: user.decorate.display_name(viewer: current_user), value: user.id, checked: investigation.owner == user }
+    end
+  %>
 
   <% someone_in_your_team = capture do %>
     <%= render "investigations/ownership/owner_selection",
       form: form,
       key: :select_team_member,
-      items: User.get_team_members(user: current_user),
+      items: @team_members,
       label: "Select team member",
       show_all_values: true
     %>
@@ -35,16 +37,18 @@
 
   <% items.push divider: "Teams" %>
 
-  <% teams = investigation.important_owner_teams.map do |team|
-    { text: team.decorate.display_name(viewer: current_user), value: team.id, checked: investigation.owner == team }
-  end %>
+  <%
+    teams = @selectable_teams.map do |team|
+      { text: team.decorate.display_name(viewer: current_user), value: team.id, checked: investigation.owner == team }
+    end
+  %>
   <% items.concat teams %>
 
   <% other_teams = capture do %>
     <%= render "investigations/ownership/owner_selection",
       form: form,
       key: :select_other_team,
-      items: Team.not_deleted,
+      items: @other_teams,
       label: "Select other team name",
       show_all_values: true
     %>
@@ -57,7 +61,7 @@
     <%= render "investigations/ownership/owner_selection",
       form: form,
       key: :select_someone_else,
-      items: User.active,
+      items: @other_users,
       label: "Select other user"
     %>
   <% end %>

--- a/spec/models/investigation_spec.rb
+++ b/spec/models/investigation_spec.rb
@@ -209,27 +209,4 @@ RSpec.describe Investigation, :with_stubbed_elasticsearch, :with_stubbed_mailer,
       end
     end
   end
-
-  describe "#past_owners" do
-    context "when there is a previous owner" do
-      let(:past_owner) { create(:team) }
-
-      before do
-        AuditActivity::Investigation::UpdateOwner.create!(
-          investigation: investigation,
-          metadata: { "owner_id" => past_owner.id }
-        )
-      end
-
-      it "returns the previous owner" do
-        expect(investigation.past_owners).to eq [past_owner]
-      end
-    end
-
-    context "when there are no previous owners" do
-      it "returns an empty list" do
-        expect(investigation.past_owners).to eq []
-      end
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,29 +125,6 @@ RSpec.describe User do
     end
   end
 
-  describe ".get_team_members" do
-    let(:team) { create(:team) }
-    let(:user) { create(:user, :activated, team: team) }
-    let(:investigation) { create(:allegation) }
-    let(:team_members) { described_class.get_team_members(user: user) }
-
-    let!(:another_active_user) { create(:user, :activated, organisation: user.organisation, team: team) }
-    let!(:another_inactive_user) { create(:user, :inactive, organisation: user.organisation, team: team) }
-    let!(:another_user_with_another_team) { create(:user, :activated, team: create(:team)) }
-
-    it "returns other users on the same team" do
-      expect(team_members).to include(another_active_user)
-    end
-
-    it "does not return other users on the same team who are not activated" do
-      expect(team_members).not_to include(another_inactive_user)
-    end
-
-    it "does not return other users on other teams" do
-      expect(team_members).not_to include(another_user_with_another_team)
-    end
-  end
-
   describe ".get_owners" do
     let!(:active_user) { create(:user, :activated) }
     let!(:inactive_user) { create(:user, :inactive) }

--- a/spec/requests/investigations/changing_owner_spec.rb
+++ b/spec/requests/investigations/changing_owner_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
   context "when the user is from the case owner’s team" do
     before do
       sign_in user_from_owner_team
-      User.current = user_from_owner_team
       put investigation_ownership_path(investigation, "select-owner"),
           params: {
             investigation: {


### PR DESCRIPTION
Technical debt remediation

## Description
Removes some usage of `User.current` which we are actively eliminating due to various unexpected behaviours. This leaves only some of the activity models using it, which are actively being refactored.

Removes some code which is apparently redundant relating to selecting previous owners of a case on the change ownership form. This code does not appear to be integrated anymore (see 4772e88d0f617669fb8204c07b20b522c2575504).
