### PR TITLE
Change copy on product form

### DIFF
--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -40,7 +40,7 @@
   classes: "app-!-max-width-three-quarters",
   label: { text: "Product name", classes: label_class },
   id: "name",
-  hint: { text: "Include model name and model number, for example ‘Playstation 5’. If you suspect the product is counterfeit, add ‘Counterfeit’ before the name, for example ‘Counterfeit Playstion 5’." } %>
+  hint: { text: "Include model name and model number, for example ‘Playstation 5’." } %>
 
 <%= render "form_components/govuk_input",
   key: :gtin13,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -30,7 +30,7 @@
   key: :brand,
   form: form,
   classes: "app-!-max-width-one-half",
-  label: { text: "Product brand", classes: label_class },
+  label: { text: "Product brand (if branded)", classes: label_class },
   hint: { text: "For example, ‘Dyson’ or ‘Sony’" } %>
 
 


### PR DESCRIPTION
This PR removes some copy as requested on this card: https://trello.com/c/kQsb5En4/813-remove-extra-hint-text-from-product-name-field

It also adds `(if branded)` to the product brand question as per this card: https://trello.com/c/simjOA1T/804-update-product-brand-field

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
