### PR TITLE
Add 'how many units are affected?' to the product page

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -308,8 +308,8 @@ private
   end
 
   def build_product_params
-    number_of_affected_units = product_request_params["exact_units"] if product_request_params["affected_units_status"] == "exact"
-    number_of_affected_units = product_request_params["approx_units"] if product_request_params["affected_units_status"] == "approx"
+    product_session_params['number_of_affected_units'] = product_session_params["exact_units"] if product_session_params["affected_units_status"] == "exact"
+    product_session_params['number_of_affected_units'] = product_session_params["approx_units"] if product_session_params["affected_units_status"] == "approx"
     product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -198,7 +198,7 @@ private
   def set_test
     @test = @investigation.tests.build(test_params)
     @test.set_dates_from_params(params[:test])
-    @test.build_product(product_step_params)
+    @test.build_product(build_product_params)
 
     attachment_params = get_attachment_params(:test_result_file, :test)
 
@@ -304,6 +304,10 @@ private
   end
 
   def product_step_params
+    product_session_params.merge(product_request_params).symbolize_keys
+  end
+
+  def build_product_params
     product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 
@@ -612,9 +616,8 @@ private
 
     # Product must be added before investigation is saved for correct audit
     # activity title generation
-    @product = @investigation.products.build(product_step_params)
+    @product = @investigation.products.build(build_product_params)
     CreateCase.call(investigation: @investigation, user: current_user)
-
     save_businesses
     save_corrective_actions
     save_risk_assessments

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -128,7 +128,7 @@ private
   end
 
   def product
-    @product ||= Product.new(ProductForm.new(product_step_params).serializable_hash)
+    @product ||= Product.new(ProductForm.new(product_step_params).serializable_hash.except("exact_units", "approx_units"))
   end
 
   def set_investigation
@@ -304,7 +304,7 @@ private
   end
 
   def product_step_params
-    product_session_params.merge(product_request_params).symbolize_keys
+    product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 
   def business_step_params

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -308,8 +308,8 @@ private
   end
 
   def build_product_params
-    product_session_params['number_of_affected_units'] = product_session_params["exact_units"] if product_session_params["affected_units_status"] == "exact"
-    product_session_params['number_of_affected_units'] = product_session_params["approx_units"] if product_session_params["affected_units_status"] == "approx"
+    product_session_params["number_of_affected_units"] = product_session_params["exact_units"] if product_session_params["affected_units_status"] == "exact"
+    product_session_params["number_of_affected_units"] = product_session_params["approx_units"] if product_session_params["affected_units_status"] == "approx"
     product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -308,6 +308,8 @@ private
   end
 
   def build_product_params
+    number_of_affected_units = product_request_params["exact_units"] if product_request_params["affected_units_status"] == "exact"
+    number_of_affected_units = product_request_params["approx_units"] if product_request_params["affected_units_status"] == "approx"
     product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -128,7 +128,7 @@ private
   end
 
   def product
-    @product ||= Product.new(ProductForm.new(product_step_params).serializable_hash.except("exact_units", "approx_units"))
+    @product ||= Product.new(ProductForm.new(product_step_params).serializable_hash)
   end
 
   def set_investigation
@@ -198,7 +198,7 @@ private
   def set_test
     @test = @investigation.tests.build(test_params)
     @test.set_dates_from_params(params[:test])
-    @test.build_product(build_product_params)
+    @test.build_product(product_step_params)
 
     attachment_params = get_attachment_params(:test_result_file, :test)
 
@@ -305,12 +305,6 @@ private
 
   def product_step_params
     product_session_params.merge(product_request_params).symbolize_keys
-  end
-
-  def build_product_params
-    product_session_params["number_of_affected_units"] = product_session_params["exact_units"] if product_session_params["affected_units_status"] == "exact"
-    product_session_params["number_of_affected_units"] = product_session_params["approx_units"] if product_session_params["affected_units_status"] == "approx"
-    product_session_params.merge(product_request_params).symbolize_keys.except(:exact_units, :approx_units)
   end
 
   def business_step_params
@@ -618,7 +612,7 @@ private
 
     # Product must be added before investigation is saved for correct audit
     # activity title generation
-    @product = @investigation.products.build(build_product_params)
+    @product = @investigation.products.build(product_step_params)
     CreateCase.call(investigation: @investigation, user: current_user)
     save_businesses
     save_corrective_actions

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -38,7 +38,7 @@ class ProductsController < ApplicationController
 
       if @product_form.valid?
         format.html do
-          product.update!(attributes_to_update)
+          product.update!(@product_form.serializable_hash)
           redirect_to product_path(product), flash: { success: "Product was successfully updated." }
         end
         format.json { render :show, status: :ok, location: product }
@@ -63,26 +63,5 @@ private
 
   def build_breadcrumbs
     @breadcrumbs = build_back_link_to_case || build_breadcrumb_structure
-  end
-
-  def attributes_to_update
-    number_of_affected_units = product_params["exact_units"] if product_params["affected_units_status"] == "exact"
-    number_of_affected_units = product_params["approx_units"] if product_params["affected_units_status"] == "approx"
-
-    {
-      authenticity: @product_form.authenticity,
-      batch_number: @product_form.batch_number,
-      brand: @product_form.brand,
-      country_of_origin: @product_form.country_of_origin,
-      description: @product_form.description,
-      gtin13: @product_form.gtin13,
-      name: @product_form.name,
-      product_code: @product_form.product_code,
-      subcategory: @product_form.subcategory,
-      category: @product_form.category,
-      webpage: @product_form.webpage,
-      affected_units_status: @product_form.affected_units_status,
-      number_of_affected_units: number_of_affected_units
-    }
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -66,8 +66,8 @@ private
   end
 
   def attributes_to_update
