### PR TITLE
fix risk assessment uploaded document cleared when create/edit form has a validation error

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -17,3 +17,4 @@ ANTIVIRUS_PASSWORD=password
 TWO_FACTOR_AUTHENTICATION_ENABLED=false
 TWO_FACTOR_AUTH_MOBILE_NUMBER=your-mobile-number-to-receive-two-factor-authentication-code
 SEED_USERS='JohannMuster:muster@example.org:07777888999;JohnDoe:example@example.org:07777888999'
+COVERAGE=false

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -122,7 +122,19 @@ module Investigations
   private
 
     def risk_assessment_params
-      params.require(:risk_assessment_form).permit(:details, :risk_level, :risk_assessment_file, :assessed_by, :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :custom_risk_level, assessed_on: %i[day month year], product_ids: [])
+      params.require(:risk_assessment_form).permit(
+        :details,
+        :risk_level,
+        :risk_assessment_file,
+        :assessed_by,
+        :assessed_by_team_id,
+        :assessed_by_business_id,
+        :assessed_by_other,
+        :custom_risk_level,
+        :existing_risk_assessment_file_file_id,
+        assessed_on: %i[day month year],
+        product_ids: []
+      )
     end
   end
 end

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -15,9 +15,12 @@ module Investigations
 
       authorize @investigation, :update?
 
-      @risk_assessment_form = RiskAssessmentForm.new(current_user: current_user, investigation: @investigation)
+      @risk_assessment_form = RiskAssessmentForm.new(
+        risk_assessment_params.merge(current_user: current_user, investigation: @investigation)
+      )
 
-      @risk_assessment_form.attributes = risk_assessment_params
+      @risk_assessment_form.cache_file!
+      @risk_assessment_form.load_risk_assessment_file
 
       if @risk_assessment_form.valid?
 

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -66,17 +66,16 @@ module Investigations
                     else
                       "other"
                     end
-
       @risk_assessment_form = RiskAssessmentForm.new(
-        @risk_assessment.attributes.symbolize_keys.slice(
-          :assessed_on, :risk_level, :custom_risk_level, :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :details
-        ).merge({
-          current_user: current_user,
-          investigation: @investigation,
-          assessed_by: assessed_by,
-          product_ids: @risk_assessment.product_ids,
-          old_file: @risk_assessment.risk_assessment_file
-        })
+        @risk_assessment.serializable_hash(
+          only: %i[assessed_on risk_level custom_risk_level assessed_by_team_id assessed_by_business_id assessed_by_other details])
+          .merge(
+            current_user: current_user,
+            investigation: @investigation,
+            assessed_by: assessed_by,
+            product_ids: @risk_assessment.product_ids,
+            old_file: @risk_assessment.risk_assessment_file_blob
+          )
       )
 
       @risk_assessment = @risk_assessment.decorate
@@ -93,7 +92,7 @@ module Investigations
       @risk_assessment_form = RiskAssessmentForm.new(
         current_user: current_user,
         investigation: @investigation,
-        old_file: @risk_assessment.risk_assessment_file
+        old_file: @risk_assessment.risk_assessment_file_blob
       )
 
       @risk_assessment_form.attributes = risk_assessment_params

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -60,14 +60,13 @@ module Investigations
       @risk_assessment_form = RiskAssessmentForm.new(
         @risk_assessment.serializable_hash(
           only: %i[assessed_on risk_level custom_risk_level assessed_by_team_id assessed_by_business_id assessed_by_other details]
+        ).merge(
+          current_user: current_user,
+          investigation: @investigation,
+          assessed_by: assessed_by,
+          product_ids: @risk_assessment.product_ids,
+          old_file: @risk_assessment.risk_assessment_file_blob
         )
-          .merge(
-            current_user: current_user,
-            investigation: @investigation,
-            assessed_by: assessed_by,
-            product_ids: @risk_assessment.product_ids,
-            old_file: @risk_assessment.risk_assessment_file_blob
-          )
       )
 
       @risk_assessment = @risk_assessment.decorate

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -57,15 +57,6 @@ module Investigations
 
       @risk_assessment = @investigation.risk_assessments.find(params[:id])
 
