### PR TITLE
Avoid sprocket building assets concurrently

### DIFF
--- a/config/initializers/sprockets.rb.rb
+++ b/config/initializers/sprockets.rb.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+  config.assets.configure do |env|
+    env.export_concurrent = false
+  end
+end


### PR DESCRIPTION
## description
This is a temporary fix until https://github.com/sass/sassc-ruby/issues/207 is
resolved

This should stop the segfault from happening upon deploy