-    number_of_affected_units = product_params['exact_units'] if product_params['affected_units_status'] == 'exact'
-    number_of_affected_units = product_params['approx_units'] if product_params['affected_units_status'] == 'approx'
+    number_of_affected_units = product_params["exact_units"] if product_params["affected_units_status"] == "exact"
+    number_of_affected_units = product_params["approx_units"] if product_params["affected_units_status"] == "approx"
 
     {
       authenticity: @product_form.authenticity,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -38,7 +38,7 @@ class ProductsController < ApplicationController
 
       if @product_form.valid?
         format.html do
-          product.update!(@product_form.serializable_hash)
+          product.update!(attributes_to_update)
           redirect_to product_path(product), flash: { success: "Product was successfully updated." }
         end
         format.json { render :show, status: :ok, location: product }
@@ -63,5 +63,26 @@ private
 
   def build_breadcrumbs
     @breadcrumbs = build_back_link_to_case || build_breadcrumb_structure
+  end
+
+  def attributes_to_update
+    number_of_affected_units = product_params['exact_units'] if product_params['affected_units_status'] == 'exact'
+    number_of_affected_units = product_params['approx_units'] if product_params['affected_units_status'] == 'approx'
+
+    {
+      authenticity: @product_form.authenticity,
+      batch_number: @product_form.batch_number,
+      brand: @product_form.brand,
+      country_of_origin: @product_form.country_of_origin,
+      description: @product_form.description,
+      gtin13: @product_form.gtin13,
+      name: @product_form.name,
+      product_code: @product_form.product_code,
+      subcategory: @product_form.subcategory,
+      category: @product_form.category,
+      webpage: @product_form.webpage,
+      affected_units_status: @product_form.affected_units_status,
+      number_of_affected_units: number_of_affected_units
+    }
   end
 end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,6 +1,5 @@
 class ProductDecorator < ApplicationDecorator
   include FormattedDescription
-  include ActionView::Helpers::TextHelper
   delegate_all
   decorates_association :investigations
 

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,5 +1,6 @@
 class ProductDecorator < ApplicationDecorator
   include FormattedDescription
+  include ActionView::Helpers::TextHelper
   delegate_all
   decorates_association :investigations
 
@@ -43,9 +44,9 @@ class ProductDecorator < ApplicationDecorator
   def units_affected
     case object.affected_units_status
     when "exact"
-      "#{object.affected_units_status} units"
+      pluralize(object.number_of_affected_units, 'unit')
     when "approx"
-      "#{object.number_of_affected_units} units approximately"
+      pluralize(object.number_of_affected_units, 'unit') + " approximately"
     when "unknown"
       "Unknown"
     when "not_relevant"

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -44,15 +44,15 @@ class ProductDecorator < ApplicationDecorator
   def units_affected
     case object.affected_units_status
     when "exact"
-      pluralize(object.number_of_affected_units, "unit")
+      I18n.t(".product.exact_units", count: object.number_of_affected_units )
     when "approx"
-      pluralize(object.number_of_affected_units, "unit") + " approximately"
+      I18n.t(".product.approx_units", count: object.number_of_affected_units )
     when "unknown"
-      "Unknown"
+      I18n.t(".product.unknown")
     when "not_relevant"
-      "Not relevant"
+      I18n.t(".product.not_relevant")
     else
-      "Not provided"
+      I18n.t(".product.not_provided")
     end
   end
 end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -44,9 +44,9 @@ class ProductDecorator < ApplicationDecorator
   def units_affected
     case object.affected_units_status
     when "exact"
-      I18n.t(".product.exact_units", count: object.number_of_affected_units )
+      I18n.t(".product.exact_units", count: object.number_of_affected_units)
     when "approx"
-      I18n.t(".product.approx_units", count: object.number_of_affected_units )
+      I18n.t(".product.approx_units", count: object.number_of_affected_units)
     when "unknown"
       I18n.t(".product.unknown")
     when "not_relevant"

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -44,9 +44,9 @@ class ProductDecorator < ApplicationDecorator
   def units_affected
     case object.affected_units_status
     when "exact"
-      pluralize(object.number_of_affected_units, 'unit')
+      pluralize(object.number_of_affected_units, "unit")
     when "approx"
-      pluralize(object.number_of_affected_units, 'unit') + " approximately"
+      pluralize(object.number_of_affected_units, "unit") + " approximately"
     when "unknown"
       "Unknown"
     when "not_relevant"

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -12,6 +12,7 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Category" }, value: { text: category } },
       { key: { text: "Product sub-category" }, value: { text: subcategory } },
       { key: { text: "Product authenticity" }, value: { text: authenticity } },
+      { key: { text: "Units affected" }, value: { text: units_affected } },
       { key: { text: "Product brand" }, value: { text: object.brand } },
       { key: { text: "Product name" }, value: { text: object.name } },
       { key: { text: "Barcode number" }, value: { text: gtin13 } },
@@ -36,6 +37,21 @@ class ProductDecorator < ApplicationDecorator
       "#{product_and_category.first} (#{product_and_category.last.downcase})"
     else
       product_and_category.first
+    end
+  end
+
+  def units_affected
+    case object.affected_units_status
+    when "exact"
+      "#{object.affected_units_status} units"
+    when "approx"
+      "#{object.number_of_affected_units} units approximately"
+    when "unknown"
+      "Unknown"
+    when "not_relevant"
+      "Not relevant"
+    else
+      "Not provided"
     end
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -31,7 +31,7 @@ class ProductForm
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :name, presence: true
-  validates :affected_units_status, presence: true
+  validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
   validates :number_of_affected_units, presence: true, if: -> { affected_units_status == "approx" || affected_units_status == "exact" }
   validates :description, length: { maximum: 10_000 }
 

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -35,7 +35,7 @@ class ProductForm
   validates :name, presence: true
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
   validates :approx_units, numericality: true, if: -> { affected_units_status.inquiry.approx? }
-  validates :exact_units, numericality: true, if: -> { affected_units_status.inquiry.exact?  }
+  validates :exact_units, numericality: true, if: -> { affected_units_status.inquiry.exact? }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)
@@ -50,17 +50,17 @@ class ProductForm
 
   def approx_units
     if persisted?
-      number_of_affected_units if affected_units_status == 'approx'
+      number_of_affected_units if affected_units_status == "approx"
     else
-      attributes['approx_units']
+      attributes["approx_units"]
     end
   end
 
   def exact_units
     if persisted?
-      number_of_affected_units if affected_units_status == 'exact'
+      number_of_affected_units if affected_units_status == "exact"
     else
-      attributes['exact_units']
+      attributes["exact_units"]
     end
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -34,8 +34,8 @@ class ProductForm
   validates :subcategory, presence: true
   validates :name, presence: true
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
-  validates :approx_units, numericality: true, if: -> { affected_units_status == "approx"  }
-  validates :exact_units, numericality: true, if: -> { affected_units_status == "exact"  }
+  validates :approx_units, numericality: true, if: -> { affected_units_status == "approx" }
+  validates :exact_units, numericality: true, if: -> { affected_units_status == "exact" }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)
@@ -50,17 +50,17 @@ class ProductForm
 
   def approx_units
     if persisted?
-      number_of_affected_units if affected_units_status == 'approx'
+      number_of_affected_units if affected_units_status == "approx"
     else
-      attributes['approx_units']
+      attributes["approx_units"]
     end
   end
 
   def exact_units
     if persisted?
-      number_of_affected_units if affected_units_status == 'exact'
+      number_of_affected_units if affected_units_status == "exact"
     else