-      assessed_by = if @risk_assessment.assessed_by_team == current_user.team
-                      "my_team"
-                    elsif @risk_assessment.assessed_by_team
-                      "another_team"
-                    elsif @risk_assessment.assessed_by_business
-                      "business"
-                    else
-                      "other"
-                    end
       @risk_assessment_form = RiskAssessmentForm.new(
         @risk_assessment.serializable_hash(
           only: %i[assessed_on risk_level custom_risk_level assessed_by_team_id assessed_by_business_id assessed_by_other details]
@@ -135,6 +126,18 @@ module Investigations
         assessed_on: %i[day month year],
         product_ids: []
       )
+    end
+
+    def assessed_by
+      if @risk_assessment.assessed_by_team == current_user.team
+        "my_team"
+      elsif @risk_assessment.assessed_by_team
+        "another_team"
+      elsif @risk_assessment.assessed_by_business
+        "business"
+      else
+        "other"
+      end
     end
   end
 end

--- a/app/controllers/investigations/risk_assessments_controller.rb
+++ b/app/controllers/investigations/risk_assessments_controller.rb
@@ -68,7 +68,8 @@ module Investigations
                     end
       @risk_assessment_form = RiskAssessmentForm.new(
         @risk_assessment.serializable_hash(
-          only: %i[assessed_on risk_level custom_risk_level assessed_by_team_id assessed_by_business_id assessed_by_other details])
+          only: %i[assessed_on risk_level custom_risk_level assessed_by_team_id assessed_by_business_id assessed_by_other details]
+        )
           .merge(
             current_user: current_user,
             investigation: @investigation,

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -586,7 +586,7 @@ private
   end
 
   def trading_standards_risk_assessment_form_params
-    params.require(:trading_standards_risk_assessment_form).permit(:further_risk_assessments, :details, :risk_level, :risk_assessment_file, :assessed_by, :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :custom_risk_level, assessed_on: %i[day month year], product_ids: [])
+    params.require(:trading_standards_risk_assessment_form).permit(:further_risk_assessments, :details, :risk_level, :existing_risk_assessment_file_file_id, :risk_assessment_file, :assessed_by, :assessed_by_team_id, :assessed_by_business_id, :assessed_by_other, :custom_risk_level, assessed_on: %i[day month year], product_ids: [])
   end
 
   def businesses_from_session

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,4 +20,20 @@ module ApplicationHelper
     sanitized_input = sanitize(text, tags: %w[br])
     rc.render(sanitized_input).html_safe
   end
+
+  def replace_uploaded_file_field(form, field_name, label:, label_classes: "govuk-label--m")
+    existing_uploaded_file_id = form.hidden_field "existing_#{field_name}_file_id"
+    file_upload_field         = form.govuk_file_upload(field_name, label: label, label_classes: label_classes)
+    uploaded_file             = form.object.public_send(field_name)
+
+    return safe_join([existing_uploaded_file_id, file_upload_field]) if uploaded_file.blank?
+
+    safe_join(
+      [
+        existing_uploaded_file_id,
+        render(uploaded_file),
+        govukDetails(summaryText: "Replace this file", html: file_upload_field)
+      ]
+    )
+  end
 end

--- a/app/services/update_risk_assessment.rb
+++ b/app/services/update_risk_assessment.rb
@@ -15,7 +15,7 @@ class UpdateRiskAssessment
     @previous_attachment_filename = risk_assessment.risk_assessment_file.filename
 
     ActiveRecord::Base.transaction do
-      risk_assessment.attributes = {
+      risk_assessment.assign_attributes(
         assessed_on: assessed_on,
         risk_level: risk_level,
         custom_risk_level: custom_risk_level.presence,
@@ -24,7 +24,7 @@ class UpdateRiskAssessment
         assessed_by_other: assessed_by_other.presence,
         details: details,
         product_ids: product_ids
-      }
+      )
 
       if risk_assessment_file
         risk_assessment.risk_assessment_file.detach

--- a/app/views/application/_upload_file_component.html.erb
+++ b/app/views/application/_upload_file_component.html.erb
@@ -1,0 +1,12 @@
+<% if old_file.present? %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= legend %></legend>
+    <%= render form.object.old_file %>
+
+    <%= govukDetails(summaryText: "Replace this file") do %>
+      <%= form.govuk_file_upload field_name, label: "Select file", label_classes: "govuk-label--s" %>
+    <% end %>
+  </fieldset>
+<% else %>
+  <%= replace_uploaded_file_field form, field_name, label: label %>
+<% end %>

--- a/app/views/investigations/active_storage/blobs/_blob.html.erb
+++ b/app/views/investigations/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,4 @@
+<p id="current-attachment-details">
+  Currently selected file:
+  <%= link_to blob.filename, url_for(blob), target: "_blank", rel: 'noopener' %>
+</p>

--- a/app/views/investigations/risk_assessments/_form_fields.html.erb
+++ b/app/views/investigations/risk_assessments/_form_fields.html.erb
@@ -68,40 +68,7 @@ assessed_by_radio_items.push(text: "Someone else", value: :other, conditional: {
   <% end %>
 <% end %>
 
-<% if form.object.old_file.present? %>
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Upload the risk assessment</legend>
-    <p id="current-attachment-details">
-      Currently selected file:
-      <%= link_to form.object.old_file.filename, form.object.old_file.blob, target: "_blank", rel: 'noopener' %>
-    </p>
-
-    <%= govukDetails(summaryText: "Replace this file") do %>
-      <%= form.govuk_file_upload :risk_assessment_file,
-        label: "Select file",
-        label_classes: "govuk-label--s"
-      %>
-    <% end %>
-  </fieldset>
-<% else %>
-  <%= form.hidden_field :existing_risk_assessment_file_file_id %>
-  <% file_upload_field = capture do %>
-    <%= form.govuk_file_upload :risk_assessment_file,
-        label: "Upload the risk assessment",
-        label_classes: "govuk-label--m"
-    %>
-  <% end %>
-  <% if form.object.risk_assessment_file.present? %>
-    <p id="current-attachment-details">
-      Currently selected file:
-      <%= link_to form.object.risk_assessment_file.filename, url_for(form.object.risk_assessment_file), target: "_blank", rel: 'noopener' %>
-    </p>
-
-    <%= govukDetails(summaryText: "Replace this file", html: file_upload_field) %>
-  <% else %>
-    <%= file_upload_field %>
-  <% end %>
-<% end %>
+<%= render "upload_file_component", form: form, old_file: form.object.old_file, field_name: :risk_assessment_file, legend: "Upload the risk assessment", label: "Upload the risk assessment" %>
 
 <%= form.govuk_text_area :details,
    label: "Further details (optional)"

--- a/app/views/investigations/risk_assessments/_form_fields.html.erb
+++ b/app/views/investigations/risk_assessments/_form_fields.html.erb
@@ -84,10 +84,23 @@ assessed_by_radio_items.push(text: "Someone else", value: :other, conditional: {
     <% end %>
   </fieldset>
 <% else %>
-  <%= form.govuk_file_upload :risk_assessment_file,
-    label: "Upload the risk assessment",
-    label_classes: "govuk-label--m"
-  %>
+  <%= form.hidden_field :existing_transcript_file_id %>
+  <% file_upload_field = capture do %>
+    <%= form.govuk_file_upload :risk_assessment_file,
+        label: "Upload the risk assessment",
+        label_classes: "govuk-label--m"
+    %>
+  <% end %>
+  <% if form.object.risk_assessment_file.present? %>
+    <p id="current-attachment-details">
+      Currently selected file:
+      <%= link_to form.object.risk_assessment_file.filename, url_for(form.object.risk_assessment_file), target: "_blank", rel: 'noopener' %>
+    </p>
+
+    <%= govukDetails(summaryText: "Replace this file", html: file_upload_field) %>
+  <% else %>
+    <%= file_upload_field %>
+  <% end %>
 <% end %>
 
 <%= form.govuk_text_area :details,

--- a/app/views/investigations/risk_assessments/_form_fields.html.erb
+++ b/app/views/investigations/risk_assessments/_form_fields.html.erb
@@ -84,7 +84,7 @@ assessed_by_radio_items.push(text: "Someone else", value: :other, conditional: {
     <% end %>
   </fieldset>
 <% else %>
-  <%= form.hidden_field :existing_transcript_file_id %>
+  <%= form.hidden_field :existing_risk_assessment_file_file_id %>
   <% file_upload_field = capture do %>
     <%= form.govuk_file_upload :risk_assessment_file,
         label: "Upload the risk assessment",

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -55,11 +55,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
                                 options: ["", "MyBrand Distributors", "MyBrand Inc"],
                                 selected: [""])
 
-    attach_file "Upload the risk assessment", risk_assessment_file
-
     click_button "Add risk assessment"
-
-    save_and_open_page
 
     expect(page).to have_text("Enter the date of the assessment")
     expect(page).to have_text("Select the risk level")
@@ -71,6 +67,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
 
     click_button "Add risk assessment"
 
+    expect(page).to have_css("#current-attachment-details a", text: risk_assessment_file.basename.to_s)
     expect(page).not_to have_text("You must upload the risk assessment")
 
     within_fieldset("Date of assessment") do
@@ -90,8 +87,6 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
     within_fieldset("Which products were assessed?") do
       check "MyBrand washing machine model X"
     end
-
-    attach_file "Upload the risk assessment", risk_assessment_file
 
     fill_in("Further details (optional)", with: "Products risk-assessed in response to incident.")
 

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -55,7 +55,11 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
                                 options: ["", "MyBrand Distributors", "MyBrand Inc"],
                                 selected: [""])
 
+    attach_file "Upload the risk assessment", risk_assessment_file
+
     click_button "Add risk assessment"
+
+    save_and_open_page
 
     expect(page).to have_text("Enter the date of the assessment")
     expect(page).to have_text("Select the risk level")

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -175,6 +175,15 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         # trigger validation to verify state in session is cleaned up correctly
         click_on "Continue"
 
+        within_fieldset("Date of assessment") do
+          fill_in("Year", with: "2020")
+        end
+
+        attach_file "Upload the risk assessment", risk_assessments.first[:file]
+        click_on "Continue"
+
+        expect(page).to have_link risk_assessments.first[:file].basename.to_s
+
         risk_assessments.each do |assessment|
           fill_in_risk_assessment_details_page(with: assessment)
           expect_to_be_on_risk_assessment_details_page
@@ -576,7 +585,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
     expect(page.find(".govuk-heading-m")).to have_sibling("p.govuk-body", text: product_details[:name])
 
-    attach_file "trading_standards_risk_assessment_form[risk_assessment_file]", with[:file]
+    page.find("details summary span.govuk-details__summary-text", text: "Replace this file").click
+    attach_file "Upload the risk assessment", with[:file]
 
     within_fieldset("Are there other risk assessments to report?") do
       choose "Yes"

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -585,7 +585,9 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
     expect(page.find(".govuk-heading-m")).to have_sibling("p.govuk-body", text: product_details[:name])
 
-    page.find("details summary span.govuk-details__summary-text", text: "Replace this file").click
+    if page.has_css?("details summary span.govuk-details__summary-text", text: "Replace this file")
+      page.find("details summary span.govuk-details__summary-text", text: "Replace this file").click
+    end
     attach_file "Upload the risk assessment", with[:file]
 
     within_fieldset("Are there other risk assessments to report?") do

--- a/spec/forms/risk_assessment_form_spec.rb
+++ b/spec/forms/risk_assessment_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
   let(:old_file) { nil }
   let(:risk_assessment_file) { Rack::Test::UploadedFile.new("test/fixtures/files/test_result.txt") }
 
-  let(:params) {
+  let(:params) do
     {
       investigation: investigation,
       current_user: user,
@@ -34,7 +34,7 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
       risk_assessment_file: risk_assessment_file,
       details: details
     }
-  }
+  end
 
   let(:form) { described_class.new(params) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ if ENV["CI"]
   end
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 
+end
+unless ENV["COVERAGE"] == "false"
   SimpleCov.start "rails" do
     enable_coverage :branch
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,6 @@ if ENV["CI"]
   end
 end
 
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,11 +10,12 @@ if ENV["CI"]
     c.single_report_path = "coverage/lcov.info"
   end
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+
+  SimpleCov.start "rails" do
+    enable_coverage :branch
+  end
 end
 
-SimpleCov.start "rails" do
-  enable_coverage :branch
-end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"


### PR DESCRIPTION
## Description

This solves the problem whereby the attachment is lost upon validation error. 

I've used the same pattern we in other controller, unifying the interface: `FormObject#cache_file!` `FormObject#load_attribute_name_file` 

I've also created a `app/views/application/_upload_file_component.html.erb ` so that partial could be reused wherever we have file to upload.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [X] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
