### PR TITLE
migrate counterfaited product flag

### DIFF
--- a/db/migrate/20201110124109_flag_as_counterfeit_products.rb
+++ b/db/migrate/20201110124109_flag_as_counterfeit_products.rb
@@ -1,0 +1,18 @@
+class FlagAsCounterfeitProducts < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up do
+          execute <<~SQL
+              UPDATE products SET authenticity = 'counterfeit' WHERE id IN (
+                   SELECT id FROM (
+                                 SELECT id AS id , CONCAT(batch_number, ' ', category, ' ', description, ' ', product_code, ' ', name, ' ', brand) AS search FROM products
+                          ) AS joined
+                   WHERE search ILIKE '%counterfeit%'
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_150751) do
+ActiveRecord::Schema.define(version: 2020_11_10_124109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Description
21 products contains the word counterfeit in various fields. This sets the `authenticity` to `counterfeit`.