-      attributes['exact_units']
+      attributes["exact_units"]
     end
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -49,7 +49,7 @@ class ProductForm
   end
 
   def approx_units
-    if attributes['id']
+    if attributes["id"]
       number_of_affected_units if affected_units_status == "approx"
     else
       attributes["approx_units"]
@@ -57,7 +57,7 @@ class ProductForm
   end
 
   def exact_units
-    if attributes['id']
+    if attributes["id"]
       number_of_affected_units if affected_units_status == "exact"
     else
       attributes["exact_units"]

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -49,7 +49,7 @@ class ProductForm
   end
 
   def approx_units
-    if persisted?
+    if attributes['id']
       number_of_affected_units if affected_units_status == "approx"
     else
       attributes["approx_units"]
@@ -57,7 +57,7 @@ class ProductForm
   end
 
   def exact_units
-    if persisted?
+    if attributes['id']
       number_of_affected_units if affected_units_status == "exact"
     else
       attributes["exact_units"]

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -31,6 +31,8 @@ class ProductForm
   validates :category, presence: true
   validates :subcategory, presence: true
   validates :name, presence: true
+  validates :affected_units_status, presence: true
+  validates :number_of_affected_units, presence: true, if: -> { affected_units_status == "approx" || affected_units_status == "exact" }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -34,8 +34,8 @@ class ProductForm
   validates :subcategory, presence: true
   validates :name, presence: true
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
-  validates :approx_units, numericality: true, if: -> { affected_units_status.inquiry.approx? }
-  validates :exact_units, numericality: true, if: -> { affected_units_status.inquiry.exact? }
+  validates :approx_units, numericality: true, if: -> { affected_units_status == "approx"  }
+  validates :exact_units, numericality: true, if: -> { affected_units_status == "exact"  }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)
@@ -50,17 +50,17 @@ class ProductForm
 
   def approx_units
     if persisted?
-      number_of_affected_units if affected_units_status == "approx"
+      number_of_affected_units if affected_units_status == 'approx'
     else
-      attributes["approx_units"]
+      attributes['approx_units']
     end
   end
 
   def exact_units
     if persisted?
-      number_of_affected_units if affected_units_status == "exact"
+      number_of_affected_units if affected_units_status == 'exact'
     else
-      attributes["exact_units"]
+      attributes['exact_units']
     end
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -20,6 +20,8 @@ class ProductForm
   attribute :created_at, :datetime
   attribute :affected_units_status
   attribute :number_of_affected_units
+  attribute :approx_units
+  attribute :exact_units
 
   before_validation { trim_line_endings(:description) }
   before_validation { convert_gtin_to_13_digits(:gtin13) }
@@ -32,7 +34,8 @@ class ProductForm
   validates :subcategory, presence: true
   validates :name, presence: true
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
-  validates :number_of_affected_units, presence: true, if: -> { affected_units_status == "approx" || affected_units_status == "exact" }
+  validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
+  validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)
@@ -43,5 +46,13 @@ class ProductForm
     return false if id.nil?
 
     authenticity.nil?
+  end
+
+  def approx_units
+    number_of_affected_units if affected_units_status == 'approx'
+  end
+
+  def exact_units
+    number_of_affected_units if affected_units_status == 'exact'
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -34,8 +34,8 @@ class ProductForm
   validates :subcategory, presence: true
   validates :name, presence: true
   validates :affected_units_status, inclusion: { in: Product.affected_units_statuses.keys }
-  validates :approx_units, presence: true, if: -> { affected_units_status == "approx" }
-  validates :exact_units, presence: true, if: -> { affected_units_status == "exact" }
+  validates :approx_units, numericality: true, if: -> { affected_units_status.inquiry.approx? }
+  validates :exact_units, numericality: true, if: -> { affected_units_status.inquiry.exact?  }
   validates :description, length: { maximum: 10_000 }
 
   def self.from(product)
@@ -49,10 +49,18 @@ class ProductForm
   end
 
   def approx_units
-    number_of_affected_units if affected_units_status == 'approx'
+    if persisted?
+      number_of_affected_units if affected_units_status == 'approx'
+    else
+      attributes['approx_units']
+    end
   end
 
   def exact_units
-    number_of_affected_units if affected_units_status == 'exact'
+    if persisted?
+      number_of_affected_units if affected_units_status == 'exact'
+    else
+      attributes['exact_units']
+    end
   end
 end

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -18,6 +18,8 @@ class ProductForm
   attribute :subcategory
   attribute :webpage
   attribute :created_at, :datetime
+  attribute :affected_units_status
+  attribute :number_of_affected_units
 
   before_validation { trim_line_endings(:description) }
   before_validation { convert_gtin_to_13_digits(:gtin13) }

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -60,8 +60,8 @@ module ProductsHelper
       { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
       { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
       { text: "Unknown",                  value: "unknown" },
-      { divider: 'or' },
-      { text: "Not relevant",             value: "not_relevant" }
+      { divider: "or" },
+      { text: "Not relevant", value: "not_relevant" }
     ]
 
     return items if product_form.affected_units_status.blank?

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -6,7 +6,7 @@ module ProductsHelper
   # Never trust parameters from the scary internet, only allow the white list through.
   def product_params
     params.require(:product).permit(
-      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity
+      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :affected_units_status, :number_of_affected_units
     )
   end
 
@@ -55,6 +55,19 @@ module ProductsHelper
     set_selected_authenticity_option(items, product_form)
   end
 
+  def items_for_affected_units(product_form, form)
+    items = [
+      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?", label_classes: "govuk-visually-hidden") } },
+      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?", label_classes: "govuk-visually-hidden") } },
+      { text: "Unknown",                  value: "unknown" },
+      { text: "Not relevant",             value: "not_relevant" }
+    ]
+
+    return items if product_form.affected_units_status.blank?
+
+    set_affected_selected_units_status_option(items, product_form)
+  end
+
   def options_for_country_of_origin(countries, product_form)
     countries.map do |country|
       text = country[0]
@@ -74,8 +87,20 @@ private
     end
   end
 
+  def set_affected_selected_units_status_option(items, product_form)
+    items.each do |item|
+      next if skip_selected_item_for_selected_option?(item, product_form)
+
+      item[:selected] = true if affected_units_status_selected?(item, product_form)
+    end
+  end
+
   def authenticity_selected?(item, product_form)
     item[:value] == product_form.authenticity
+  end
+
+  def affected_units_status_selected?(item, product_form)
+    item[:value] == product_form.affected_units_status
   end
 
   def skip_selected_item_for_selected_option?(item, product_form)

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -105,7 +105,7 @@ private
   end
 
   def skip_selected_item_for_selected_option?(item, product_form)
-    item[:value].inquiry.missing? && product_form.id.nil?
+    item[:divider] || item[:value].inquiry.missing? && product_form.id.nil?
   end
 
   def have_excluded_id(excluded_ids)

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -57,8 +57,8 @@ module ProductsHelper
 
   def items_for_affected_units(product_form, form)
     items = [
-      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?", label_classes: "govuk-visually-hidden") } },
-      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?", label_classes: "govuk-visually-hidden") } },
+      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
+      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
       { text: "Unknown",                  value: "unknown" },
       { text: "Not relevant",             value: "not_relevant" }
     ]

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -6,7 +6,7 @@ module ProductsHelper
   # Never trust parameters from the scary internet, only allow the white list through.
   def product_params
     params.require(:product).permit(
-      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :affected_units_status, :number_of_affected_units
+      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units
     )
   end
 
@@ -57,8 +57,8 @@ module ProductsHelper
 
   def items_for_affected_units(product_form, form)
     items = [
-      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
-      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
+      { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:exact_units, label: "How many units?") } },
+      { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:approx_units, label: "How many units?") } },
       { text: "Unknown",                  value: "unknown" },
       { divider: "or" },
       { text: "Not relevant", value: "not_relevant" }

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -60,6 +60,7 @@ module ProductsHelper
       { text: "Exact number known",       value: "exact", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
       { text: "Approximate number known", value: "approx", conditional: { html: form.govuk_input(:number_of_affected_units, label: "How many units?") } },
       { text: "Unknown",                  value: "unknown" },
+      { divider: 'or' },
       { text: "Not relevant",             value: "not_relevant" }
     ]
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -10,6 +10,13 @@ class Product < ApplicationRecord
     "unsure" => "unsure"
   }
 
