### PR TITLE
Fix N+1 query performance issue on ownership selection form

### DIFF
--- a/app/controllers/investigations/ownership_controller.rb
+++ b/app/controllers/investigations/ownership_controller.rb
@@ -75,9 +75,9 @@ private
 
   def get_potential_assignees
     @selectable_users = [@investigation.owner_user&.object, current_user].uniq.compact
-    @team_members = current_user.team.users.active
+    @team_members = current_user.team.users.active.includes(:team)
     @selectable_teams = [current_user.team, Team.get_visible_teams(current_user), @investigation.owner_team&.object].flatten.uniq.compact
     @other_teams = Team.not_deleted
-    @other_users = User.active
+    @other_users = User.active.includes(:team)
   end
 end


### PR DESCRIPTION
Fixes a N+1 query performance issue on the case ownership form page.

Example Scout report at https://scoutapm.com/apps/156303/endpoints/Q29udHJvbGxlci9pbnZlc3RpZ2F0aW9ucy9vd25lcnNoaXAvc2hvdw==/trace/1565238595?time=e%3A2020-11-11T00%3A00%3A00-08%3A00%2Cd%3A7-day%2Cc%3Anone