### PR TITLE
Fix script to backfill date_closed field for closed investigations

### DIFF
--- a/lib/tasks/backfill_date_closed.rake
+++ b/lib/tasks/backfill_date_closed.rake
@@ -6,8 +6,8 @@ namespace :investigations do
     puts "Backfilling date closed for #{closed_investigations.count} closed investigations"
 
     closed_investigations.each do |investigation|
-      date_closed = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").order(created_at: :asc).last.created_at
-      investigation.update!(date_closed: date_closed)
+      closing_activity = investigation.activities.where(type: "AuditActivity::Investigation::UpdateStatus").order(created_at: :asc).last
+      investigation.update!(date_closed: closing_activity.created_at) unless closing_activity.nil?
     end
   end
 end


### PR DESCRIPTION
Fix an issue where the backfilling script fails when a closed investigation does not have a corresponding activity.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