+  enum affected_units_status: {
+    "exact" => "exact",
+    "approx" => "approx",
+    "unknown" => "unknown",
+    "not_relevant" => "not_relevant"
+  }
+
   index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "products"].join("_")
 
   has_many_attached :documents

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -41,7 +41,7 @@ class AddProductToCase
         webpage: webpage,
         source: build_user_source,
         affected_units_status: affected_units_status,
-        number_of_affected_units: calculate_number_of_affected_units
+        number_of_affected_units: number_of_affected_units
       )
 
       context.activity = create_audit_activity_for_product_added
@@ -71,11 +71,6 @@ private
         "#{investigation.case_type.upcase_first} updated"
       ).deliver_later
     end
-  end
-
-  def calculate_number_of_affected_units
-    return exact_units if affected_units_status == "exact"
-    return approx_units if affected_units_status == "approx"
   end
 
   def build_user_source

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -18,6 +18,8 @@ class AddProductToCase
            :product,
            :affected_units_status,
            :number_of_affected_units,
+           :exact_units,
+           :approx_units,
            to: :context
 
   def call
@@ -39,7 +41,7 @@ class AddProductToCase
         webpage: webpage,
         source: build_user_source,
         affected_units_status: affected_units_status,
-        number_of_affected_units: number_of_affected_units
+        number_of_affected_units: calculate_number_of_affected_units
       )
 
       context.activity = create_audit_activity_for_product_added
@@ -69,6 +71,11 @@ private
         "#{investigation.case_type.upcase_first} updated"
       ).deliver_later
     end
+  end
+
+  def calculate_number_of_affected_units
+    return exact_units if affected_units_status == 'exact'
+    return approx_units if affected_units_status == 'approx'
   end
 
   def build_user_source

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -16,6 +16,8 @@ class AddProductToCase
            :category,
            :user,
            :product,
+           :affected_units_status,
+           :number_of_affected_units,
            to: :context
 
   def call
@@ -35,7 +37,9 @@ class AddProductToCase
         subcategory: subcategory,
         category: category,
         webpage: webpage,
-        source: build_user_source
+        source: build_user_source,
+        affected_units_status: affected_units_status,
+        number_of_affected_units: number_of_affected_units
       )
 
       context.activity = create_audit_activity_for_product_added

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -74,8 +74,8 @@ private
   end
 
   def calculate_number_of_affected_units
-    return exact_units if affected_units_status == 'exact'
-    return approx_units if affected_units_status == 'approx'
+    return exact_units if affected_units_status == "exact"
+    return approx_units if affected_units_status == "approx"
   end
 
   def build_user_source

--- a/app/views/investigations/products/new.html.erb
+++ b/app/views/investigations/products/new.html.erb
@@ -11,7 +11,7 @@
 <%= form_with model: @product_form, scope: :product, url: investigation_products_path(@investigation), local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity name gtin13]) %>
+      <%= error_summary(@product_form.errors, %i[category subcategory authenticity affected_units_status number_of_affected_units name gtin13]) %>
       <%= render "investigation_heading", investigation: @investigation %>
 
       <h2 class="govuk-heading-m">Add product</h2>

--- a/app/views/investigations/ts_investigations/product.html.erb
+++ b/app/views/investigations/ts_investigations/product.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @product_form, scope: :product, url: wizard_path, method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category product_type authenticity name]) %>
+      <%= error_summary(@product_form.errors, %i[category product_type authenticity affected_units_status number_of_affected_units name]) %>
       <span class="govuk-caption-l">Report an unsafe or non-compliant product</span>
       <h1 class="govuk-heading-l"><%= page_heading %></h1>
       <%= render "products/form", form: form, product_form: @product_form, countries: @countries, submit_text: "Continue" %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -26,7 +26,7 @@
 
 <%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", items: items_for_authenticity(product_form) %>
 
-<%= form.govuk_radios :affected_units_status, legend: "Which standard was the product tested against?", items: items_for_affected_units(product_form, form) %>
+<%= form.govuk_radios :affected_units_status, legend: "Add 'how many units are affected?", items: items_for_affected_units(product_form, form) %>
 
 <%= render "form_components/govuk_input",
   key: :brand,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -26,7 +26,7 @@
 
 <%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", items: items_for_authenticity(product_form) %>
 
-<%= form.govuk_radios :affected_units_status, legend: "Add 'how many units are affected?", items: items_for_affected_units(product_form, form) %>
+<%= form.govuk_radios :affected_units_status, legend: "How many units are affected?", items: items_for_affected_units(product_form, form) %>
 
 <%= render "form_components/govuk_input",
   key: :brand,

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -26,6 +26,8 @@
 
 <%= form.govuk_radios :authenticity, legend: "Is the product counterfeit?", items: items_for_authenticity(product_form) %>
 
