### PR TITLE
Show a success message when adding an attachment. Add feature specs

### DIFF
--- a/app/controllers/documents_flow_controller.rb
+++ b/app/controllers/documents_flow_controller.rb
@@ -29,6 +29,8 @@ class DocumentsFlowController < ApplicationController
 
     attach_blobs_to_list(@file_blob, file_collection)
 
+    flash[:success] = t(:file_added, type: @parent.model_name.human.downcase)
+
     return redirect_to(@parent) unless @parent.is_a?(Investigation)
 
     AuditActivity::Document::Add.from(@file_blob, @parent)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,6 +477,7 @@ en:
   coronavirus_related_form:
     inclusion: "Select whether or not the case is related to the coronavirus outbreak"
   enter_email_address: "Enter your email address"
+  file_added: "File has been added to the %{type}"
   otp_code:
     blank: "Enter the security code"
     too_short: "You haven’t entered enough numbers"

--- a/spec/features/add_attachment_to_a_business_spec.rb
+++ b/spec/features/add_attachment_to_a_business_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.feature "Add an attachment to a business", :with_stubbed_elasticsearch, :with_stubbed_antivirus, type: :feature do
+  let(:user)     { create(:user, :activated, has_viewed_introduction: true) }
+  let(:business) { create(:business) }
+
+  let(:file)        { Rails.root + "test/fixtures/files/testImage.png" }
+  let(:title)       { Faker::Lorem.sentence }
+  let(:description) { Faker::Lorem.paragraph }
+
+  scenario "Adding an attachment" do
+    sign_in user
+    visit "/businesses/#{business.id}"
+
+    expect_to_be_on_business_page(business_id: business.id, business_name: business.trading_name)
+
+    click_link "Add attachment"
+    expect_to_be_on_add_attachment_to_a_business_upload_page(business_id: business.id)
+
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_business_upload_page(business_id: business.id)
+    expect(page).to have_error_summary("Enter file")
+
+    attach_file "document[file][file]", file
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_business_metadata_page(business_id: business.id)
+
+    click_button "Save attachment"
+
+    expect_to_be_on_add_attachment_to_a_business_metadata_page(business_id: business.id)
+    expect(page).to have_error_summary("Enter title")
+
+    fill_in "Document title", with: title
+    fill_in "Description",    with: description
+
+    click_button "Save attachment"
+
+    expect_to_be_on_business_page(business_id: business.id, business_name: business.trading_name)
+    expect_confirmation_banner("File has been added to the business")
+
+    within "#attachments" do
+      expect(page).to have_selector("h2", text: title)
+      expect(page).to have_selector("p", text: description)
+    end
+  end
+end

--- a/spec/features/add_attachment_to_a_case_spec.rb
+++ b/spec/features/add_attachment_to_a_case_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.feature "Add an attachment to a case", :with_stubbed_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
+  let(:user)          { create(:user, :activated, has_viewed_introduction: true) }
+  let(:investigation) { create(:allegation, creator: user) }
+
+  let(:image_file)  { Rails.root + "test/fixtures/files/testImage.png" }
+  let(:other_file)  { Rails.root + "test/fixtures/files/attachment_filename.txt" }
+  let(:title)       { Faker::Lorem.sentence }
+  let(:description) { Faker::Lorem.paragraph }
+
+  scenario "Adding an attachment that is not an image" do
+    sign_in user
+    visit "/cases/#{investigation.pretty_id}/supporting-information/new"
+
+    expect_to_be_on_add_supporting_information_page
+
+    choose "Other document or attachment"
+    click_button "Continue"
+
+    expect_to_be_on_add_attachment_to_a_case_upload_page
+
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_case_upload_page
+    expect(page).to have_error_summary("Enter file")
+
+    attach_file "document[file][file]", other_file
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_case_metadata_page
+
+    click_button "Save attachment"
+
+    expect_to_be_on_add_attachment_to_a_case_metadata_page
+    expect(page).to have_error_summary("Enter title")
+
+    fill_in "Document title", with: title
+    fill_in "Description",    with: description
+
+    click_button "Save attachment"
+
+    expect_to_be_on_supporting_information_page(case_id: investigation.pretty_id)
+    expect_confirmation_banner("File has been added to the allegation")
+
+    within page.find("h2", text: "Other files and attachments").find(:xpath, "..") do
+      expect(page).to have_selector("h2", text: title)
+      expect(page).to have_selector("p", text: description)
+    end
+  end
+
+  scenario "Adding an image" do
+    sign_in user
+    visit "/cases/#{investigation.pretty_id}/supporting-information/new"
+
+    expect_to_be_on_add_supporting_information_page
+
+    choose "Other document or attachment"
+    click_button "Continue"
+
+    expect_to_be_on_add_attachment_to_a_case_upload_page
+
+    attach_file "document[file][file]", image_file
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_case_metadata_page
+
+    fill_in "Document title", with: title
+    fill_in "Description",    with: description
+
+    click_button "Save attachment"
+
+    expect_to_be_on_images_page
+    expect_confirmation_banner("File has been added to the allegation")
+
+    expect(page).to have_selector("h2", text: title)
+    expect(page).to have_selector("p", text: description)
+  end
+end

