### PR TITLE
Fix total search results count

### DIFF
--- a/app/views/businesses/index.html.erb
+++ b/app/views/businesses/index.html.erb
@@ -12,7 +12,7 @@
       <% if params[:q].present? %>
         <%= params[:q] %>
         <span class="govuk-caption-m">
-          <%= "#{@businesses.count} #{'result'.pluralize(@businesses.count)}" %>
+          <%= "#{@businesses.total_entries} #{'result'.pluralize(@businesses.total_entries)}" %>
         </span>
       <% else %>
         Businesses

--- a/app/views/investigations/_heading.html.erb
+++ b/app/views/investigations/_heading.html.erb
@@ -9,7 +9,7 @@
       <% if params[:q].present? %>
         <%= params[:q] %>
         <span class="govuk-caption-m">
-          <%= "#{answer.results.count} #{'result'.pluralize(answer.results.count)}" %>
+          <%= "#{answer.results.total_entries} #{'result'.pluralize(answer.results.total_entries)}" %>
         </span>
       <% else %>
         Cases

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-l">
       <% if params[:q].present? %>
         <%= params[:q] %>
-        <span class="govuk-caption-m"><% "#{@products.count} #{'result'.pluralize(@products.count)}" %></span>
+        <span class="govuk-caption-m"><% "#{@products.total_entries} #{'result'.pluralize(@products.total_entries)}" %></span>
       <% else %>
         Products
       <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-l">
       <% if params[:q].present? %>
         <%= params[:q] %>
-        <span class="govuk-caption-m"><% "#{@products.total_entries} #{'result'.pluralize(@products.total_entries)}" %></span>
+        <span class="govuk-caption-m"><%= "#{@products.total_entries} #{'result'.pluralize(@products.total_entries)}" %></span>
       <% else %>
         Products
       <% end %>


### PR DESCRIPTION
https://trello.com/c/AtLllGyL/591-count-of-search-results-all-tabs-is-wrong

Fixes the total search result count shown in the top left of the cases, businesses and products pages not reflecting the total number of matches. Instead it was showing the number of results on the current page.

Also fixes the count not being output on the product search results page.