+<%= form.govuk_radios :affected_units_status, legend: "Which standard was the product tested against?", items: items_for_affected_units(product_form, form) %>
+
 <%= render "form_components/govuk_input",
   key: :brand,
   form: form,

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -6,7 +6,7 @@
 <%= form_with model: @product_form, scope: :product, url: product_path(@product_form.id), method: :put, local: true, builder: ApplicationFormBuilder do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= error_summary(@product_form.errors, %i[category subcategory authenticity name]) %>
+      <%= error_summary(@product_form.errors, %i[category subcategory authenticity affected_units_status number_of_affected_units name]) %>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,7 +252,7 @@ en:
               invalid: "Enter a valid barcode number"
               wrong_length: "Enter a valid barcode number"
             affected_units_status:
-              blank: "You must state how many units are affected"
+              inclusion: "You must state how many units are affected"
             number_of_affected_units:
               blank: "Give the number of units affected"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -466,6 +466,17 @@ en:
     genuine: "Genuine"
     unsure: "Unsure"
     missing: "Not provided"
+    unknown: "Unknown"
+    not_relevant: "Not relevant"
+    not_provided: "Not provided"
+    exact_units: {
+      one: "1 unit",
+      other: "%{count} units"
+    }
+    approx_units: {
+      one: "1 unit approximately",
+      other: "%{count} units approximately"
+    }
 
   corrective_action:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,8 +253,10 @@ en:
               wrong_length: "Enter a valid barcode number"
             affected_units_status:
               inclusion: "You must state how many units are affected"
-            number_of_affected_units:
-              blank: "Give the number of units affected"
+            approx_units:
+              not_a_number: "Give the number of units affected"
+            exact_units:
+              not_a_number: "Give the number of units affected"
 
         risk_assessment_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,10 @@ en:
             gtin13:
               invalid: "Enter a valid barcode number"
               wrong_length: "Enter a valid barcode number"
+            affected_units_status:
+              blank: "You must state how many units are affected"
+            number_of_affected_units:
+              blank: "Give the number of units affected"
 
         risk_assessment_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,14 +469,12 @@ en:
     unknown: "Unknown"
     not_relevant: "Not relevant"
     not_provided: "Not provided"
-    exact_units: {
-      one: "1 unit",
+    exact_units:
+      one: "1 unit"
       other: "%{count} units"
-    }
-    approx_units: {
-      one: "1 unit approximately",
+    approx_units:
+      one: "1 unit approximately"
       other: "%{count} units approximately"
-    }
 
   corrective_action:
     attributes:

--- a/db/migrate/20201125160042_add_affected_units_status_and_number_of_affected_units_to_products.rb
+++ b/db/migrate/20201125160042_add_affected_units_status_and_number_of_affected_units_to_products.rb
@@ -1,6 +1,0 @@
-class AddAffectedUnitsStatusAndNumberOfAffectedUnitsToProducts < ActiveRecord::Migration[6.0]
-  def change
-    add_column :products, :affected_units_status, :string
-    add_column :products, :number_of_affected_units, :integer
-  end
-end

--- a/db/migrate/20201125160042_add_affected_units_status_and_number_of_affected_units_to_products.rb
+++ b/db/migrate/20201125160042_add_affected_units_status_and_number_of_affected_units_to_products.rb
@@ -1,0 +1,6 @@
+class AddAffectedUnitsStatusAndNumberOfAffectedUnitsToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :affected_units_status, :string
+    add_column :products, :number_of_affected_units, :integer
+  end
+end

--- a/db/migrate/20201125171036_add_affected_units_status_and_number_of_affected_units_to_products.rb
+++ b/db/migrate/20201125171036_add_affected_units_status_and_number_of_affected_units_to_products.rb
@@ -1,0 +1,12 @@
+class AddAffectedUnitsStatusAndNumberOfAffectedUnitsToProducts < ActiveRecord::Migration[6.0]
+  def change
+      safety_assured do
+        reversible do |dir|
+          dir.up { execute "CREATE TYPE affected_units_statuses AS ENUM ('exact', 'approx', 'unknown', 'not_relevant');" }
+          dir.down { execute "DROP TYPE IF EXISTS affected_units_statuses;" }
+        end
+        add_column :products, :affected_units_status, :affected_units_statuses
+        add_column :products, :number_of_affected_units, :integer
+      end
+    end
+end

--- a/db/migrate/20201125171036_add_affected_units_status_and_number_of_affected_units_to_products.rb
+++ b/db/migrate/20201125171036_add_affected_units_status_and_number_of_affected_units_to_products.rb
@@ -1,12 +1,12 @@
 class AddAffectedUnitsStatusAndNumberOfAffectedUnitsToProducts < ActiveRecord::Migration[6.0]
   def change
-      safety_assured do
-        reversible do |dir|
-          dir.up { execute "CREATE TYPE affected_units_statuses AS ENUM ('exact', 'approx', 'unknown', 'not_relevant');" }
-          dir.down { execute "DROP TYPE IF EXISTS affected_units_statuses;" }
-        end
-        add_column :products, :affected_units_status, :affected_units_statuses
-        add_column :products, :number_of_affected_units, :integer
+    safety_assured do
+      reversible do |dir|
+        dir.up { execute "CREATE TYPE affected_units_statuses AS ENUM ('exact', 'approx', 'unknown', 'not_relevant');" }
+        dir.down { execute "DROP TYPE IF EXISTS affected_units_statuses;" }
       end
+      add_column :products, :affected_units_status, :affected_units_statuses
+      add_column :products, :number_of_affected_units, :integer
     end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_160042) do
+ActiveRecord::Schema.define(version: 2020_11_25_171036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   # These are custom enum types that must be created before they can be used in the schema definition
+  create_enum "affected_units_statuses", ["exact", "approx", "unknown", "not_relevant"]
   create_enum "authenticities", ["counterfeit", "genuine", "unsure"]
   create_enum "reported_reasons", ["unsafe", "non_compliant", "unsafe_and_non_compliant", "safe_and_compliant"]
   create_enum "risk_levels", ["serious", "high", "medium", "low", "other"]
@@ -219,7 +220,7 @@ ActiveRecord::Schema.define(version: 2020_11_25_160042) do
   end
 
   create_table "products", id: :serial, force: :cascade do |t|
-    t.string "affected_units_status"
+    t.enum "affected_units_status", as: "affected_units_statuses"
     t.enum "authenticity", as: "authenticities"
     t.string "batch_number"
     t.text "brand"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_121612) do
+ActiveRecord::Schema.define(version: 2020_11_25_160042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_121612) do
   end
 
   create_table "products", id: :serial, force: :cascade do |t|
+    t.string "affected_units_status"
     t.enum "authenticity", as: "authenticities"
     t.string "batch_number"
     t.text "brand"
