### PR TITLE
Fix issue with page incorrectly loading when product does not have af…

### DIFF
--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -41,9 +41,9 @@ class ProductForm
 
   def self.from(product)
     new(product.serializable_hash(except: %i[updated_at])).tap do |product_form|
-      if product.affected_units_status.inquiry.approx?
+      if product.affected_units_status == Product.affected_units_statuses["approx"]
         product_form.approx_units = product.number_of_affected_units
-      elsif product.affected_units_status.inquiry.exact?
+      elsif product.affected_units_status == Product.affected_units_statuses["exact"]
         product_form.exact_units = product.number_of_affected_units
       end
     end


### PR DESCRIPTION
…fect_units_status

https://sentry.io/organizations/beis/issues/2072528830/?environment=staging&project=1329381&query=is%3Aunresolved

This error occurred due to products in prod not having `affected_units_status`.

## Description
- Compare values of product.affected_units_status directly, without using `inquiry`
- Test scenario

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