--- a/spec/features/add_attachment_to_a_product_spec.rb
+++ b/spec/features/add_attachment_to_a_product_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.feature "Add an attachment to a product", :with_stubbed_elasticsearch, :with_stubbed_antivirus, type: :feature do
+  let(:user)    { create(:user, :activated, has_viewed_introduction: true) }
+  let(:product) { create(:product) }
+
+  let(:file)        { Rails.root + "test/fixtures/files/testImage.png" }
+  let(:title)       { Faker::Lorem.sentence }
+  let(:description) { Faker::Lorem.paragraph }
+
+  scenario "Adding an attachment" do
+    sign_in user
+    visit "/products/#{product.id}"
+
+    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
+
+    click_link "Add attachment"
+    expect_to_be_on_add_attachment_to_a_product_upload_page(product_id: product.id)
+
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_product_upload_page(product_id: product.id)
+    expect(page).to have_error_summary("Enter file")
+
+    attach_file "document[file][file]", file
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id: product.id)
+
+    click_button "Save attachment"
+
+    expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id: product.id)
+    expect(page).to have_error_summary("Enter title")
+
+    fill_in "Document title", with: title
+    fill_in "Description",    with: description
+
+    click_button "Save attachment"
+
+    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
+    expect_confirmation_banner("File has been added to the product")
+
+    within "#attachments" do
+      expect(page).to have_selector("h2", text: title)
+      expect(page).to have_selector("p", text: description)
+    end
+  end
+end

--- a/spec/features/case_images_tab_spec.rb
+++ b/spec/features/case_images_tab_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Manage Images", :with_stubbed_elasticsearch, :with_stubbed_antivi
     fill_and_submit_attachment_details_page
 
     expect_to_be_on_images_page
+    expect_confirmation_banner("File has been added to the allegation")
 
     expect_case_images_page_to_show_entered_information
 

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -139,6 +139,16 @@ module PageExpectations
     expect(page).to have_selector("h1", text: "What type of information are you adding?")
   end
 
+  def expect_to_be_on_add_attachment_to_a_case_upload_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/upload")
+    expect(page).to have_h1("Add attachment")
+  end
+
+  def expect_to_be_on_add_attachment_to_a_case_metadata_page
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new/metadata")
+    expect(page).to have_h1("Add attachment")
+  end
+
   def expect_to_be_on_case_actions_page(case_id:)
     expect(page).to have_current_path("/cases/#{case_id}/actions")
     expect(page).to have_selector("h1", text: "Select an action")
@@ -366,6 +376,16 @@ module PageExpectations
     expect(page).to have_selector("h1", text: product_name)
   end
 
+  def expect_to_be_on_add_attachment_to_a_product_upload_page(product_id:)
+    expect(page).to have_current_path("/products/#{product_id}/documents/new/upload")
+    expect(page).to have_h1("Add attachment")
+  end
+
+  def expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id:)
+    expect(page).to have_current_path("/products/#{product_id}/documents/new/metadata")
+    expect(page).to have_h1("Add attachment")
+  end
+
   # Shared pages across different flows
   def expect_to_be_on_coronavirus_page(path)
     expect(page).to have_current_path(path)
@@ -468,6 +488,16 @@ module PageExpectations
   def expect_to_be_on_remove_location_for_a_business_page(business_id:, location_id: nil)
     expect(page).to have_current_path("/businesses/#{business_id}/locations/#{location_id}/remove")
     expect(page).to have_h1("Remove location")
+  end
+
+  def expect_to_be_on_add_attachment_to_a_business_upload_page(business_id:)
+    expect(page).to have_current_path("/businesses/#{business_id}/documents/new/upload")
+    expect(page).to have_h1("Add attachment")
+  end
+
+  def expect_to_be_on_add_attachment_to_a_business_metadata_page(business_id:)
+    expect(page).to have_current_path("/businesses/#{business_id}/documents/new/metadata")
+    expect(page).to have_h1("Add attachment")
   end
 
   def expect_to_be_on_add_contact_to_a_business_page(business_id:)


### PR DESCRIPTION
https://trello.com/c/hU0jTM3S/290-no-confirmation-message-banner-after-attachment-is-added

Shows a confirmation message when an attachment is created. Note we currently have no way of knowing if the file was actually processed and not corrupt or invalid, so this is misleading in some circumstances. We have a story in the backlog to correct this.

I have also added feature specs around adding attachments to cases, products and businesses.