### PR TITLE
fix empty paragraphs when empty description

### DIFF
--- a/app/decorators/concerns/formated_description.rb
+++ b/app/decorators/concerns/formated_description.rb
@@ -1,0 +1,7 @@
+module FormatedDescription
+  extend ActiveSupport::Concern
+
+  def description
+    h.simple_format(object.description) if object.description.present?
+  end
+end

--- a/app/decorators/concerns/formatted_description.rb
+++ b/app/decorators/concerns/formatted_description.rb
@@ -1,4 +1,4 @@
-module FormatedDescription
+module FormattedDescription
   extend ActiveSupport::Concern
 
   def description

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -1,4 +1,5 @@
 class InvestigationDecorator < ApplicationDecorator
+  include FormatedDescription
   delegate_all
   decorates_associations :complainant, :documents_attachments, :creator_user, :owner_user, :owner_team, :activities, :risk_assessments
 
@@ -6,10 +7,6 @@ class InvestigationDecorator < ApplicationDecorator
 
   def title
     user_title
-  end
-
-  def description
-    h.simple_format(object.description)
   end
 
   def display_product_summary_list?

--- a/app/decorators/investigation_decorator.rb
+++ b/app/decorators/investigation_decorator.rb
@@ -1,5 +1,5 @@
 class InvestigationDecorator < ApplicationDecorator
-  include FormatedDescription
+  include FormattedDescription
   delegate_all
   decorates_associations :complainant, :documents_attachments, :creator_user, :owner_user, :owner_team, :activities, :risk_assessments
 

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,5 +1,5 @@
 class ProductDecorator < ApplicationDecorator
-  include FormatedDescription
+  include FormattedDescription
   delegate_all
   decorates_association :investigations
 

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,4 +1,5 @@
 class ProductDecorator < ApplicationDecorator
+  include FormatedDescription
   delegate_all
   decorates_association :investigations
 
@@ -26,10 +27,6 @@ class ProductDecorator < ApplicationDecorator
 
   def authenticity
     I18n.t(object.authenticity || :missing, scope: Product.model_name.i18n_key)
-  end
-
-  def description
-    h.simple_format(object.description)
   end
 
   def product_type_and_category_label

--- a/spec/decorators/investigation_decorator_spec.rb
+++ b/spec/decorators/investigation_decorator_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe InvestigationDecorator, :with_stubbed_elasticsearch, :with_stubbe
 
   describe "#description" do
     include_examples "a formated text", :investigation, :description
+    include_examples "with a blank description", :investigation, :decorated_investigation
   end
 
   describe "#products_list" do

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe ProductDecorator do
 
   describe "#description" do
     include_examples "a formated text", :product, :description
+    include_examples "with a blank description", :product, :decorated_product
   end
 
   describe "#product_type_and_category_label" do

--- a/spec/support/shared_examples/simple_format.rb
+++ b/spec/support/shared_examples/simple_format.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "with a blank description" do |object, reader|
+  describe "with a blank description" do
+    before { public_send(object).description = "" }
+
+    specify { expect(public_send(reader).description).to be nil }
+  end
+end


### PR DESCRIPTION
## Description
When a description is empty the `simple_format` helper output an empty `<p/>`.


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [X] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)
