### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/services/change_case_owner_spec.rb
+++ b/spec/services/change_case_owner_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe ChangeCaseOwner, :with_stubbed_elasticsearch, :with_test_queue_ad
 
           it "creates proper collaboration" do
             result
-            expect(investigation.teams_with_edit_access).to eq([creator_team, investigation.owner_team])
+            expect(investigation.teams_with_edit_access).to contain_exactly(creator_team, investigation.owner_team)
           end
         end
 


### PR DESCRIPTION
## Description
Fixes a flaky spec which I have seen a few times today, for example: https://github.com/UKGovernmentBEIS/beis-opss-psd/runs/1314426997. The issue is that the order of the collection was sometimes different.
