### PR TITLE
Bug fix: Accessing a MSA case creation wizard step page before starting from the beginning

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -24,6 +24,7 @@ class Investigations::TsInvestigationsController < ApplicationController
         :other_files,
         :reference_number
 
+  before_action :redirect_to_first_step_if_wizard_not_started, if: -> { step && (step != steps.first) }
   before_action :set_countries, only: %i[show create update]
   before_action :set_product, only: %i[show create update]
   before_action :set_investigation, only: %i[show create update]
@@ -120,6 +121,10 @@ class Investigations::TsInvestigationsController < ApplicationController
   end
 
 private
+
+  def redirect_to_first_step_if_wizard_not_started
+    redirect_to action: :new unless session[:investigation]
+  end
 
   def set_product
     @product = Product.new(product_step_params)

--- a/spec/requests/msa_create_case_wizard_spec.rb
+++ b/spec/requests/msa_create_case_wizard_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Market Surveillance Authority case creation wizard", :with_stubbed_elasticsearch, type: :request do
+  let(:user) { create(:user, :activated) }
+
+  before { sign_in(user) }
+
+  context "when requesting a later step before having started the wizard" do
+    before { get "/ts_investigation/which_businesses" }
+
+    it "responds with a 302 status code" do
+      expect(response).to redirect_to(new_ts_investigation_path)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Wyv846Fk/694-interim-journey-urls-when-accessed-directly-without-session-data-then-it-should-return-to-dashboard

## Description
This fixes a bug whereby a user could access a page in the MSA case creation flow directly without having started the wizard. This could sometimes render an error if assumed session data was missing, or otherwise create a broken state with unexpected results.

This is an interim quick fix before refactoring the offending controller completely.

Rather than redirecting to the dashboard I have chosen to redirect to the first wizard page. Redirecting to the `new` action is better than redirecting to the first step using the Wicked helper because it sets up the session data in the call to `clear_session`. This is important even though it's not obvious.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)
