### PR TITLE
Error ordering to match field ordering on forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,10 +4,25 @@ module ApplicationHelper
     content_for(:page_title, title)
   end
 
-  def error_summary(errors)
+  def error_summary(errors, ordered_attributes = [])
     return unless errors.any?
 
-    error_list = errors.map { |attribute, error| error ? { text: error, href: "##{attribute}" } : nil }.compact
+    ordered_errors = ActiveSupport::OrderedHash.new
+    ordered_attributes.map { |attr| ordered_errors[attr] = [] }
+
+    errors.map do |attribute, error|
+      next if error.blank?
+
+      # Errors for attributes that are not included in the ordered list will be
+      # added at the end after the errors for ordered attributes.
+      if ordered_errors[attribute]
+        ordered_errors[attribute] << { text: error, href: "##{attribute}" }
+      else
+        ordered_errors[attribute] = [{ text: error, href: "##{attribute}" }]
+      end
+    end
+    error_list = ordered_errors.values.flatten.compact
+
     govukErrorSummary(titleText: "There is a problem", errorList: error_list)
   end
 

--- a/app/models/investigation/allegation.rb
+++ b/app/models/investigation/allegation.rb
@@ -1,6 +1,6 @@
 class Investigation < ApplicationRecord
   class Allegation < Investigation
-    validates :description, :hazard_type, :product_category, presence: true, on: :allegation_details
+    validates :description, :product_category, :hazard_type, presence: true, on: :allegation_details
 
     index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "investigations"].join("_")
 

--- a/app/models/investigation/enquiry.rb
+++ b/app/models/investigation/enquiry.rb
@@ -1,6 +1,6 @@
 class Investigation < ApplicationRecord
   class Enquiry < Investigation
-    validates :user_title, :description, presence: true, on: :enquiry_details
+    validates :description, :user_title, presence: true, on: :enquiry_details
     validates :date_received,
               presence: true,
               real_date: true,

--- a/app/views/investigations/creation_flow/allegation_details.html.slim
+++ b/app/views/investigations/creation_flow/allegation_details.html.slim
@@ -4,7 +4,7 @@
 = form_with model: @investigation, scope: :allegation, local: true, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
-      = render "form_components/govuk_error_summary", form: form
+      = error_summary(@investigation.errors, %i[description product_category hazard_type])
       h1.govuk-heading-l = @page_title
 
       = render "form_components/govuk_textarea",

--- a/app/views/investigations/creation_flow/enquiry_details.html.slim
+++ b/app/views/investigations/creation_flow/enquiry_details.html.slim
@@ -5,7 +5,7 @@
 = form_with model: @investigation, scope: :enquiry, local: true, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
-      = render "form_components/govuk_error_summary", form: form
+      = error_summary(@investigation.errors, %i[description user_title])
       h1.govuk-heading-l
         = @page_title
       fieldset.govuk-fieldset

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -11,7 +11,7 @@
 <%= form_with model: @product_form, scope: :product, url: investigation_products_path(@investigation), local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @product_form.errors %>
+      <%= error_summary(@product_form.errors, %i[category product_type authenticity name gtin13]) %>
       <%= render "investigation_heading", investigation: @investigation %>
 
       <h2 class="govuk-heading-m">Add product</h2>

--- a/app/views/investigations/record_corrective_actions/details.html.erb
+++ b/app/views/investigations/record_corrective_actions/details.html.erb
@@ -13,7 +13,7 @@
 <%= form_with model: @corrective_action.object, local: true, url: wizard_path, method: :put, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@corrective_action.errors) %>
+      <%= error_summary(@corrective_action.errors, %i[action date_decided legislation measure_type duration geographic_scope related_file]) %>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_title %></h1>

--- a/app/views/investigations/risk_assessments/edit.html.erb
+++ b/app/views/investigations/risk_assessments/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessment_path(@investigation.pretty_id, @risk_assessment), method: :patch, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
 
-        <%= error_summary @risk_assessment_form.errors %>
+        <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level custom_risk_level assessed_by product_ids risk_assessment_file])%>
         <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
         <h1 class="govuk-heading-l"><%= page_heading %></h1>
 

