### PR TITLE
Fix email validation bug when whitelisting is turned on

### DIFF
--- a/app/forms/invite_user_to_team_form.rb
+++ b/app/forms/invite_user_to_team_form.rb
@@ -34,6 +34,9 @@ private
 
   def email_domain_must_be_whitelisted
     address = Mail::Address.new(email)
+  rescue Mail::Field::IncompleteParseError
+    errors.add(:email, :not_whitelisted, opss_enquiries_email: opss_enquiries_email)
+  else
     errors.add(:email, :not_whitelisted, opss_enquiries_email: opss_enquiries_email) unless whitelisted_domains.include?(address.domain.to_s.downcase)
   end
 

--- a/app/forms/invite_user_to_team_form.rb
+++ b/app/forms/invite_user_to_team_form.rb
@@ -35,7 +35,7 @@ private
   def email_domain_must_be_whitelisted
     address = Mail::Address.new(email)
   rescue Mail::Field::IncompleteParseError
-    return
+    # This error will be thrown when an email address is incorrectly formatted. The form will be invalid based on that so no need to do add error here.
   else
     errors.add(:email, :not_whitelisted, opss_enquiries_email: opss_enquiries_email) unless whitelisted_domains.include?(address.domain.to_s.downcase)
   end

--- a/app/forms/invite_user_to_team_form.rb
+++ b/app/forms/invite_user_to_team_form.rb
@@ -35,7 +35,7 @@ private
   def email_domain_must_be_whitelisted
     address = Mail::Address.new(email)
   rescue Mail::Field::IncompleteParseError
-    errors.add(:email, :not_whitelisted, opss_enquiries_email: opss_enquiries_email)
+    return
   else
     errors.add(:email, :not_whitelisted, opss_enquiries_email: opss_enquiries_email) unless whitelisted_domains.include?(address.domain.to_s.downcase)
   end

--- a/spec/forms/invite_user_to_team_form_spec.rb
+++ b/spec/forms/invite_user_to_team_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe InviteUserToTeamForm do
       it "populates an error message" do
         form.validate
         errors.each do |property, message|
-          expect(form.errors.full_messages_for(property)).to eq([message])
+          expect(form.errors.full_messages_for(property)).to eq([message].flatten)
         end
       end
     end
@@ -63,17 +63,29 @@ RSpec.describe InviteUserToTeamForm do
       end
     end
 
-    context "when whitelisted email is supplied with whitelisting enabled" do
+    context "with whitelisting enabled" do
       let(:email) { "test@beis.gov.uk" }
 
       before { set_whitelisting_enabled(true) }
 
       include_examples "valid form"
 
-      context "when the supplied email is uppercased" do
+      context "when whitelisted email is supplied and uppercased" do
         let(:email) { "test@BEIS.gov.uk" }
 
         include_examples "valid form"
+      end
+
+      context "when incorrectly formatted email is supplied" do
+        let(:email) { "an.onymous:sheffield.gov.uk" }
+
+        include_examples "invalid form", [
+          :email,
+          [
+            "Enter an email address in the correct format, like name@example.com",
+            "The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@beis.gov.uk to add it to the approved list."
+          ]
+        ]
       end
     end
 

--- a/spec/forms/invite_user_to_team_form_spec.rb
+++ b/spec/forms/invite_user_to_team_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe InviteUserToTeamForm do
       it "populates an error message" do
         form.validate
         errors.each do |property, message|
-          expect(form.errors.full_messages_for(property)).to eq([message].flatten)
+          expect(form.errors.full_messages_for(property)).to eq([message])
         end
       end
     end
@@ -79,13 +79,7 @@ RSpec.describe InviteUserToTeamForm do
       context "when incorrectly formatted email is supplied" do
         let(:email) { "an.onymous:sheffield.gov.uk" }
 
-        include_examples "invalid form", [
-          :email,
-          [
-            "Enter an email address in the correct format, like name@example.com",
-            "The email address is not recognised. Check you’ve entered it correctly, or email opss.enquiries@beis.gov.uk to add it to the approved list."
-          ]
-        ]
+        include_examples "invalid form", [:email, "Enter an email address in the correct format, like name@example.com"]
       end
     end
 


### PR DESCRIPTION
## Description
Prior to this commit whitelisting emails is enabled we see errors being raised if an incorrectly formatted email is entered. We did not see this issue raised in tests, nor could we replicate it in development, because `EMAIL_WHITELIST_ENABLED` is set to false.

The issue is that Mail::Field::IncompleteParseError is raised but not handled.

This commit rescues from this error and adds the whitelisted domain error to our form.

Note: This will raise both an error for incorrectly formatted error and an error for non-whitelisted email. The other option I considered was to return from `#email_domain_must_be_whitelisted` if there were existing validation errors, but while I believe that `validates` run before `validate` I can't seem to find any concrete documentation on that, and so I do not want to rely on the validations running in order (e.g validating email formatting before this whitelisting validation.)

Another option could be to validate format of the email again, but that is obviously more expensive.

https://trello.com/c/m425Ruk8/810-email-validations-bug

Screenshots (with whitelisting turned on):
Before:
![Screenshot 2020-11-10 at 13 43 02](https://user-images.githubusercontent.com/13124899/98681484-acea5800-235a-11eb-80b3-2d2d97b63a69.png)

After:
![Screenshot 2020-11-10 at 13 41 09](https://user-images.githubusercontent.com/13124899/98681318-7c0a2300-235a-11eb-9249-c4f585485e27.png)


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
