### PR TITLE
Add ‘Was the product placed on the market before 1 January 2021?’ to …

### DIFF
--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -33,7 +33,16 @@ class ProductDecorator < ApplicationDecorator
   end
 
   def when_placed_on_market
-    I18n.t(object.when_placed_on_market || :missing, scope: Product.model_name.i18n_key)
+    case object.when_placed_on_market
+    when "before_2021"
+      I18n.t(".product.before_2021")
+    when "on_or_after_2021"
+      I18n.t(".product.on_or_after_2021")
+    when "unknown"
+      I18n.t(".product.when_placed_on_market.unknown_date")
+    else
+      I18n.t(".product.not_provided")
+    end
   end
 
   def subcategory_and_category_label

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -21,7 +21,8 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Other product identifiers" }, value: { text: product_code } },
       { key: { text: "Webpage" }, value: { text: object.webpage } },
       { key: { text: "Description" }, value: { text: description } },
-      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } }
+      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
+      { key: { text: "When placed on market" }, value: { text: when_placed_on_market } }
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows
@@ -31,8 +32,12 @@ class ProductDecorator < ApplicationDecorator
     I18n.t(object.authenticity || :missing, scope: Product.model_name.i18n_key)
   end
 
-  def subcategory_and_category_label
-    product_and_category = [subcategory.presence, category.presence].compact
+  def when_placed_on_market
+    I18n.t(object.when_placed_on_market || :missing, scope: Product.model_name.i18n_key)
+  end
+
+  def product_type_and_category_label
+    product_and_category = [product_type.presence, category.presence].compact
 
     if product_and_category.length > 1
       "#{product_and_category.first} (#{product_and_category.last.downcase})"

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -9,6 +9,7 @@ class ProductDecorator < ApplicationDecorator
 
   def summary_list
     rows = [
+      { key: { text: "When placed on market" }, value: { text: when_placed_on_market } },
       { key: { text: "Category" }, value: { text: category } },
       { key: { text: "Product subcategory" }, value: { text: subcategory } },
       { key: { text: "Product authenticity" }, value: { text: authenticity } },
@@ -21,8 +22,7 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Other product identifiers" }, value: { text: product_code } },
       { key: { text: "Webpage" }, value: { text: object.webpage } },
       { key: { text: "Description" }, value: { text: description } },
-      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
-      { key: { text: "When placed on market" }, value: { text: when_placed_on_market } }
+      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } }
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -9,7 +9,6 @@ class ProductDecorator < ApplicationDecorator
 
   def summary_list
     rows = [
-      { key: { text: "When placed on market" }, value: { text: when_placed_on_market } },
       { key: { text: "Category" }, value: { text: category } },
       { key: { text: "Product subcategory" }, value: { text: subcategory } },
       { key: { text: "Product authenticity" }, value: { text: authenticity } },
@@ -17,6 +16,7 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Units affected" }, value: { text: units_affected } },
       { key: { text: "Product brand" }, value: { text: object.brand } },
       { key: { text: "Product name" }, value: { text: object.name } },
+      { key: { text: "When placed on market" }, value: { text: when_placed_on_market } },
       { key: { text: "Barcode number" }, value: { text: gtin13 } },
       { key: { text: "Batch number" }, value: { text: batch_number } },
       { key: { text: "Other product identifiers" }, value: { text: product_code } },

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -38,8 +38,8 @@ class ProductDecorator < ApplicationDecorator
       I18n.t(".product.before_2021")
     when "on_or_after_2021"
       I18n.t(".product.on_or_after_2021")
-    when "unknown"
-      I18n.t(".product.when_placed_on_market.unknown_date")
+    when "unknown_date"
+      I18n.t(".product.unknown_date")
     else
       I18n.t(".product.not_provided")
     end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -36,8 +36,8 @@ class ProductDecorator < ApplicationDecorator
     I18n.t(object.when_placed_on_market || :missing, scope: Product.model_name.i18n_key)
   end
 
-  def product_type_and_category_label
-    product_and_category = [product_type.presence, category.presence].compact
+  def subcategory_and_category_label
+    product_and_category = [subcategory.presence, category.presence].compact
 
     if product_and_category.length > 1
       "#{product_and_category.first} (#{product_and_category.last.downcase})"

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -25,6 +25,7 @@ class ProductForm
 
   attr_accessor :approx_units
   attr_accessor :exact_units
+  attribute :when_placed_on_market
 
   before_validation { trim_line_endings(:description) }
   before_validation { convert_gtin_to_13_digits(:gtin13) }
@@ -39,6 +40,7 @@ class ProductForm
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
   validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
   validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
+  validates :when_placed_on_market, presence: true
   validates :description, length: { maximum: 10_000 }
 
   validates :has_markings, inclusion: { in: Product.has_markings.keys }

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -73,7 +73,7 @@ module ProductsHelper
     items = [
       { text: "Yes",    value: "before_2021" },
       { text: "No",     value: "on_or_after_2021" },
-      { text: "Unable to ascertain", value: "unknown" }
+      { text: "Unable to ascertain", value: "unknown_date" }
     ]
     return items if product_form.when_placed_on_market.blank?
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -6,7 +6,7 @@ module ProductsHelper
   # Never trust parameters from the scary internet, only allow the white list through.
   def product_params
     params.require(:product).permit(
-      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units, :has_markings, markings: []
+      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :when_placed_on_market, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units, :has_markings, markings: []
     ).with_defaults(markings: [])
   end
 
@@ -69,6 +69,17 @@ module ProductsHelper
     set_affected_selected_units_status_option(items, product_form)
   end
 
+  def items_for_before_2021_radio(product_form)
+    items = [
+      { text: "Yes",    value: "before_2021" },
+      { text: "No",     value: "on_or_after_2021" },
+      { text: "Unable to ascertain", value: "unknown" }
+    ]
+    return items if product_form.when_placed_on_market.blank?
+
+    set_selected_when_placed_on_market_option(items, product_form)
+  end
+
   def options_for_country_of_origin(countries, product_form)
     countries.map do |country|
       text = country[0]
@@ -96,12 +107,24 @@ private
     end
   end
 
+  def set_selected_when_placed_on_market_option(items, product_form)
+    items.each do |item|
+      next if skip_selected_item_for_selected_option?(item, product_form)
+
+      item[:selected] = true if when_placed_on_market_option_selected?(item, product_form)
+    end
+  end
+
   def authenticity_selected?(item, product_form)
     item[:value] == product_form.authenticity
   end
 
   def affected_units_status_selected?(item, product_form)
     item[:value] == product_form.affected_units_status
+  end
+
+  def when_placed_on_market_option_selected?(item, product_form)
+    item[:value] == product_form.when_placed_on_market
   end
 
   def skip_selected_item_for_selected_option?(item, product_form)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -23,6 +23,12 @@ class Product < ApplicationRecord
     "markings_unknown" => "markings_unknown"
   }
 
