### PR TITLE
Replace usage of deprecated add-path in GitHub workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C $GITHUB_WORKSPACE/bin
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
     - name: Create GitHub deployment for Staging
       env:

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C $GITHUB_WORKSPACE/bin
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
     - name: Delete review app
       run: |

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C $GITHUB_WORKSPACE/bin
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
     - name: Deploy
       env:


### PR DESCRIPTION
Replaces usage of `add-path` in GitHub Actions as described in:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Resolves warning messages seen in action annotations.