### PR TITLE
Add user without opss_user role to seed file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -485,8 +485,10 @@ if run_seeds
     end
   else
     organisation = Organisation.create!(name: "Office for Product Safety and Standards")
+    trading_standards = Organisation.create!(name: "Trading Standards")
     enforcement = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
     operational_support = Team.create!(name: "OPSS Operational support unit", team_recipient_email: nil, "organisation": organisation)
+    ts_team = Team.create!(name: "TS team", team_recipient_email: nil, "organisation": trading_standards)
 
     Team.create!(name: "OPSS Science and Tech", team_recipient_email: nil, "organisation": organisation)
     Team.create!(name: "OPSS Trading Standards Co-ordination", team_recipient_email: nil, "organisation": organisation)
@@ -513,14 +515,14 @@ if run_seeds
       team: operational_support,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
-    user3 = User.create!(
+    User.create!(
       name: "TS User",
       email: "ts_user@example.com",
       password: "testpassword",
       password_confirmation: "testpassword",
-      organisation: organisation,
+      organisation: trading_standards,
       mobile_number_verified: true,
-      team: enforcement,
+      team: ts_team,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -513,6 +513,16 @@ if run_seeds
       team: operational_support,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
+    user3 = User.create!(
+      name: "TS User",
+      email: "ts_user@example.com",
+      password: "testpassword",
+      password_confirmation: "testpassword",
+      organisation: organisation,
+      mobile_number_verified: true,
+      team: enforcement,
+      mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
+    )
 
     %i[opss_user user].each do |role|
       UserRole.create!(user: user1, name: role)


### PR DESCRIPTION
This PR adds a user to our seed file that does not have `opss_user` role. We currently do not have a this kind of user and this will be useful to test the different flow available to trading standards users.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
