### PR TITLE
Upload coverage report to CodeCov

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -100,6 +100,9 @@ jobs:
       run: |
         bundle exec rspec spec --tag ${{ matrix.rspec-tag }}
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Built by the [Office for Product Safety and Standards](https://www.gov.uk/govern
 For enquiries, contact [opss.enquiries@beis.gov.uk](opss.enquiries@beis.gov.uk)
 
 ![](https://github.com/UKGovernmentBEIS/beis-opss-psd/workflows/RSpec%20test%20suite/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/UKGovernmentBEIS/beis-opss-psd/badge.svg?branch=master)](https://coveralls.io/github/UKGovernmentBEIS/beis-opss-psd?branch=master)
+[![Test coverage](https://codecov.io/gh/UKGovernmentBEIS/beis-opss-psd/branch/master/graph/badge.svg?token=QJPCC6LEUW)](https://codecov.io/gh/UKGovernmentBEIS/beis-opss-psd)
 [![Maintainability](https://api.codeclimate.com/v1/badges/233b845a516a9c2eecea/maintainability)](https://codeclimate.com/github/UKGovernmentBEIS/beis-opss-psd/maintainability)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=UKGovernmentBEIS/beis-opss-psd)](https://dependabot.com)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# Delay notifying or posting PR comments about coverage until both CI test
+# suite workflows are completed. See .github/workflows/rspec.yml
+codecov:
+    notify:
+        after_n_builds: 2
+comment:
+  after_n_builds: 2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 
 require "simplecov"
 
-# Output coverage in LCOV format for Coveralls in CI environment
+# Output coverage in LCOV format for CodeCov in CI environment
 if ENV["CI"]
   require "simplecov-lcov"
   SimpleCov::Formatter::LcovFormatter.config do |c|


### PR DESCRIPTION
Implements code coverage reporting with [CodeCov](https://codecov.io/), replacing the previous Coveralls integration.

There were some issues with Coveralls' GitHub Action not working in parallel with other pull requests (throwing errors), reporting changes in coverage incorrectly, and necessitating two test runs per push in order to get PR comments.

I have tested CodeCov's implementation and it seems to resolve most of the issues. I haven't been able to test whether it works in parallel with multiple PRs. This will emerge when we use it in anger.

The main disadvantage compared with Coveralls that I have identified is that in order to prevent premature reporting it is necessary to manually specify the number of parallel test runs (2). Coveralls has a separate 'finish' action which seems more elegant. However this will only be a problem if we need to further split up the tests and can't predict the number of runs needed.