--- a/app/views/investigations/risk_assessments/new.html.erb
+++ b/app/views/investigations/risk_assessments/new.html.erb
@@ -15,7 +15,7 @@
 
       <%= form_with(model: @risk_assessment_form, local: true, url: investigation_risk_assessments_path, method: :post, builder: ApplicationFormBuilder, html: {novalidate: true}) do |form| %>
 
-        <%= error_summary @risk_assessment_form.errors %>
+        <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level custom_risk_level assessed_by product_ids risk_assessment_file]) %>
         <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
         <h1 class="govuk-heading-l"><%= page_heading %></h1>
 

--- a/app/views/investigations/test_results/new.html.erb
+++ b/app/views/investigations/test_results/new.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <%= render "form_components/govuk_error_summary", form: form %>
+      <%= error_summary(@test_result.errors, %i[legislation date result base])%>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_title %></h1>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -6,7 +6,7 @@
 <%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @product_form.errors %>
+      <%= error_summary(@product_form.errors, %i[category product_type authenticity name]) %>
     </div>
   </div>
 

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -57,11 +57,12 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
 
     click_button "Add risk assessment"
 
-    expect(page).to have_text("Enter the date of the assessment")
-    expect(page).to have_text("Select the risk level")
-    expect(page).to have_text("Select who completed the assessment")
-    expect(page).to have_text("You must choose at least one product")
-    expect(page).to have_text("You must upload the risk assessment")
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Enter the date of the assessment"
+    expect(errors_list[1].text).to eq "Select the risk level"
+    expect(errors_list[2].text).to eq "Select who completed the assessment"
+    expect(errors_list[3].text).to eq "You must choose at least one product"
+    expect(errors_list[4].text).to eq "You must upload the risk assessment"
 
     attach_file "Upload the risk assessment", risk_assessment_file
 

--- a/spec/features/add_corrective_action_spec.rb
+++ b/spec/features/add_corrective_action_spec.rb
@@ -41,6 +41,17 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     expect_to_be_on_record_corrective_action_for_case_page
     expect(page).not_to have_error_messages
 
+    click_button "Continue"
+    expect(page).to have_error_messages
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Select type of corrective action"
+    expect(errors_list[1].text).to eq "Enter date the corrective action was decided"
+    expect(errors_list[2].text).to eq "Select the legislation relevant to the corrective action"
+    expect(errors_list[3].text).to eq "You must state whether the action is mandatory or voluntary"
+    expect(errors_list[4].text).to eq "You must state how long the action will be in place"
+    expect(errors_list[5].text).to eq "You must state the geographic scope of the action"
+    expect(errors_list[6].text).to eq "Select whether you want to upload a related file"
+
     fill_and_submit_form
 
     expect_to_be_on_confirmation_page

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -20,11 +20,12 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
 
     # Expected validation errors
     expect(page).to have_error_messages
-    expect(page).to have_text("Name cannot be blank")
-    expect(page).to have_text("Category cannot be blank")
-    expect(page).to have_text("Product type cannot be blank")
-    expect(page).to have_text("Enter a valid barcode number")
-    expect(page).to have_text("You must state whether the product is a counterfeit")
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Category cannot be blank"
+    expect(errors_list[1].text).to eq "Product type cannot be blank"
+    expect(errors_list[2].text).to eq "You must state whether the product is a counterfeit"
+    expect(errors_list[3].text).to eq "Name cannot be blank"
+    expect(errors_list[4].text).to eq "Enter a valid barcode number"
 
     select attributes[:category], from: "Product category"
 

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -28,10 +28,11 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
 
       click_button "Continue"
 
-      expect(page).to have_summary_error("Enter date of the test")
-      expect(page).to have_summary_error("Select the legislation that relates to this test")
-      expect(page).to have_summary_error("Select result of the test")
-      expect(page).to have_summary_error("Provide the test results file")
+      errors_list = page.find(".govuk-error-summary__list").all("li")
+      expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
+      expect(errors_list[1].text).to eq "Enter date of the test"
+      expect(errors_list[2].text).to eq "Select result of the test"
+      expect(errors_list[3].text).to eq "Provide the test results file"
 
       fill_in "Further details", with: "Test result includes certificate of conformity"
       fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date: date, test_result: "Pass", file: file)

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -65,9 +65,11 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       click_button "Create allegation"
 
       expect_to_be_on_allegation_details_page
