### PR TITLE
Correct ordering of errors for TS flow

### DIFF
--- a/app/views/investigations/ts_investigations/_repeatable_info.html.erb
+++ b/app/views/investigations/ts_investigations/_repeatable_info.html.erb
@@ -1,10 +1,11 @@
 <% page_heading = title %>
 <% page_title page_heading, errors: model.errors.any? %>
 <% scope ||= nil %>
+<% error_order ||= nil %>
 <%= form_with model: model, scope: scope, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(model.errors) %>
+      <%= error_summary(model.errors, error_order) %>
 
       <span class="govuk-caption-l">
         Report an unsafe or non-compliant product

--- a/app/views/investigations/ts_investigations/corrective_action.html.erb
+++ b/app/views/investigations/ts_investigations/corrective_action.html.erb
@@ -4,6 +4,7 @@
            scope: :corrective_action,
            other_text: "Are there other actions to report?",
            hide_break: false,
+           error_order: %i[action date_decided legislation measure_type duration geographic_scope related_file further_corrective_action],
            further_key: :further_corrective_action do |form| %>
 
   <%= render "investigations/record_corrective_actions/form",

--- a/app/views/investigations/ts_investigations/product.html.erb
+++ b/app/views/investigations/ts_investigations/product.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @product_form, scope: :product, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary @product_form.errors %>
+      <%= error_summary(@product_form.errors, %i[category product_type authenticity name]) %>
       <span class="govuk-caption-l">Report an unsafe or non-compliant product</span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <%= render "products/form", form: form, product_form: @product_form, countries: @countries, submit_text: "Continue" %>

--- a/app/views/investigations/ts_investigations/risk_assessments.html.erb
+++ b/app/views/investigations/ts_investigations/risk_assessments.html.erb
@@ -3,7 +3,7 @@
 <%= form_with model: @risk_assessment_form, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@risk_assessment_form.errors) %>
+      <%= error_summary(@risk_assessment_form.errors, %i[assessed_on risk_level custom_risk_level assessed_by product_ids risk_assessment_file]) %>
 
       <span class="govuk-caption-l">
         Report an unsafe or non-compliant product

--- a/app/views/investigations/ts_investigations/test_results.html.slim
+++ b/app/views/investigations/ts_investigations/test_results.html.slim
@@ -4,6 +4,7 @@
          scope: :test,
          other_text: "Are there other test results to report?",
          hide_break: false,
+         error_order: %i[legislation date result base],
          further_key: :further_test_results do |form|
   = render "investigations/test_results/form",
            form: form,


### PR DESCRIPTION
This PR ensures the ordering of errors for TS users matches the order in which the information is requested on the form by providing the required error ordering to  `#error_summary`.

https://trello.com/c/nJTg0LCO/814-correctly-order-error-summaries-for-ts-journies

## Screenshots
### Product before and after
![ts_product_before](https://user-images.githubusercontent.com/13124899/99188592-95451200-2754-11eb-9bbb-dada775f8f25.png)
![ts_product_after](https://user-images.githubusercontent.com/13124899/99188596-97a76c00-2754-11eb-92d9-7a6d98a56992.png)

### Risk assessment before and after
![ts_risk_assessment_before](https://user-images.githubusercontent.com/13124899/99188601-a1c96a80-2754-11eb-8211-9ce279cec95c.png)
![ts_risk_assessment_after](https://user-images.githubusercontent.com/13124899/99188604-a3932e00-2754-11eb-9e9f-a6dbb255ad30.png)

### Corrective action before and after
![ts_corrective_action_before](https://user-images.githubusercontent.com/13124899/99188613-b148b380-2754-11eb-85c2-8710e01fa9bc.png)
![ts_corrective_action_after](https://user-images.githubusercontent.com/13124899/99188616-b443a400-2754-11eb-940c-d34c751812d9.png)

### Test result before and after
![ts_test_result_before](https://user-images.githubusercontent.com/13124899/99188622-be65a280-2754-11eb-899a-a373b840a19c.png)
![ts_test_result_after](https://user-images.githubusercontent.com/13124899/99188623-c0c7fc80-2754-11eb-8998-15d931db7490.png)


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
