### PR TITLE
Fix N+1 query performance issue on case export

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -19,7 +19,7 @@ class InvestigationsController < ApplicationController
         authorize Investigation, :export?
 
         @answer = search_for_investigations
-        @investigations = @answer.records(includes: %i[complainant creator_user])
+        @investigations = @answer.records(includes: %i[complainant creator_user products owner_team owner_user])
 
         @activity_counts = Activity.group(:investigation_id).count
         @business_counts = InvestigationBusiness.unscoped.group(:investigation_id).count


### PR DESCRIPTION
Fixes a N+1 query performance issue on the case ownership form page.

Example Scout report at https://scoutapm.com/apps/156303/endpoints/Q29udHJvbGxlci9pbnZlc3RpZ2F0aW9ucy9pbmRleA==/trace/1652083634?section=timing&nplusone=2879.029193