### PR TITLE
Fix images not being attached to products on TS case creation flow on hosted environments

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -697,9 +697,12 @@ private
   end
 
   def save_product_files
+    # Obtain updated product state before attaching files to ensure changes are saved immediately
+    @product.reload
+
     session[:product_files].each do |file_blob_id|
       file_blob = ActiveStorage::Blob.find_by(id: file_blob_id)
-      attach_blobs_to_list(file_blob, @product.documents)
+      @product.documents.attach(file_blob)
     end
   end
 

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -234,7 +234,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         click_link "Products (1)"
 
         expect_to_be_on_case_products_page
-        expect_case_products_page_to_show(info: product_details)
+        expect_case_products_page_to_show(info: product_details, images: product_images)
 
         click_link "Businesses (2)"
 
@@ -350,7 +350,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
         click_link "Products (1)"
 
         expect_to_be_on_case_products_page
-        expect_case_products_page_to_show(info: product_details)
+        expect_case_products_page_to_show(info: product_details, images: [])
 
         click_link "Activity"
 
@@ -385,16 +385,19 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     expect(page.find("dt", text: "Coronavirus related")).to have_sibling("dd", text: "Not a coronavirus related case")
   end
 
-  def expect_case_products_page_to_show(info:)
-    expect(page).to have_selector("h2", text: info[:name])
-    expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: info[:name])
-    expect(page.find("dt", text: "Barcode number")).to have_sibling("dd", text: info[:gtin13]) if info[:gtin13]
-    expect(page.find("dt", text: "Other product identifiers")).to have_sibling("dd", text: info[:barcode]) if info[:barcode]
-    expect(page.find("dt", text: "Product sub-category")).to have_sibling("dd", text: info[:type])
-    expect(page.find("dt", text: "Category")).to have_sibling("dd", text: info[:category])
-    expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: info[:webpage]) if info[:webpage]
-    expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: info[:country_of_origin]) if info[:country_of_origin]
-    expect(page.find("dt", text: "Description")).to have_sibling("dd", text: info[:description]) if info[:description]
+  def expect_case_products_page_to_show(info:, images:)
+    within page.find(".product-summary") do
+      expect(page).to have_selector("h2", text: info[:name])
+      expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: info[:name])
+      expect(page.find("dt", text: "Barcode number")).to have_sibling("dd", text: info[:gtin13]) if info[:gtin13]
+      expect(page.find("dt", text: "Other product identifiers")).to have_sibling("dd", text: info[:barcode]) if info[:barcode]
+      expect(page.find("dt", text: "Product sub-category")).to have_sibling("dd", text: info[:type])
+      expect(page.find("dt", text: "Category")).to have_sibling("dd", text: info[:category])
+      expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: info[:webpage]) if info[:webpage]
+      expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: info[:country_of_origin]) if info[:country_of_origin]
+      expect(page.find("dt", text: "Description")).to have_sibling("dd", text: info[:description]) if info[:description]
+      expect(page).to have_css("img[alt=\"#{images.first[:title]}\"]") unless images.empty?
+    end
   end
 
   def expect_case_businesses_page_to_show(label:, business:)


### PR DESCRIPTION
This fixes a  bug reported by users when the application is running on production.

I was able to reproduce the error on staging and on review apps. It was not possible to reproduce in development or test modes locally or in CI.

The problem was that the product is instantiated as a child of `@investigation` and assigned to `@product` before it is saved in a later call to `CreateCase`, which calls `save` on the parent Investigation. See https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/app/controllers/investigations/ts_investigations_controller.rb#L615-L616. The product is therefore saved as well, but this state is not automatically updated in the controller.

Later, when images are attached to the product, it defers the saving of the attachments until the product is saved. This behaviour is different to when the product is already saved, in which case the attachments are saved immediately. That's the behaviour this code expects.

There is clearly some difference in behaviour between `development` and `production` modes related to tracking the state of associated ActiveRecord objects when the parent is saved. This is also clearly a regression since it must have worked before. It may have been introduced in the Rails 6 upgrade.

Consequently although I have written a test (and this does improve the test quality a bit) it doesn't really provide us with confidence that there will not be a regression in future. I'm open to suggestions about how we can improve this.