### PR TITLE
Fix Sidekiq::Web showing Forbidden errors

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require "sidekiq/web"
 require "sidekiq/cron/web"
 
-Sidekiq::Web.set :session_secret, Rails.application.credentials[:secret_key_base]
+Sidekiq::Web.set :session_secret, Rails.application.secret_key_base
 
 if Rails.env.production?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|


### PR DESCRIPTION
Resolves a long-standing issue with Sidekiq::Web returning `Forbidden` errors when performing operations such as kill/delete.

Our application still uses the outdated secrets approach to storing the secret key, so the previous code always returned `nil`. This is the correct approach to read the secret key as described in the [documentation](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base).