### PR TITLE
Fix for repeating info pages in TS flow when there is a validation error

### DIFF
--- a/app/views/investigations/ts_investigations/_repeatable_info.html.erb
+++ b/app/views/investigations/ts_investigations/_repeatable_info.html.erb
@@ -1,7 +1,7 @@
 <% page_heading = title %>
 <% page_title page_heading, errors: model.errors.any? %>
 <% scope ||= nil %>
-<% error_order ||= nil %>
+<% error_order ||= [] %>
 <%= form_with model: model, scope: scope, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -107,6 +107,20 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         }
       end
       let(:coronavirus) { false }
+      let(:product_images) do
+        image = lambda {
+          {
+            file: Rails.root + "test/fixtures/files/testImage.png",
+            title: Faker::Lorem.sentence,
+            description: Faker::Lorem.paragraph
+          }
+        }
+
+        [
+          image.call,
+          image.call
+        ]
+      end
 
       scenario "not coronavirus-related" do
         visit new_ts_investigation_path
@@ -187,6 +201,18 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         risk_assessments.each do |assessment|
           fill_in_risk_assessment_details_page(with: assessment)
           expect_to_be_on_risk_assessment_details_page
+        end
+
+        skip_page
+
+        expect_to_be_on_product_image_page
+
+        # trigger validation to verify errors are handled correctly
+        click_on "Continue"
+
+        product_images.each do |product_image|
+          fill_in_product_image_page(with: product_image)
+          expect_to_be_on_product_image_page
         end
 
         skip_page
@@ -544,6 +570,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
   def fill_in_other_information_page(test_results: true, risk_assessments: true)
     check "Test results" if test_results
     check "Risk assessments" if risk_assessments
+    check "Product images" if product_images
     click_button "Continue"
   end
 
@@ -591,6 +618,18 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     attach_file "Upload the risk assessment", with[:file]
 
     within_fieldset("Are there other risk assessments to report?") do
+      choose "Yes"
+    end
+
+    click_button "Continue"
+  end
+
+  def fill_in_product_image_page(with:)
+    attach_file "Upload a file", with[:file]
+    fill_in "Title", with: with[:title]
+    fill_in "Description", with: with[:description]
+
+    within_fieldset("Are there other product images to report?") do
       choose "Yes"
     end
 

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -359,6 +359,11 @@ module PageExpectations
     expect(page).to have_selector("h1", text: "Test result details")
   end
 
+  def expect_to_be_on_product_image_page
+    expect(page).to have_current_path("/ts_investigation/product_images")
+    expect(page).to have_selector("h1", text: "Upload a product image")
+  end
+
   # Product pages
   def expect_to_be_on_remove_attachment_from_product_confirmation_page
     expect(page).to have_current_path("/products/#{product.id}/documents/#{document.id}/remove")


### PR DESCRIPTION
This fixes a regression bug introduced by https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/1031

When there is a validation error on user-supplied input, the page is supposed to display again showing validation errors. It was throwing a 500 error as seen here https://sentry.io/organizations/beis/issues/2042190291/?project=1329381.

I have improved the test coverage to cover this behaviour to prevent it reoccurring.