+  enum when_placed_on_market: {
+    "before_2021" => "before_2021",
+    "on_or_after_2021" => "on_or_after_2021",
+    "unknown" => "unknown"
+  }
+
   MARKINGS = %w[UKCA UKNI CE].freeze
 
   index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "products"].join("_")

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,7 +26,7 @@ class Product < ApplicationRecord
   enum when_placed_on_market: {
     "before_2021" => "before_2021",
     "on_or_after_2021" => "on_or_after_2021",
-    "unknown" => "unknown"
+    "unknown_date" => "unknown_date"
   }
 
   MARKINGS = %w[UKCA UKNI CE].freeze

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -22,11 +22,13 @@ class AddProductToCase
            :number_of_affected_units,
            :exact_units,
            :approx_units,
+           :when_placed_on_market,
            to: :context
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
     context.fail!(error: "No user supplied") unless user.is_a?(User)
+    when_placed_on_market = context.when_placed_on_market
 
     Product.transaction do
       context.product = investigation.products.create!(
@@ -45,13 +47,15 @@ class AddProductToCase
         webpage: webpage,
         source: build_user_source,
         affected_units_status: affected_units_status,
-        number_of_affected_units: number_of_affected_units
+        number_of_affected_units: number_of_affected_units,
+        when_placed_on_market: when_placed_on_market
       )
 
       context.activity = create_audit_activity_for_product_added
 
       send_notification_email
     end
