### PR TITLE
Remove Minitest badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Built by the [Office for Product Safety and Standards](https://www.gov.uk/govern
 For enquiries, contact [opss.enquiries@beis.gov.uk](opss.enquiries@beis.gov.uk)
 
 ![](https://github.com/UKGovernmentBEIS/beis-opss-psd/workflows/RSpec%20test%20suite/badge.svg?branch=master)
-![](https://github.com/UKGovernmentBEIS/beis-opss-psd/workflows/Minitest%20test%20suite/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/UKGovernmentBEIS/beis-opss-psd/badge.svg?branch=master)](https://coveralls.io/github/UKGovernmentBEIS/beis-opss-psd?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/233b845a516a9c2eecea/maintainability)](https://codeclimate.com/github/UKGovernmentBEIS/beis-opss-psd/maintainability)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=UKGovernmentBEIS/beis-opss-psd)](https://dependabot.com)


### PR DESCRIPTION
The Minitest suite was deprecated and removed so this badge is no longer relevant.