### PR TITLE
Add date closed to investigation

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -61,6 +61,7 @@ class InvestigationsController < ApplicationController
   # PATCH /cases/1/status
   def status
     authorize @investigation, :change_owner_or_status?
+    @investigation.date_closed = update_params[:is_closed] == "true" ? Date.current : nil
     update!
   end
 

--- a/app/views/investigations/index.xlsx.axlsx
+++ b/app/views/investigations/index.xlsx.axlsx
@@ -3,7 +3,8 @@ book = xlsx_package.workbook
 book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Metrics/BlockLength
   sheet_investigations.add_row %w[ID Status Title Type Description Product_Category Hazard_Type Coronavirus_Related
                                   Risk_Level Case_Owner_Team Case_Owner_User Source Complainant_Type
-                                  Products Businesses Activities Correspondences Corrective_Actions Tests]
+                                  Products Businesses Activities Correspondences Corrective_Actions Tests
+                                  Date_Created Last_Updated Date_Closed]
   @investigations.each do |investigation|
     complainant = investigation.complainant
     sheet_investigations.add_row [
@@ -25,7 +26,10 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
       @activity_counts[investigation.id] || 0,
       @correspondence_counts[investigation.id] || 0,
       @corrective_action_counts[investigation.id] || 0,
-      @test_counts[investigation.id] || 0
+      @test_counts[investigation.id] || 0,
+      investigation.created_at,
+      investigation.updated_at,
+      investigation.date_closed
     ], types: :text
   end
 end

--- a/db/migrate/20201124121612_add_date_closed_to_investigations.rb
+++ b/db/migrate/20201124121612_add_date_closed_to_investigations.rb
@@ -1,0 +1,5 @@
+class AddDateClosedToInvestigations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :investigations, :date_closed, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_115921) do
+ActiveRecord::Schema.define(version: 2020_11_24_121612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_115921) do
     t.boolean "coronavirus_related", default: false
     t.datetime "created_at", null: false
     t.string "custom_risk_level"
+    t.datetime "date_closed"
     t.date "date_received"
     t.text "description"
     t.text "hazard_description"

--- a/lib/tasks/backfill_date_closed.rake
+++ b/lib/tasks/backfill_date_closed.rake
@@ -1,0 +1,13 @@
+namespace :investigations do
+  desc "Backfill date_closed field"
+  task backfill_date_closed: :environment do
+    closed_investigations = Investigation.includes(:activities).where(is_closed: true, date_closed: nil)
+
+    puts "Backfilling date closed for #{closed_investigations.count} closed investigations"
+
+    closed_investigations.each do |investigation|
+      date_closed = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").last.created_at
+      investigation.update(date_closed: date_closed)
+    end
+  end
+end

--- a/lib/tasks/backfill_date_closed.rake
+++ b/lib/tasks/backfill_date_closed.rake
@@ -7,7 +7,7 @@ namespace :investigations do
 
     closed_investigations.each do |investigation|
       date_closed = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").last.created_at
-      investigation.update(date_closed: date_closed)
+      investigation.update!(date_closed: date_closed)
     end
   end
 end

--- a/lib/tasks/backfill_date_closed.rake
+++ b/lib/tasks/backfill_date_closed.rake
@@ -6,7 +6,7 @@ namespace :investigations do
     puts "Backfilling date closed for #{closed_investigations.count} closed investigations"
 
     closed_investigations.each do |investigation|
-      date_closed = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").last.created_at
+      date_closed = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").order(created_at: :asc).last.created_at
       investigation.update!(date_closed: date_closed)
     end
   end

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
       end
 
       context "when investigation is open" do
-        it 'date_closed column is empty' do
-          investigation = create(:allegation)
+        it "date_closed column is empty" do
+          create(:allegation)
 
           Investigation.import refresh: true, force: true
 
@@ -167,8 +167,8 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
       end
 
       context "when investigation is closed" do
-        it 'date_closed column is empty' do
-          investigation = create(:allegation, is_closed: true, date_closed: Date.yesterday)
+        it "date_closed column is empty" do
+          create(:allegation, is_closed: true, date_closed: Date.yesterday)
 
           Investigation.import refresh: true, force: true
 

--- a/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
+++ b/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Updating the status of a case", :with_stubbed_elasticsearch, :wi
                 investigation: { is_closed: "false", status_rationale: "Test" }
               }
       end
+
       it "updates the investigation and redirects to the investigation page" do
         aggregate_failures do
           expect(investigation.reload.is_closed).to be false

--- a/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
+++ b/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
@@ -29,10 +29,29 @@ RSpec.describe "Updating the status of a case", :with_stubbed_elasticsearch, :wi
             }
     end
 
-    it "updates the investigation and redirects to the investigation page" do
-      aggregate_failures do
-        expect(investigation.reload.is_closed).to be true
-        expect(response).to redirect_to(investigation_path(investigation))
+    context "when status is changed to closed" do
+      it "updates the investigation and redirects to the investigation page" do
+        aggregate_failures do
+          expect(investigation.reload.is_closed).to be true
+          expect(investigation.date_closed).not_to be nil
+          expect(response).to redirect_to(investigation_path(investigation))
+        end
+      end
+    end
+
+    context "when case is reopened" do
+      before do
+        patch status_investigation_path(investigation),
+              params: {
+                investigation: { is_closed: "false", status_rationale: "Test" }
+              }
+      end
+      it "updates the investigation and redirects to the investigation page" do
+        aggregate_failures do
+          expect(investigation.reload.is_closed).to be false
+          expect(investigation.date_closed).to be nil
+          expect(response).to redirect_to(investigation_path(investigation))
+        end
       end
     end
   end

--- a/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
+++ b/spec/requests/investigations/updating_the_status_of_a_case_spec.rb
@@ -30,12 +30,10 @@ RSpec.describe "Updating the status of a case", :with_stubbed_elasticsearch, :wi
     end
 
     context "when status is changed to closed" do
-      it "updates the investigation and redirects to the investigation page" do
-        aggregate_failures do
-          expect(investigation.reload.is_closed).to be true
-          expect(investigation.date_closed).not_to be nil
-          expect(response).to redirect_to(investigation_path(investigation))
-        end
+      it "updates the investigation and redirects to the investigation page", :aggregate_failures do
+        expect(investigation.reload.is_closed).to be true
+        expect(investigation.date_closed).not_to be nil
+        expect(response).to redirect_to(investigation_path(investigation))
       end
     end
 
@@ -47,12 +45,10 @@ RSpec.describe "Updating the status of a case", :with_stubbed_elasticsearch, :wi
               }
       end
 
-      it "updates the investigation and redirects to the investigation page" do
-        aggregate_failures do
-          expect(investigation.reload.is_closed).to be false
-          expect(investigation.date_closed).to be nil
-          expect(response).to redirect_to(investigation_path(investigation))
-        end
+      it "updates the investigation and redirects to the investigation page", :aggregate_failures do
+        expect(investigation.reload.is_closed).to be false
+        expect(investigation.date_closed).to be nil
+        expect(response).to redirect_to(investigation_path(investigation))
       end
     end
   end


### PR DESCRIPTION
Adding date_closed field to `investigations` so that we do not have to query activities and get slow/unreliable results when attempting to find out when an investigation was closed. Also add additional fields to the CSV export.

## Description
- Migration to add `date_closed` to investigations
- Change in controller to populate this field.
- Adding test coverage for this change
- Add fields to csv export
- Add tests to cover csv export changes
- Rake task to backfill field for existing closed investigations

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