+
   end
 
 private

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -55,7 +55,6 @@ class AddProductToCase
 
       send_notification_email
     end
-
   end
 
 private

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -11,7 +11,7 @@
 <%= form_with model: @product_form, scope: :product, url: investigation_products_path(@investigation), local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings affected_units_status number_of_affected_units name gtin13]) %>
+      <%= error_summary(@product_form.errors, %i[category subcategory authenticity when_placed_on_market has_markings markings affected_units_status number_of_affected_units name gtin13]) %>
       <%= render "investigation_heading", investigation: @investigation %>
 
       <h2 class="govuk-heading-m">Add product</h2>

--- a/app/views/investigations/ts_investigations/product.html.erb
+++ b/app/views/investigations/ts_investigations/product.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @product_form, scope: :product, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category product_type authenticity has_markings markings affected_units_status number_of_affected_units name]) %>
+      <%= error_summary(@product_form.errors, %i[category product_type authenticity has_markings markings when_placed_on_market affected_units_status number_of_affected_units name]) %>
       <span class="govuk-caption-l">Report an unsafe or non-compliant product</span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <%= render "products/form", form: form, product_form: @product_form, countries: @countries, submit_text: "Continue" %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -4,6 +4,8 @@
 <% product_category_classes = ["app-!-autocomplete--max-width-three-quarters",
   ("govuk-form-group--error" if product_form.errors[:category].any?)] %>
 
+<%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
+
 <%= render "form_components/govuk_select",
   formGroup: { classes: product_category_classes },
   choices: product_categories,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -4,8 +4,6 @@
 <% product_category_classes = ["app-!-autocomplete--max-width-three-quarters",
   ("govuk-form-group--error" if product_form.errors[:category].any?)] %>
 
-<%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
-
 <%= render "form_components/govuk_select",
   formGroup: { classes: product_category_classes },
   choices: product_categories,
@@ -62,6 +60,8 @@
   label: { text: "Product name", classes: label_class },
   id: "name",
   hint: { text: "Include model name and model number, for example ‘PlayStation 5’" } %>
+
+<%= form.govuk_radios :when_placed_on_market, legend: "Was the product placed on the market before 1 January 2021?", items: items_for_before_2021_radio(product_form) %>
 
 <%= render "form_components/govuk_input",
   key: :gtin13,

--- a/app/views/products/_product_card.html.erb
+++ b/app/views/products/_product_card.html.erb
@@ -6,13 +6,17 @@
     <span><%= link_to product.name, product %></span>
   </div>
   <div class="govuk-grid-column-one-half">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-third">
       <span class="govuk-caption-m govuk-!-font-size-16">Sub-category</span>
       <span class="govuk-!-font-weight-regular"><%= product.subcategory %></span>
     </div>
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-third">
       <span class="govuk-caption-m govuk-!-font-size-16">Origin</span>
       <span class="govuk-!-font-weight-regular"><%= country_from_code product.country_of_origin %></span>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <span class="govuk-caption-m govuk-!-font-size-16">When placed on market</span>
+      <span class="govuk-!-font-weight-regular"><%= product.when_placed_on_market %></span>
     </div>
   </div>
 </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -6,7 +6,7 @@
 <%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings affected_units_status number_of_affected_units name]) %>
+      <%= error_summary(@product_form.errors, %i[category subcategory authenticity has_markings markings when_placed_on_market affected_units_status number_of_affected_units name]) %>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -508,7 +508,7 @@ en:
     none: "None"
     before_2021: "Before 1 January 2021"
     on_or_after_2021: "On or after 1 January 2021"