-      expect(page).to have_summary_error("Description cannot be blank")
-      expect(page).to have_summary_error("Enter the primary hazard")
-      expect(page).to have_summary_error("Enter a valid product category")
+
+      errors_list = page.find('.govuk-error-summary__list').all('li')
+      expect(errors_list[0].text).to eq "Description cannot be blank"
+      expect(errors_list[1].text).to eq "Enter a valid product category"
+      expect(errors_list[2].text).to eq "Enter the primary hazard"
 
       enter_allegation_details(**allegation_details)
 

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       expect_to_be_on_allegation_details_page
 
-      errors_list = page.find('.govuk-error-summary__list').all('li')
+      errors_list = page.find(".govuk-error-summary__list").all("li")
       expect(errors_list[0].text).to eq "Description cannot be blank"
       expect(errors_list[1].text).to eq "Enter a valid product category"
       expect(errors_list[2].text).to eq "Enter the primary hazard"

--- a/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -228,7 +228,7 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     click_button "Create enquiry"
 
     expect(page).to have_error_messages
-    errors_list = page.find('.govuk-error-summary__list').all('li')
+    errors_list = page.find(".govuk-error-summary__list").all("li")
     expect(errors_list[0].text).to eq "Description cannot be blank"
     expect(errors_list[1].text).to eq "User title cannot be blank"
   end

--- a/spec/features/create_enquiry_as_opss_user_spec.rb
+++ b/spec/features/create_enquiry_as_opss_user_spec.rb
@@ -18,6 +18,13 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       file: Rails.root + "test/fixtures/files/testImage.png",
     }
   end
+  let(:blank_enquiry_details) do
+    {
+      enquiry_description: nil,
+      enquiry_title: nil,
+      file: nil,
+    }
+  end
 
   let(:user) { create(:user, :activated, :opss_user) }
   let(:other_user_same_team) { create(:user, :activated, organisation: user.organisation, team: user.team) }
@@ -57,6 +64,9 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
       enter_contact_details(**contact_details)
 
       expect_to_be_on_enquiry_details_page
+
+      check_cannot_be_blank_errors
+
       fill_in_new_enquiry_details(with: enquiry_details)
       click_button "Create enquiry"
 
@@ -211,6 +221,16 @@ RSpec.feature "Reporting enquiries", :with_stubbed_elasticsearch, :with_stubbed_
     fill_in_when_and_how_was_it_received(received_type: "Other", day: "", month: "", year: date.year, other_received_type: other_received_type)
     expect(page).to have_error_messages
     expect(page).to have_error_summary "Date enquiry received must include a day and month"