@@ -228,6 +229,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_121612) do
     t.text "description"
     t.string "gtin13", limit: 13
     t.string "name"
+    t.integer "number_of_affected_units"
     t.string "product_code"
     t.string "subcategory"
     t.datetime "updated_at", null: false

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProductDecorator do
 
   describe "#units_affected" do
     context "when affected_units_status is `exact`" do
-      it 'returns correct units affected string' do
+      it "returns correct units affected string" do
         product.affected_units_status = "exact"
         product.number_of_affected_units = 12
         expect(decorated_product.units_affected).to eq "12 units"
@@ -19,7 +19,7 @@ RSpec.describe ProductDecorator do
     end
 
     context "when affected_units_status is `approx`" do
-      it 'returns correct units affected string' do
+      it "returns correct units affected string" do
         product.affected_units_status = "approx"
         product.number_of_affected_units = 12
         expect(decorated_product.units_affected).to eq "12 units approximately"
@@ -27,14 +27,14 @@ RSpec.describe ProductDecorator do
     end
 
     context "when affected_units_status is `unknown`" do
-      it 'returns correct units affected string' do
+      it "returns correct units affected string" do
         product.affected_units_status = "unknown"
         expect(decorated_product.units_affected).to eq "Unknown"
       end
     end
 
     context "when affected_units_status is `not_relevant`" do
-      it 'returns correct units affected string' do
+      it "returns correct units affected string" do
         product.affected_units_status = "not_relevant"
         expect(decorated_product.units_affected).to eq "Not relevant"
       end

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -9,6 +9,38 @@ RSpec.describe ProductDecorator do
     specify { expect(decorated_product.pretty_description).to eq("Product: #{product.name}") }
   end
 
+  describe "#units_affected" do
+    context "when affected_units_status is `exact`" do
+      it 'returns correct units affected string' do
+        product.affected_units_status = "exact"
+        product.number_of_affected_units = 12
+        expect(decorated_product.units_affected).to eq "12 units"
+      end
+    end
+
+    context "when affected_units_status is `approx`" do
+      it 'returns correct units affected string' do
+        product.affected_units_status = "approx"
+        product.number_of_affected_units = 12
+        expect(decorated_product.units_affected).to eq "12 units approximately"
+      end
+    end
+
+    context "when affected_units_status is `unknown`" do
+      it 'returns correct units affected string' do
+        product.affected_units_status = "unknown"
+        expect(decorated_product.units_affected).to eq "Unknown"
+      end
+    end
+
+    context "when affected_units_status is `not_relevant`" do
+      it 'returns correct units affected string' do
+        product.affected_units_status = "not_relevant"
+        expect(decorated_product.units_affected).to eq "Not relevant"
+      end
+    end
+  end
+
   describe "#summary_list" do
     include CountriesHelper
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     authenticity { Product.authenticities.keys.sample }
     batch_number { "123123123" }
     brand { Faker::Company.name }
+    affected_units_status { "unknown" }
 
     factory :product_iphone do
       product_code { 234 }

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -48,7 +48,8 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     within_fieldset("How many units are affected?") do
       choose affected_units_status_answer(attributes[:affected_units_status])
       if attributes[:affected_units_status] == "approx" || attributes[:affected_units_status] == "exact"
-        fill_in "How many units?", with: "10"
+        field = attributes[:affected_units_status] == "exact" ? all("#number_of_affected_units").first : all("#number_of_affected_units").last
+        field.set("10")
       end
     end
 

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -47,10 +47,8 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
 
     within_fieldset("How many units are affected?") do
       choose affected_units_status_answer(attributes[:affected_units_status])
-      if attributes[:affected_units_status] == "approx" || attributes[:affected_units_status] == "exact"
-        field = attributes[:affected_units_status] == "exact" ? all("#number_of_affected_units").first : all("#number_of_affected_units").last
-        field.set("10")
-      end
+      find("#exact_units").set(10) if attributes[:affected_units_status] == "exact"
+      find("#approx_units").set(10) if attributes[:affected_units_status] == "approx"
     end
 
     select attributes[:country_of_origin], from: "Country of origin"

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing").sample,
                                     affected_units_status: Product.affected_units_statuses.keys.sample)
   end
-  let(:other_user)    { create(:user, :activated) }
+  let(:other_user) { create(:user, :activated) }
 
   before do
     ChangeCaseOwner.call!(investigation: investigation, owner: user.team, user: user)
@@ -47,8 +47,8 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
 
     within_fieldset("How many units are affected?") do
       choose affected_units_status_answer(attributes[:affected_units_status])
-      if (attributes[:affected_units_status] == 'approx' || attributes[:affected_units_status] == 'exact')
-        fill_in "How many units?", with: '10'
+      if attributes[:affected_units_status] == "approx" || attributes[:affected_units_status] == "exact"
+        fill_in "How many units?", with: "10"
       end
     end
 

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       country_of_origin: Country.all.sample.first,
       description: Faker::Lorem.sentence,
       authenticity: Product.authenticities.keys.without("missing").sample,
-      affected_units_status: "not_relevant"
+      affected_units_status: "approx"
     }
   end
 
@@ -144,7 +144,10 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     select country_of_origin,             from: "Country of origin"
     fill_in "Product sub-category", with: type
     within_fieldset("Is the product counterfeit?") { choose counterfeit_answer(authenticity) }
-    within_fieldset("How many units are affected?") { choose affected_units_status_answer(affected_units_status) }
+    within_fieldset("How many units are affected?") do
+      choose affected_units_status_answer(affected_units_status)
+      find("#approx_units").set(21)
+    end
     fill_in "Product name",               with: name
     fill_in "Other product identifiers",  with: barcode
     fill_in "Webpage",                    with: webpage
@@ -161,7 +164,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: webpage)
     expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: country_of_origin)
     expect(page.find("dt", text: "Description")).to have_sibling("dd", text: description)
-    expect(page.find("dt", text: "Units affected")).to have_sibling("dd", text: "Not relevant")
+    expect(page.find("dt", text: "Units affected")).to have_sibling("dd", text: "21 units approximately")
   end
 
   def expect_details_on_summary_page

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       webpage: Faker::Internet.url,
       country_of_origin: Country.all.sample.first,
       description: Faker::Lorem.sentence,
-      authenticity: Product.authenticities.keys.without("missing").sample
+      authenticity: Product.authenticities.keys.without("missing").sample,
+      affected_units_status: 'not_relevant'
     }
   end
 
@@ -138,11 +139,12 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     click_button "Create allegation"
   end
 