-    unknown: "Unable to ascertain"
+    unknown_date: "Unable to ascertain"
 
   corrective_action:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,8 @@ en:
               inclusion: "Select yes if the product has UKCA, UKNI or CE marking"
             markings:
               blank: "Select the product marking(s)"
+            when_placed_on_market:
+              blank: "Select yes if the product was placed on the market before 1 January 2021"
 
         risk_assessment_form:
           attributes:
@@ -504,6 +506,9 @@ en:
     not_relevant: "Not relevant"
     not_provided: "Not provided"
     none: "None"
+    before_2021: "Before 1 January 2021"
+    on_or_after_2021: "On or after 1 January 2021"
+    unknown: "Unable to ascertain"
 
   corrective_action:
     attributes:

--- a/db/migrate/20201117141013_add_when_placed_on_market_to_products.rb
+++ b/db/migrate/20201117141013_add_when_placed_on_market_to_products.rb
@@ -1,0 +1,11 @@
+class AddWhenPlacedOnMarketToProducts < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up { execute "CREATE TYPE when_placed_on_markets AS ENUM ('before_2021', 'on_or_after_2021', 'unknown');" }
+        dir.down { execute "DROP TYPE IF EXISTS when_placed_on_markets;" }
+      end
+      add_column :products, :when_placed_on_market, :when_placed_on_markets
+    end
+  end
+end

--- a/db/migrate/20201117141013_add_when_placed_on_market_to_products.rb
+++ b/db/migrate/20201117141013_add_when_placed_on_market_to_products.rb
@@ -2,7 +2,7 @@ class AddWhenPlacedOnMarketToProducts < ActiveRecord::Migration[6.0]
   def change
     safety_assured do
       reversible do |dir|
-        dir.up { execute "CREATE TYPE when_placed_on_markets AS ENUM ('before_2021', 'on_or_after_2021', 'unknown');" }
+        dir.up { execute "CREATE TYPE when_placed_on_markets AS ENUM ('before_2021', 'on_or_after_2021', 'unknown_date');" }
         dir.down { execute "DROP TYPE IF EXISTS when_placed_on_markets;" }
       end
       add_column :products, :when_placed_on_market, :when_placed_on_markets

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_113650) do
   create_enum "has_markings_values", ["markings_yes", "markings_no", "markings_unknown"]
   create_enum "reported_reasons", ["unsafe", "non_compliant", "unsafe_and_non_compliant", "safe_and_compliant"]
   create_enum "risk_levels", ["serious", "high", "medium", "low", "other"]
-  create_enum "when_placed_on_markets", ["before_2021", "on_or_after_2021", "unknown"]
+  create_enum "when_placed_on_markets", ["before_2021", "on_or_after_2021", "unknown_date"]
 
   create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
     t.bigint "blob_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_113650) do
   create_enum "has_markings_values", ["markings_yes", "markings_no", "markings_unknown"]
   create_enum "reported_reasons", ["unsafe", "non_compliant", "unsafe_and_non_compliant", "safe_and_compliant"]
   create_enum "risk_levels", ["serious", "high", "medium", "low", "other"]
+  create_enum "when_placed_on_markets", ["before_2021", "on_or_after_2021", "unknown"]
 
   create_table "active_storage_attachments", id: :serial, force: :cascade do |t|
     t.bigint "blob_id", null: false
@@ -247,6 +248,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_113650) do
     t.string "subcategory"
     t.datetime "updated_at", null: false
     t.string "webpage"
+    t.enum "when_placed_on_market", as: "when_placed_on_markets"
   end
 
   create_table "rapex_imports", id: :serial, force: :cascade do |t|

--- a/lib/tasks/backfill_products_when_placed_on_market.rake
+++ b/lib/tasks/backfill_products_when_placed_on_market.rake
@@ -1,6 +1,6 @@
 namespace :products do
   desc "Marks the given user as deleted, assigning their investigations to their team"
   task backfill_when_placed_on_market: :environment do
