### PR TITLE
Order the error messages on forms in the same order as the questions

### DIFF
--- a/app/models/investigation/allegation.rb
+++ b/app/models/investigation/allegation.rb
@@ -1,6 +1,6 @@
 class Investigation < ApplicationRecord
   class Allegation < Investigation
-    validates :description, :hazard_type, :product_category, presence: true, on: :allegation_details
+    validates :description, :product_category, :hazard_type, presence: true, on: :allegation_details
 
     index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "investigations"].join("_")
 

--- a/app/models/investigation/enquiry.rb
+++ b/app/models/investigation/enquiry.rb
@@ -1,6 +1,6 @@
 class Investigation < ApplicationRecord
   class Enquiry < Investigation
-    validates :user_title, :description, presence: true, on: :enquiry_details
+    validates :description, :user_title, presence: true, on: :enquiry_details
     validates :date_received,
               presence: true,
               real_date: true,

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -65,9 +65,11 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       click_button "Create allegation"
 
       expect_to_be_on_allegation_details_page
-      expect(page).to have_summary_error("Description cannot be blank")
-      expect(page).to have_summary_error("Enter the primary hazard")
-      expect(page).to have_summary_error("Enter a valid product category")
+
+      errors_list = page.find('.govuk-error-summary__list').all('li')
+      expect(errors_list[0].text).to eq "Description cannot be blank"
+      expect(errors_list[1].text).to eq "Enter a valid product category"
+      expect(errors_list[2].text).to eq "Enter the primary hazard"
 
       enter_allegation_details(**allegation_details)
 

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       expect_to_be_on_allegation_details_page
 
-      errors_list = page.find('.govuk-error-summary__list').all('li')
+      errors_list = page.find(".govuk-error-summary__list").all("li")
       expect(errors_list[0].text).to eq "Description cannot be blank"
       expect(errors_list[1].text).to eq "Enter a valid product category"
       expect(errors_list[2].text).to eq "Enter the primary hazard"

--- a/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -228,7 +228,7 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     click_button "Create enquiry"
 
     expect(page).to have_error_messages
-    errors_list = page.find('.govuk-error-summary__list').all('li')
+    errors_list = page.find(".govuk-error-summary__list").all("li")
     expect(errors_list[0].text).to eq "Description cannot be blank"
     expect(errors_list[1].text).to eq "User title cannot be blank"
   end

--- a/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -18,6 +18,13 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       file: Rails.root + "test/fixtures/files/testImage.png",
     }
   end
+  let(:blank_enquiry_details) do
+    {
+      enquiry_description: nil,
+      enquiry_title: nil,
+      file: nil,
+    }
+  end
 
   let(:user) { create(:user, :activated, :opss_user) }
   let(:other_user_same_team) { create(:user, :activated, organisation: user.organisation, team: user.team) }
@@ -57,6 +64,9 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       enter_contact_details(**contact_details)
 
       expect_to_be_on_enquiry_details_page
+
+      check_cannot_be_blank_errors
+
       fill_in_new_enquiry_details(with: enquiry_details)
       click_button "Create enquiry"
 
@@ -211,6 +221,16 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     fill_in_when_and_how_was_it_received(received_type: "Other", day: "", month: "", year: date.year, other_received_type: other_received_type)
     expect(page).to have_error_messages
     expect(page).to have_error_summary "Date enquiry received must include a day and month"
+  end
+
+  def check_cannot_be_blank_errors
+    fill_in_new_enquiry_details(with: blank_enquiry_details)
+    click_button "Create enquiry"
+
+    expect(page).to have_error_messages
+    errors_list = page.find('.govuk-error-summary__list').all('li')
+    expect(errors_list[0].text).to eq "Description cannot be blank"
+    expect(errors_list[1].text).to eq "User title cannot be blank"
   end
 
   def check_the_other_received_type_field_has_retained_its_value


### PR DESCRIPTION
https://trello.com/c/swtimLYe/806-enquiry-form-error-summary-to-be-in-correct-order

## Description
Prior to this PR both the enquiry form and the allegation had error messages showing in the incorrect order (see screenshots).

The ordering of errors is based upon the order in which the validations are run, so ensuring the validations are run in the same order as the fields appear on the form corrects the issue.

This PR orders the errors in the same order as the questions appear on the forms.

## Before:
![Screenshot 2020-11-12 at 09 38 32](https://user-images.githubusercontent.com/13124899/98932191-eba51d00-24d6-11eb-9ead-a3fee3835fb3.png)
![Screenshot 2020-11-12 at 09 39 08](https://user-images.githubusercontent.com/13124899/98922915-f063d400-24ca-11eb-94a5-1fe5cf16cbd8.png)

## After:
![Screenshot 2020-11-12 at 09 37 06](https://user-images.githubusercontent.com/13124899/98922707-b09cec80-24ca-11eb-8d9f-006ea31dcd0f.png)
![Screenshot 2020-11-12 at 09 38 04](https://user-images.githubusercontent.com/13124899/98922791-cad6ca80-24ca-11eb-9021-932d4da21cd7.png)


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