-  def enter_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:)
+  def enter_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:)
     select category,                      from: "Product category"
     select country_of_origin,             from: "Country of origin"
     fill_in "Product sub-category", with: type
     within_fieldset("Is the product counterfeit?") { choose counterfeit_answer(authenticity) }
+    within_fieldset("How many units are affected?") { choose affected_units_status_answer(affected_units_status) }
     fill_in "Product name",               with: name
     fill_in "Other product identifiers",  with: barcode
     fill_in "Webpage",                    with: webpage
@@ -150,7 +152,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     click_button "Save product"
   end
 
-  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:)
+  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:)
     expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: name)
     expect(page.find("dt", text: "Product sub-category")).to have_sibling("dd", text: type)
     expect(page.find("dt", text: "Product authenticity")).to have_sibling("dd", text: I18n.t(authenticity, scope: Product.model_name.i18n_key))
@@ -159,6 +161,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: webpage)
     expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: country_of_origin)
     expect(page.find("dt", text: "Description")).to have_sibling("dd", text: description)
+    expect(page.find("dt", text: "Units affected")).to have_sibling("dd", text: "Not relevant")
   end
 
   def expect_details_on_summary_page

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
 
       click_link "Products (1)"
 
-      expect_page_to_show_entered_product_details(**product_details)
+      expect_page_to_show_entered_product_details(**product_details.except(:affected_units_status))
 
       click_link "Activity"
       expect_details_on_activity_page(contact_details, allegation_details)

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
       country_of_origin: Country.all.sample.first,
       description: Faker::Lorem.sentence,
       authenticity: Product.authenticities.keys.without("missing").sample,
-      affected_units_status: 'not_relevant'
+      affected_units_status: "not_relevant"
     }
   end
 
@@ -152,7 +152,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     click_button "Save product"
   end
 
-  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:, affected_units_status:)
+  def expect_page_to_show_entered_product_details(name:, barcode:, category:, type:, webpage:, country_of_origin:, description:, authenticity:)
     expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: name)
     expect(page.find("dt", text: "Product sub-category")).to have_sibling("dd", text: type)
     expect(page.find("dt", text: "Product authenticity")).to have_sibling("dd", text: I18n.t(authenticity, scope: Product.model_name.i18n_key))

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:product) do
     create(:product,
            authenticity: nil,
-           affected_units_status: 'exact',
+           affected_units_status: "exact",
            number_of_affected_units: 1000,
            brand: brand,
            product_code: product_code,
@@ -89,7 +89,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expect(page).to have_summary_item(key: "Category", value: new_product_category)
     expect(page).to have_summary_item(key: "Product sub-category", value: new_subcategory)
     expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
-    expect(page).to have_summary_item(key: "Units affected",            value: '14 units approximately')
+    expect(page).to have_summary_item(key: "Units affected",            value: "14 units approximately")
     expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
     expect(page).to have_summary_item(key: "Product name",              value: new_name)
     expect(page).to have_summary_item(key: "Barcode number",            value: new_gtin13)

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_subcategory) { Faker::Hipster.word }
   let(:new_gtin13)            { Faker::Barcode.ean(13) }
   let(:new_authenticity)      { (Product.authenticities.keys - [product.authenticity]).sample }
-  let(:new_affected_units_status)      { "not_relevant" }
+  let(:new_affected_units_status) { "not_relevant" }
   let(:new_batch_number)      { Faker::Number.number(digits: 10) }
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:product) do
     create(:product,
            authenticity: nil,
-           affected_units_status: nil,
+           affected_units_status: 'exact',
+           number_of_affected_units: 1000,
            brand: brand,
            product_code: product_code,
            webpage: webpage,
@@ -23,7 +24,8 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_subcategory) { Faker::Hipster.word }
   let(:new_gtin13)            { Faker::Barcode.ean(13) }
   let(:new_authenticity)      { (Product.authenticities.keys - [product.authenticity]).sample }
-  let(:new_affected_units_status) { "not_relevant" }
+  let(:new_affected_units_status) { "approx" }
+  let(:new_number_of_affected_units) { 14 }
   let(:new_batch_number)      { Faker::Number.number(digits: 10) }
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }
@@ -70,6 +72,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
 
     within_fieldset("How many units are affected?") do
       choose affected_units_status_answer(new_affected_units_status)
+      find("#approx_units").set(new_number_of_affected_units)
     end
 
     fill_in "Product brand",            with: new_brand
@@ -86,7 +89,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expect(page).to have_summary_item(key: "Category", value: new_product_category)
     expect(page).to have_summary_item(key: "Product sub-category", value: new_subcategory)
     expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
-    expect(page).to have_summary_item(key: "Units affected",            value: affected_units_status_answer(new_affected_units_status))
+    expect(page).to have_summary_item(key: "Units affected",            value: '14 units approximately')
     expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
     expect(page).to have_summary_item(key: "Product name",              value: new_name)
     expect(page).to have_summary_item(key: "Barcode number",            value: new_gtin13)

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:product) do
     create(:product,
            authenticity: nil,
+           affected_units_status: nil,
            brand: brand,
            product_code: product_code,
            webpage: webpage,
@@ -22,6 +23,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_subcategory) { Faker::Hipster.word }
   let(:new_gtin13)            { Faker::Barcode.ean(13) }
   let(:new_authenticity)      { (Product.authenticities.keys - [product.authenticity]).sample }
+  let(:new_affected_units_status)      { "not_relevant" }
   let(:new_batch_number)      { Faker::Number.number(digits: 10) }
   let(:new_product_code)      { Faker::Barcode.issn }
   let(:new_webpage)           { Faker::Internet.url }
@@ -66,6 +68,10 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
       choose counterfeit_answer(new_authenticity)
     end
 
+    within_fieldset("How many units are affected?") do
+      choose affected_units_status_answer(new_affected_units_status)
+    end
+
     fill_in "Product brand",            with: new_brand
     fill_in "Product name",             with: new_name
     fill_in "Barcode number",           with: new_gtin13
@@ -80,6 +86,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expect(page).to have_summary_item(key: "Category", value: new_product_category)
     expect(page).to have_summary_item(key: "Product sub-category", value: new_subcategory)
     expect(page).to have_summary_item(key: "Product authenticity",      value: I18n.t(new_authenticity, scope: Product.model_name.i18n_key))
+    expect(page).to have_summary_item(key: "Units affected",            value: affected_units_status_answer(new_affected_units_status))
     expect(page).to have_summary_item(key: "Product brand",             value: new_brand)
     expect(page).to have_summary_item(key: "Product name",              value: new_name)
     expect(page).to have_summary_item(key: "Barcode number",            value: new_gtin13)

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -104,7 +104,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           country_of_origin: Country.all.sample.first,
           description: Faker::Lorem.sentence,
           authenticity: "Yes",