-    Product.where(when_placed_on_market: nil).update_all(when_placed_on_market: 'before_2021')
+    Product.where(when_placed_on_market: nil).update_all(when_placed_on_market: "before_2021")
   end
 end

--- a/lib/tasks/backfill_products_when_placed_on_market.rake
+++ b/lib/tasks/backfill_products_when_placed_on_market.rake
@@ -1,0 +1,6 @@
+namespace :products do
+  desc "Marks the given user as deleted, assigning their investigations to their team"
+  task backfill_when_placed_on_market: :environment do
+    Product.where(when_placed_on_market: nil).update_all(when_placed_on_market: 'before_2021')
+  end
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     affected_units_status { "unknown" }
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }
+    when_placed_on_market { 'before_2021' }
 
     factory :product_iphone do
       product_code { 234 }

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     affected_units_status { "unknown" }
     has_markings { Product.has_markings.keys.sample }
     markings { [Product::MARKINGS.sample] }
-    when_placed_on_market { 'before_2021' }
+    when_placed_on_market { "before_2021" }
 
     factory :product_iphone do
       product_code { 234 }

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -27,11 +27,11 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expect(errors_list[0].text).to eq "Category cannot be blank"
     expect(errors_list[1].text).to eq "Subcategory cannot be blank"
     expect(errors_list[2].text).to eq "You must state whether the product is a counterfeit"
-    expect(errors_list[3].text).to eq "Select yes if the product has UKCA, UKNI or CE marking"
-    expect(errors_list[4].text).to eq "You must state how many units are affected"
-    expect(errors_list[5].text).to eq "Name cannot be blank"
-    expect(errors_list[6].text).to eq "Enter a valid barcode number"
-    expect(errors_list[7].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
+    expect(errors_list[3].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
+    expect(errors_list[4].text).to eq "Select yes if the product has UKCA, UKNI or CE marking"
+    expect(errors_list[5].text).to eq "You must state how many units are affected"
+    expect(errors_list[6].text).to eq "Name cannot be blank"
+    expect(errors_list[7].text).to eq "Enter a valid barcode number"
 
     select attributes[:category], from: "Product category"
 

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expect(errors_list[4].text).to eq "You must state how many units are affected"
     expect(errors_list[5].text).to eq "Name cannot be blank"
     expect(errors_list[6].text).to eq "Enter a valid barcode number"
+    expect(errors_list[7].text).to eq "Select yes if the product was placed on the market before 1 January 2021"
 
     select attributes[:category], from: "Product category"
 

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -42,6 +42,10 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     fill_in "Batch number",                      with: attributes[:batch_number]
     fill_in "Webpage",                           with: attributes[:webpage]
 
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(attributes[:when_placed_on_market])
+    end
+
     within_fieldset("Is the product counterfeit?") do
       choose counterfeit_answer(attributes[:authenticity])
     end
@@ -87,6 +91,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expect(page).to have_summary_item(key: "Webpage",                   value: attributes[:webpage])
     expect(page).to have_summary_item(key: "Country of origin",         value: attributes[:country])
     expect(page).to have_summary_item(key: "Description",               value: attributes[:description])
+    expect(page).to have_summary_item(key: "When placed on market",     value: I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key))
   end
 
   scenario "Not being able to add a product to another team’s case" do

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -29,7 +29,8 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       authenticity: Product.authenticities.keys.without("missing").sample,
       affected_units_status: "approx",
       has_markings: %w[Yes No Unknown].sample,
-      markings: [Product::MARKINGS.sample]
+      markings: [Product::MARKINGS.sample],
+      when_placed_on_market: Product.when_placed_on_markets.keys.without("missing").sample
     }
   end
 
@@ -144,6 +145,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
   def enter_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:, has_markings:, markings:)
     select category,                      from: "Product category"
     select country_of_origin,             from: "Country of origin"
