### PR TITLE
Disable Coveralls reporting

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: RSpec test suite
 
-on: ["push", "pull_request"]
+on: [push]
 
 env:
   DATABASE_URL: postgres://postgres@localhost:5432
@@ -100,25 +100,8 @@ jobs:
       run: |
         bundle exec rspec spec --tag ${{ matrix.rspec-tag }}
 
-    - name: Submit coverage report to Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        flag-name: run-${{ matrix.rspec-tag }}
-        parallel: true
-
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
         name: capybara screenshots
         path: tmp/capybara
-
-  finish:
-    needs: ruby
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true


### PR DESCRIPTION
The Coveralls GitHub action appears to have some issues when running multiple jobs concurrently, e.g. https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/816/checks?check_run_id=1359213763

I suspect this is related to https://github.com/coverallsapp/github-action/issues/59

For now this PR disables the reporting until it can be resolved.