-          affected_units_status: "Unknown"
+          affected_units_status: "Approximate number known",
+          number_of_affected_units: 22
         }
       end
       let(:coronavirus) { false }
@@ -487,6 +488,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
     within_fieldset("How many units are affected?") do
       choose with[:affected_units_status]
+      find("#approx_units").set(with[:number_of_affected_units])
     end
 
     fill_in "Product name",                      with: with[:name]

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -103,7 +103,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           webpage: Faker::Internet.url,
           country_of_origin: Country.all.sample.first,
           description: Faker::Lorem.sentence,
-          authenticity: "Yes"
+          authenticity: "Yes",
+          affected_units_status: "Unknown"
         }
       end
       let(:coronavirus) { false }
@@ -264,7 +265,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           name: Faker::Lorem.sentence,
           category: Rails.application.config.product_constants["product_category"].sample,
           type: Faker::Appliance.equipment,
-          authenticity: "Yes"
+          authenticity: "Yes",
+          affected_units_status: "Unknown"
         }
       end
 
@@ -481,6 +483,10 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
     within_fieldset("Is the product counterfeit?") do
       choose with[:authenticity]
+    end
+
+    within_fieldset("How many units are affected?") do
+      choose with[:affected_units_status]
     end
 
     fill_in "Product name",                      with: with[:name]

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
            product_code: "MBWM01",
            batch_number: "Batches 0001 to 0231",
            webpage: "http://example.com/mybrand/washing-machines",
-           description: "White with chrome buttons")
+           description: "White with chrome buttons",
+           affected_units_status: 'not_relevant')
   end
 
   scenario "Updating a product" do
@@ -39,6 +40,9 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
     fill_in "Batch number", with: "Batches 0005 to 1023"
     fill_in "Webpage", with: "http://example.com/mybrand/dishwashers"
     fill_in "Description of product", with: "White with chrome handle"
+    within_fieldset("How many units are affected?") do
+      choose 'Unknown'
+    end
 
     click_button "Save product"
 
@@ -53,5 +57,6 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
     expect(page).to have_summary_item(key: "Batch number", value: "Batches 0005 to 1023")
     expect(page).to have_summary_item(key: "Webpage", value: "http://example.com/mybrand/dishwashers")
     expect(page).to have_summary_item(key: "Description", value: "White with chrome handle")
+    expect(page).to have_summary_item(key: "Units affected", value: "Unknown")
   end
 end

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -12,7 +12,8 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
            batch_number: "Batches 0001 to 0231",
            webpage: "http://example.com/mybrand/washing-machines",
            description: "White with chrome buttons",
-           affected_units_status: "not_relevant")
+           affected_units_status: "approx",
+           number_of_affected_units: 1)
   end
 
   scenario "Updating a product" do
@@ -41,7 +42,8 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
     fill_in "Webpage", with: "http://example.com/mybrand/dishwashers"
     fill_in "Description of product", with: "White with chrome handle"
     within_fieldset("How many units are affected?") do
-      choose "Unknown"
+      choose "Approximate number known"
+      find("#approx_units").set(2)
     end
 
     click_button "Save product"
@@ -57,6 +59,6 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
     expect(page).to have_summary_item(key: "Batch number", value: "Batches 0005 to 1023")
     expect(page).to have_summary_item(key: "Webpage", value: "http://example.com/mybrand/dishwashers")
     expect(page).to have_summary_item(key: "Description", value: "White with chrome handle")
-    expect(page).to have_summary_item(key: "Units affected", value: "Unknown")
+    expect(page).to have_summary_item(key: "Units affected", value: "2 units approximately")
   end
 end

--- a/spec/features/update_product_details_spec.rb
+++ b/spec/features/update_product_details_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
            batch_number: "Batches 0001 to 0231",
            webpage: "http://example.com/mybrand/washing-machines",
            description: "White with chrome buttons",
-           affected_units_status: 'not_relevant')
+           affected_units_status: "not_relevant")
   end
 
   scenario "Updating a product" do
@@ -41,7 +41,7 @@ RSpec.feature "Updating product details", :with_stubbed_mailer, :with_stubbed_el
     fill_in "Webpage", with: "http://example.com/mybrand/dishwashers"
     fill_in "Description of product", with: "White with chrome handle"
     within_fieldset("How many units are affected?") do
-      choose 'Unknown'
+      choose "Unknown"
     end
 
     click_button "Save product"

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe ProductForm do
-  subject(:form) { described_class.new(attriutes) }
+  subject(:form) { described_class.new(attributes) }
 
-  let(:attriutes) { attributes_for(:product) }
+  let(:attributes) { attributes_for(:product) }
 
   describe "gtin13 validations" do
     context "when setting an empty string" do

--- a/spec/support/product_helper.rb
+++ b/spec/support/product_helper.rb
@@ -7,6 +7,15 @@ RSpec.shared_context "with product form helpers", shared_context: :metadata do
     when "missing"     then "Not provided"
     end
   end
+
+  def affected_units_status_answer(affected_units_status)
+    case affected_units_status
+    when "exact"          then "Exact number known"
+    when "approx"         then "Approximate number known"
+    when "unknown"        then "Unknown"
+    when "not_relevant"   then "Not relevant"
+    end
+  end
 end
 
 RSpec.configure do |rspec|


### PR DESCRIPTION
https://trello.com/c/rjd0MTN9/203-5-add-how-many-units-are-affected-to-the-product-page

## Description
- Add :affected_units_status, :number_of_affected_units fields to products table.
- Add units affected question on the product form below the counterfeit question.
- Show answer on summary pages
- Add tests

##Screenshots
![Screenshot 2020-11-27 at 11 19 57](https://user-images.githubusercontent.com/13124899/100454109-2c468e00-30b4-11eb-92ed-b167a36b0535.png)
![Screenshot 2020-11-27 at 11 25 37](https://user-images.githubusercontent.com/13124899/100454111-2ea8e800-30b4-11eb-9307-5946f5c5bcf7.png)
![Screenshot 2020-11-27 at 11 31 03](https://user-images.githubusercontent.com/13124899/100454117-31a3d880-30b4-11eb-915b-01316ec7192e.png)
![Screenshot 2020-11-27 at 11 31 17](https://user-images.githubusercontent.com/13124899/100454120-336d9c00-30b4-11eb-8f7a-d097e3757f51.png)
![Screenshot 2020-11-27 at 13 08 07](https://user-images.githubusercontent.com/13124899/100454127-35cff600-30b4-11eb-8c38-e343d5edc1b3.png)

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