+  end
+
+  def check_cannot_be_blank_errors
+    fill_in_new_enquiry_details(with: blank_enquiry_details)
+    click_button "Create enquiry"
+
+    expect(page).to have_error_messages
+    errors_list = page.find('.govuk-error-summary__list').all('li')
+    expect(errors_list[0].text).to eq "Description cannot be blank"
+    expect(errors_list[1].text).to eq "User title cannot be blank"
   end
 
   def check_the_other_received_type_field_has_retained_its_value

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#error_summary" do
+    let(:view_class) do
+      Class.new do
+        include ApplicationHelper
+        include GovukDesignSystem::ErrorSummaryHelper
+      end
+    end
+
+    let(:view) { view_class.new }
+    let(:errors) do
+      [
+        [:name, "Name cannot be blank"],
+        [:email, "Email cannot be blank"],
+        [:mobile_number, "Mobile number is too short"],
+      ]
+    end
+
+    before { allow(view).to receive(:govukErrorSummary) }
+
+    def expect_error_summary_for(formatted_errors)
+      expect(view).to have_received(:govukErrorSummary).with(
+        titleText: "There is a problem",
+        errorList: formatted_errors,
+      )
+    end
+
+    context "when no attributes order is given" do
+      let(:order) { [] }
+
+      it "calls for the error summary with a formatted unordered list of errors" do
+        view.error_summary(errors, order)
+        expect_error_summary_for([{ text: "Name cannot be blank", href: "#name" },
+                                  { text: "Email cannot be blank", href: "#email" },
+                                  { text: "Mobile number is too short", href: "#mobile_number" }])
+      end
+    end
+
+    context "when providing a list with attributes order" do
+      context "with all the attributes defined in the order" do
+        let(:order) { %i[mobile_number email name] }
+
+        it "generates the error summary with an ordered and formatted list of errors" do
+          view.error_summary(errors, order)
+          expect_error_summary_for([{ text: "Mobile number is too short", href: "#mobile_number" },
+                                    { text: "Email cannot be blank", href: "#email" },
+                                    { text: "Name cannot be blank", href: "#name" }])
+        end
+      end
+
+      context "when some attribute is missing in the order" do
+        let(:order) { %i[mobile_number name] }
+
+        it "adds the attribute errors after the ordered ones" do
+          view.error_summary(errors, order)
+          expect_error_summary_for([{ text: "Mobile number is too short", href: "#mobile_number" },
+                                    { text: "Name cannot be blank", href: "#name" },
+                                    { text: "Email cannot be blank", href: "#email" }])
+        end
+      end
+
+      context "when the order includes attributes without errors" do
+        let(:order) { %i[bar name foo mobile_number email] }
+
+        it "ignores them and respects the order for the attributes with errors" do
+          view.error_summary(errors, order)
+          expect_error_summary_for([{ text: "Name cannot be blank", href: "#name" },
+                                    { text: "Mobile number is too short", href: "#mobile_number" },
+                                    { text: "Email cannot be blank", href: "#email" }])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR started from [this ticket](https://trello.com/c/swtimLYe/806-enquiry-form-error-summary-to-be-in-correct-order) which related to incorrect ordering of errors on the enquiry form, but also includes fixes for incorrectly ordered errors on (hopefully) all the other forms that have this issue (which can be found in the comments on the card).

# Description
- Take the logic from the cosmetics app that allows us to optionally specify an ordering of errors each time we call `#error_summary` in a view.
- Add custom ordering to the views in question that already use `#error_summary`
- Change specified views that do not use `#error_summary` already to use it, and give custom ordering.
- Tests.

# Screen shots
### Enquiries
### Before
![enquiries_before](https://user-images.githubusercontent.com/13124899/99056102-b6a9d080-2591-11eb-9c64-ceae53564b52.png)
### After
![enquiries_after](https://user-images.githubusercontent.com/13124899/99056116-be697500-2591-11eb-9f31-71dd9b8ff9d3.png)

###  Allegations
###  Before 
![allegations_before](https://user-images.githubusercontent.com/13124899/99056173-d2ad7200-2591-11eb-9b77-a8b65fc04492.png)
###  After
![allegations_after](https://user-images.githubusercontent.com/13124899/99056188-d8a35300-2591-11eb-9d2a-845c33e480db.png)

###  Corrective Action
###  Before
![add_corrective_action_before](https://user-images.githubusercontent.com/13124899/99056234-eeb11380-2591-11eb-8f17-98a8e3a9258b.png)
###  After
![add_corrective_action_after](https://user-images.githubusercontent.com/13124899/99056248-f2dd3100-2591-11eb-9e46-cfefd99b6430.png)

###  Risk assessment
###  Before
![add_risk_assesment_before](https://user-images.githubusercontent.com/13124899/99056323-0ee0d280-2592-11eb-9cc9-e8ed7f8ce4e2.png)
###  After
![add_risk_assesment_after](https://user-images.githubusercontent.com/13124899/99056343-1607e080-2592-11eb-9a1a-ed45e07ca704.png)

### Test result
###  Before
![add_test_result_before](https://user-images.githubusercontent.com/13124899/99056444-3899f980-2592-11eb-9ed8-af40a1ba98f8.png)
###  After
![add_test_result_after](https://user-images.githubusercontent.com/13124899/99056482-40f23480-2592-11eb-8747-110f02feb4a6.png)

### Add product
###  Before
![add_products_before](https://user-images.githubusercontent.com/13124899/99056686-94648280-2592-11eb-8268-09845f107cd7.png)
###  After
![add_products_after](https://user-images.githubusercontent.com/13124899/99056702-99c1cd00-2592-11eb-9ce0-9549fcb2d5fa.png)

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