+    within_fieldset("Was the product placed on the market before 1 January 2021?") { choose when_placed_on_market_answer(when_placed_on_market) }
     fill_in "Product subcategory", with: type
     within_fieldset("Is the product counterfeit?") { choose counterfeit_answer(authenticity) }
 
@@ -172,7 +174,9 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
                         when "No" then "None"
                         when "Unknown" then "Unknown"
                         end
+  end
 
+  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, when_placed_on_market:)
     expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: name)
     expect(page.find("dt", text: "Product subcategory")).to have_sibling("dd", text: type)
     expect(page.find("dt", text: "Product authenticity")).to have_sibling("dd", text: I18n.t(authenticity, scope: Product.model_name.i18n_key))
@@ -183,6 +187,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: country_of_origin)
     expect(page.find("dt", text: "Description")).to have_sibling("dd", text: description)
     expect(page.find("dt", text: "Units affected")).to have_sibling("dd", text: "21")
+    expect(page.find("dt", text: "When placed on market")).to have_sibling("dd", text: I18n.t(when_placed_on_market, scope: Product.model_name.i18n_key))
   end
 
   def expect_details_on_summary_page

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -174,9 +174,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
                         when "No" then "None"
                         when "Unknown" then "Unknown"
                         end
-  end
 
-  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, when_placed_on_market:)
     expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: name)
     expect(page.find("dt", text: "Product subcategory")).to have_sibling("dd", text: type)
     expect(page.find("dt", text: "Product authenticity")).to have_sibling("dd", text: I18n.t(authenticity, scope: Product.model_name.i18n_key))

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     click_button "Create allegation"
   end
 
-  def enter_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:, has_markings:, markings:)
+  def enter_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:, has_markings:, markings:, when_placed_on_market:)
     select category,                      from: "Product category"
     select country_of_origin,             from: "Country of origin"
     within_fieldset("Was the product placed on the market before 1 January 2021?") { choose when_placed_on_market_answer(when_placed_on_market) }
@@ -168,7 +168,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     click_button "Save product"
   end
 
-  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, has_markings:, markings:)
+  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, has_markings:, markings:, when_placed_on_market:)
     expected_markings = case has_markings
                         when "Yes" then markings.join(", ")
                         when "No" then "None"

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -204,6 +204,10 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
       find("#approx_units").set(new_number_of_affected_units)
     end
 
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose when_placed_on_market_answer(new_when_placed_on_market)
+    end
+
     fill_in "Product brand",            with: new_brand
     fill_in "Product name",             with: new_name
     fill_in "Barcode number",           with: new_gtin13

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }
   let(:new_country_of_origin) { "South Korea" }
+  let(:new_when_placed_on_market)  { (Product.when_placed_on_markets.keys - [product.when_placed_on_market]).sample }
 
   before { sign_in user }
 
@@ -87,6 +88,10 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
 
     select new_product_category, from: "Product category"
     fill_in "Product subcategory", with: new_subcategory
+
+    within_fieldset "Was the product placed on the market before 1 January 2021?" do
+      choose when_placed_on_market_answer(new_when_placed_on_market)
+    end
 
     within_fieldset "Is the product counterfeit?" do
       choose counterfeit_answer(new_authenticity)
@@ -231,6 +236,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expect(page).to have_summary_item(key: "Webpage",                   value: new_webpage)
     expect(page).to have_summary_item(key: "Country of origin",         value: new_country_of_origin)
     expect(page).to have_summary_item(key: "Description",               value: new_description)
+    expect(page).to have_summary_item(key: "When placed on market",     value: I18n.t(new_when_placed_on_market, scope: Product.model_name.i18n_key))
   end
 
   scenario "upload an document" do

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }
   let(:new_country_of_origin) { "South Korea" }
-  let(:new_when_placed_on_market)  { (Product.when_placed_on_markets.keys - [product.when_placed_on_market]).sample }
+  let(:new_when_placed_on_market) { (Product.when_placed_on_markets.keys - [product.when_placed_on_market]).sample }
 
   before { sign_in user }
 

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -109,7 +109,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           affected_units_status: "Approximate number known",
           number_of_affected_units: 22,
           has_markings: "markings_yes",
-          markings: [Product::MARKINGS.sample]
+          markings: [Product::MARKINGS.sample],
+          when_placed_on_market: "Yes"
         }
       end
       let(:coronavirus) { false }
@@ -273,7 +274,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           type: Faker::Appliance.equipment,
           authenticity: "Yes",
           affected_units_status: "Unknown",
-          has_markings: "markings_no"
+          has_markings: "markings_no",
+          when_placed_on_market: "Yes"
         }
       end
 
@@ -504,6 +506,10 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     select with[:category],                      from: "Product category"
     select with[:country_of_origin],             from: "Country of origin" if with[:country_of_origin]
     fill_in "Product subcategory", with: with[:type]
+
+    within_fieldset("Was the product placed on the market before 1 January 2021?") do
+      choose with[:when_placed_on_market]
+    end
 
     within_fieldset("Is the product counterfeit?") do
       choose with[:authenticity]

--- a/spec/support/product_helper.rb
+++ b/spec/support/product_helper.rb
@@ -21,7 +21,7 @@ RSpec.shared_context "with product form helpers", shared_context: :metadata do
     case when_placed_on_market
     when "before_2021" then "Yes"
     when "on_or_after_2021" then "No"
-    when "unknown" then "Unable to ascertain"
+    when "unknown_date" then "Unable to ascertain"
     when "missing" then "Not provided"
     end
   end

--- a/spec/support/product_helper.rb
+++ b/spec/support/product_helper.rb
@@ -16,6 +16,15 @@ RSpec.shared_context "with product form helpers", shared_context: :metadata do
     when "not_relevant"   then "Not relevant"
     end
   end
+
+  def when_placed_on_market_answer(when_placed_on_market)
+    case when_placed_on_market
+    when "before_2021" then "Yes"
+    when "on_or_after_2021"     then "No"
+    when "unknown"      then "Unable to ascertain"
+    when "missing"     then "Not provided"
+    end
+  end
 end
 
 RSpec.configure do |rspec|

--- a/spec/support/product_helper.rb
+++ b/spec/support/product_helper.rb
@@ -20,9 +20,9 @@ RSpec.shared_context "with product form helpers", shared_context: :metadata do
   def when_placed_on_market_answer(when_placed_on_market)
     case when_placed_on_market
     when "before_2021" then "Yes"
-    when "on_or_after_2021"     then "No"
-    when "unknown"      then "Unable to ascertain"
-    when "missing"     then "Not provided"
+    when "on_or_after_2021" then "No"
+    when "unknown" then "Unable to ascertain"
+    when "missing" then "Not provided"
     end
   end
 end


### PR DESCRIPTION
…product forms

https://trello.com/c/tAFdBAee/816-3-add-was-the-product-placed-on-the-market-before-1-january-2021-to-the-product-page

## Description
- Add the new ‘Was the product placed on the market before 1 January 2021?’ on add and edit product forms
- Add new column to product table to persist the answer
- Add row to product table to display data

## Screenshots
![Screenshot 2020-11-19 at 15 13 40](https://user-images.githubusercontent.com/13124899/99697936-1b7c9380-2a88-11eb-9bcb-ec9d2ec9d68e.png)
![Screenshot 2020-11-19 at 15 16 13](https://user-images.githubusercontent.com/13124899/99697947-1d465700-2a88-11eb-896c-7c8265be58dc.png)
![Screenshot 2020-11-19 at 15 16 27](https://user-images.githubusercontent.com/13124899/99697958-20414780-2a88-11eb-8918-8f32b13cdff3.png)
![Screenshot 2020-11-19 at 15 16 50](https://user-images.githubusercontent.com/13124899/99697962-220b0b00-2a88-11eb-9683-e0aa0f15d6d9.png)


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
