### PR TITLE
Add risk validation

### DIFF
--- a/app/controllers/investigations/risk_validations_controller.rb
+++ b/app/controllers/investigations/risk_validations_controller.rb
@@ -16,7 +16,7 @@ module Investigations
                                           user: current_user)
 
       if result.changes_made
-        flash[:success] = "Case risk level validated"
+        flash[:success] = t("investigations.risk_validation.success_message")
       end
 
       redirect_to investigation_path(@investigation)
@@ -29,14 +29,6 @@ module Investigations
     end
 
   private
-
-    def set_success_flash_message(result)
-      return if result.change_action.blank?
-
-      flash[:success] = I18n.t(".success.#{result.change_action}",
-                               scope: "investigations.risk_level",
-                               level: result.updated_risk_level.downcase)
-    end
 
     def is_risk_validated
       params.dig :investigation, :is_risk_validated

--- a/app/controllers/investigations/risk_validations_controller.rb
+++ b/app/controllers/investigations/risk_validations_controller.rb
@@ -5,13 +5,18 @@ module Investigations
       @investigation = Investigation.find_by!(pretty_id: params.require(:investigation_pretty_id)).decorate
       #TODO authorize @investigation, :update?
 
-      @risk_validation_form = RiskValidationForm.new(params.require(:investigation).permit(:is_risk_validated))
+      @risk_validation_form = RiskValidationForm.new(is_risk_validated: is_risk_validated, risk_validated_by: current_user.team.name, risk_validated_at: Date.current)
+      
       return render :edit unless @risk_validation_form.valid?
 
-      result = ChangeRiskValidation.call!(investigation: @investigation, is_risk_validated: @risk_validation_form.is_risk_validated, user: current_user)
+      result = ChangeRiskValidation.call!(investigation: @investigation,
+                                          is_risk_validated: @risk_validation_form.is_risk_validated,
+                                          risk_validated_at: @risk_validation_form.risk_validated_at,
+                                          risk_validated_by: @risk_validation_form.risk_validated_by,
+                                          user: current_user)
 
       if result.changes_made
-        flash[:success] = "Updated all that stuff"
+        flash[:success] = "Case risk level validated"
       end
 
       redirect_to investigation_path(@investigation)
@@ -31,6 +36,10 @@ module Investigations
       flash[:success] = I18n.t(".success.#{result.change_action}",
                                scope: "investigations.risk_level",
                                level: result.updated_risk_level.downcase)
+    end
+
+    def is_risk_validated
+      params.dig :investigation, :is_risk_validated
     end
   end
 end

--- a/app/controllers/investigations/risk_validations_controller.rb
+++ b/app/controllers/investigations/risk_validations_controller.rb
@@ -1,0 +1,34 @@
+module Investigations
+  class RiskValidationsController < ApplicationController
+    include UrlHelper
+    def update
+      @investigation = Investigation.find_by!(pretty_id: params.require(:investigation_pretty_id)).decorate
+      authorize @investigation, :update?
+
+      byebug
+      #
+      # @risk_level_form = RiskLevelForm.new(params.require(:investigation).permit(:risk_level, :custom_risk_level))
+      # return render :show unless @risk_level_form.valid?
+      #
+      # result = ChangeCaseRiskLevel.call!(
+      #   @risk_level_form.attributes.merge(investigation: @investigation, user: current_user)
+      # )
+      # set_success_flash_message(result)
+      # redirect_to investigation_path(@investigation)
+    end
+
+    def edit
+      @breadcrumbs = build_back_link_to_case
+    end
+
+  private
+
+    def set_success_flash_message(result)
+      return if result.change_action.blank?
+
+      flash[:success] = I18n.t(".success.#{result.change_action}",
+                               scope: "investigations.risk_level",
+                               level: result.updated_risk_level.downcase)
+    end
+  end
+end

--- a/app/controllers/investigations/risk_validations_controller.rb
+++ b/app/controllers/investigations/risk_validations_controller.rb
@@ -3,21 +3,23 @@ module Investigations
     include UrlHelper
     def update
       @investigation = Investigation.find_by!(pretty_id: params.require(:investigation_pretty_id)).decorate
-      authorize @investigation, :update?
+      #TODO authorize @investigation, :update?
 
-      byebug
-      #
-      # @risk_level_form = RiskLevelForm.new(params.require(:investigation).permit(:risk_level, :custom_risk_level))
-      # return render :show unless @risk_level_form.valid?
-      #
-      # result = ChangeCaseRiskLevel.call!(
-      #   @risk_level_form.attributes.merge(investigation: @investigation, user: current_user)
-      # )
-      # set_success_flash_message(result)
-      # redirect_to investigation_path(@investigation)
+      @risk_validation_form = RiskValidationForm.new(params.require(:investigation).permit(:is_risk_validated))
+      return render :edit unless @risk_validation_form.valid?
+
+      result = ChangeRiskValidation.call!(investigation: @investigation, is_risk_validated: @risk_validation_form.is_risk_validated, user: current_user)
+
+      if result.changes_made
+        flash[:success] = "Updated all that stuff"
+      end
+
+      redirect_to investigation_path(@investigation)
     end
 
     def edit
+      @investigation = Investigation.find_by(pretty_id: params["investigation_pretty_id"])
+      @risk_validation_form = RiskValidationForm.new(is_risk_validated: nil)
       @breadcrumbs = build_back_link_to_case
     end
 

--- a/app/controllers/investigations/risk_validations_controller.rb
+++ b/app/controllers/investigations/risk_validations_controller.rb
@@ -3,10 +3,10 @@ module Investigations
     include UrlHelper
     def update
       @investigation = Investigation.find_by!(pretty_id: params.require(:investigation_pretty_id)).decorate
-      #TODO authorize @investigation, :update?
+      # TODO: authorize @investigation, :update?
 
       @risk_validation_form = RiskValidationForm.new(is_risk_validated: is_risk_validated, risk_validated_by: current_user.team.name, risk_validated_at: Date.current)
-      
+
       return render :edit unless @risk_validation_form.valid?
 
       result = ChangeRiskValidation.call!(investigation: @investigation,

--- a/app/forms/risk_validation_form.rb
+++ b/app/forms/risk_validation_form.rb
@@ -1,0 +1,6 @@
+class RiskValidationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :is_risk_validated, :boolean, default: nil
+end

--- a/app/forms/risk_validation_form.rb
+++ b/app/forms/risk_validation_form.rb
@@ -3,4 +3,8 @@ class RiskValidationForm
   include ActiveModel::Attributes
 
   attribute :is_risk_validated, :boolean, default: nil
+  attribute :risk_validated_by, :string
+  attribute :risk_validated_at, :datetime
+
+  validates :is_risk_validated, inclusion: { in: [true, false], message: "Select yes if you have validated the case risk level" }
 end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -307,7 +307,7 @@ module InvestigationsHelper
     end
 
     risk_validated_value = if investigation.risk_validated_by
-                             t("investigations.risk_validation.validated_status", risk_validated_by: investigation.risk_validated_by, risk_validated_at: investigation.risk_validated_at)
+                             t("investigations.risk_validation.validated_status", risk_validated_by: investigation.risk_validated_by, risk_validated_at: investigation.risk_validated_at.strftime("%d %B %Y"))
                            else
                              t("investigations.risk_validation.not_validated")
                            end

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -312,15 +312,10 @@ module InvestigationsHelper
                              t("investigations.risk_validation.not_validated")
                            end
 
-    risk_validated_link_text = investigation.risk_validated_by ? "" : t("investigations.risk_validation.validate")
-
     validated_row = {
       key: { text: t("investigations.risk_validation.page_title") },
       value: { text: risk_validated_value },
-      actions: { items: [
-        href: edit_investigation_risk_validations_path(investigation.pretty_id),
-        text: risk_validated_link_text
-      ] }
+      actions: risk_validation_actions(investigation, user)
     }
 
     rows = [risk_level_row, validated_row, risk_assessment_row]
@@ -340,6 +335,23 @@ module InvestigationsHelper
     end
 
     rows
+  end
+
+  def risk_validation_actions(investigation, user)
+    if @investigation.teams_with_access.include?(user.team)
+      {
+        items: [
+          href: edit_investigation_risk_validations_path(investigation.pretty_id),
+          text: risk_validated_link_text(investigation)
+        ]
+      }
+    else
+      {}
+    end
+  end
+
+  def risk_validated_link_text(investigation)
+    investigation.risk_validated_by ? "" : t("investigations.risk_validation.validate")
   end
 
   # This builds an array from an investigation which can then

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -320,7 +320,7 @@ module InvestigationsHelper
       actions: { items: [
         href: edit_investigation_risk_validations_path(investigation.pretty_id),
         text: risk_validated_link_text
-      ]}
+      ] }
     }
 
     rows = [risk_level_row, validated_row, risk_assessment_row]

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -306,12 +306,15 @@ module InvestigationsHelper
       }
     end
 
+    risk_validated_value = investigation.risk_validated_by ? "Validated by #{investigation.risk_validated_by} on #{investigation.risk_validated_at}" : "No"
+    risk_validated_link_text = investigation.risk_validated_by ? "" : "Validate"
+
     validated_row = {
       key: { text: 'Risk level validated' },
-      value: { text: 'LOL NO M8' },
+      value: { text: risk_validated_value },
       actions: { items: [
         href: edit_investigation_risk_validations_path(investigation.pretty_id),
-        text: "This is where the link will go"
+        text: risk_validated_link_text
       ]}
     }
 

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -306,7 +306,16 @@ module InvestigationsHelper
       }
     end
 
-    rows = [risk_level_row, risk_assessment_row]
+    validated_row = {
+      key: { text: 'Risk level validated' },
+      value: { text: 'LOL NO M8' },
+      actions: { items: [
+        href: '/',
+        text: "This is where the link will go"
+      ]}
+    }
+
+    rows = [risk_level_row, validated_row, risk_assessment_row]
 
     if investigation.hazard_type.present?
       rows << {

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -310,7 +310,7 @@ module InvestigationsHelper
       key: { text: 'Risk level validated' },
       value: { text: 'LOL NO M8' },
       actions: { items: [
-        href: '/',
+        href: edit_investigation_risk_validations_path(investigation.pretty_id),
         text: "This is where the link will go"
       ]}
     }

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -306,11 +306,16 @@ module InvestigationsHelper
       }
     end
 
-    risk_validated_value = investigation.risk_validated_by ? "Validated by #{investigation.risk_validated_by} on #{investigation.risk_validated_at}" : "No"
-    risk_validated_link_text = investigation.risk_validated_by ? "" : "Validate"
+    risk_validated_value = if investigation.risk_validated_by
+                             t("investigations.risk_validation.validated_status", risk_validated_by: investigation.risk_validated_by, risk_validated_at: investigation.risk_validated_at)
+                           else
+                             t("investigations.risk_validation.not_validated")
+                           end
+
+    risk_validated_link_text = investigation.risk_validated_by ? "" : t("investigations.risk_validation.validate")
 
     validated_row = {
-      key: { text: 'Risk level validated' },
+      key: { text: t("investigations.risk_validation.page_title") },
       value: { text: risk_validated_value },
       actions: { items: [
         href: edit_investigation_risk_validations_path(investigation.pretty_id),

--- a/app/models/audit_activity/investigation/update_risk_level_validation.rb
+++ b/app/models/audit_activity/investigation/update_risk_level_validation.rb
@@ -1,0 +1,17 @@
+class AuditActivity::Investigation::UpdateRiskLevelValidation < AuditActivity::Investigation::Base
+  def self.from(*)
+    raise "Deprecated - use UpdateRiskLevelValidation.call instead"
+  end
+
+  def self.build_metadata(investigation)
+    updated_values = investigation.previous_changes.slice(:risk_validated_at).merge(investigation.previous_changes.slice(:risk_validated_by))
+
+    {
+      updates: updated_values
+    }
+  end
+
+  def title(*)
+    I18n.t("investigations.risk_validation.activity.success")
+  end
+end

--- a/app/services/change_risk_validation.rb
+++ b/app/services/change_risk_validation.rb
@@ -1,0 +1,42 @@
+class ChangeRiskValidation
+  include Interactor
+  include EntitiesToNotify
+
+  delegate :investigation, :is_risk_validated, :user, to: :context
+
+  def call
+    context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
+    context.fail!(error: "No risk validation supplied") if is_risk_validated.nil?
+    context.fail!(error: "No user supplied") unless user.is_a?(User)
+
+    context.changes_made = false
+
+    investigation.assign_attributes(is_risk_validated: is_risk_validated)
+    return if investigation.changes.none?
+
+    ActiveRecord::Base.transaction do
+      investigation.save!
+      create_audit_activity_for_risk_validation_changed
+    end
+
+    context.changes_made = true
+  end
+
+private
+
+  def create_audit_activity_for_risk_validation_changed
+    metadata = activity_class.build_metadata(investigation)
+
+    activity_class.create!(
+      source: UserSource.new(user: user),
+      investigation: investigation,
+      title: nil,
+      body: nil,
+      metadata: metadata
+    )
+  end
+
+  def activity_class
+    AuditActivity::Investigation::UpdateCoronavirusStatus
+  end
+end

--- a/app/services/change_risk_validation.rb
+++ b/app/services/change_risk_validation.rb
@@ -10,7 +10,7 @@ class ChangeRiskValidation
 
     context.changes_made = false
 
-    update_risk_validation_attributes
+    assign_risk_validation_attributes
     return if investigation.changes.none?
 
     ActiveRecord::Base.transaction do
@@ -41,7 +41,7 @@ private
     AuditActivity::Investigation::UpdateRiskLevelValidation
   end
 
-  def update_risk_validation_attributes
+  def assign_risk_validation_attributes
     if is_risk_validated
       investigation.assign_attributes(risk_validated_at: risk_validated_at, risk_validated_by: risk_validated_by)
     else

--- a/app/services/change_risk_validation.rb
+++ b/app/services/change_risk_validation.rb
@@ -38,7 +38,7 @@ private
   end
 
   def activity_class
-    AuditActivity::Investigation::UpdateCoronavirusStatus
+    AuditActivity::Investigation::UpdateRiskLevelValidation
   end
 
   def update_risk_validation_attributes

--- a/app/views/investigations/activities/investigation/_update_risk_level_validation.html.erb
+++ b/app/views/investigations/activities/investigation/_update_risk_level_validation.html.erb
@@ -1,0 +1,1 @@
+<%= markdown simple_format(activity.body) %>

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -16,7 +16,6 @@
 
       <%= render "form_components/govuk_radios", form: form, key: :is_risk_validated,
                  fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
-                 hint: { text: t(".hint") },
                  items: [{ text: "Yes", value: "true", id: "risk_validationd" },
                          { text: "No", value: "false" }] %>
 

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -16,7 +16,7 @@
 
       <%= render "form_components/govuk_radios", form: form, key: :is_risk_validated,
                  fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
-                 items: [{ text: "Yes", value: "true", id: "risk_validation" },
+                 items: [{ text: "Yes", value: "true", id: "is_risk_validated" },
                          { text: "No", value: "false" }] %>
 
       <div class="govuk-form-group">

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -1,0 +1,5 @@
+<% content_for :after_header do %>
+  <%= render "breadcrumbs_navigation", breadcrumbs: @breadcrumbs %>
+<% end %>
+
+yoyoyoyoyoyoyo

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -1,5 +1,29 @@
-<% content_for :after_header do %>
-  <%= render "breadcrumbs_navigation", breadcrumbs: @breadcrumbs %>
+<% page_heading = "Have you validated the case risk level?" %>
+<% page_title page_heading, errors: @risk_validation_form.errors.any? %>
+<% content_for :back_link do %>
+  <%= govukBackLink(
+    text: "Back to #{@investigation.description.downcase}",
+    href: investigation_path(@investigation)
+  ) %>
 <% end %>
 
-yoyoyoyoyoyoyo
+<%= render "investigations/pages_top", investigation: @investigation %>
+
+<%= form_with scope: :investigation, model: @risk_validation_form, url: investigation_risk_validations_path(@investigation), method: :put, local: true do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= error_summary @risk_validation_form.errors %>
+
+      <%= render "form_components/govuk_radios", form: form, key: :is_risk_validated,
+                 fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
+                 hint: { text: t(".hint") },
+                 items: [{ text: "Yes", value: "true", id: "risk_validationd" },
+                         { text: "No", value: "false" }] %>
+
+      <div class="govuk-form-group">
+        <%= govukButton(text: t(".submit_button")) %>
+        <p><%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link--no-visited-state" %></p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -16,7 +16,7 @@
 
       <%= render "form_components/govuk_radios", form: form, key: :is_risk_validated,
                  fieldset: { legend: { text: page_heading, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
-                 items: [{ text: "Yes", value: "true", id: "risk_validationd" },
+                 items: [{ text: "Yes", value: "true", id: "risk_validation" },
                          { text: "No", value: "false" }] %>
 
       <div class="govuk-form-group">

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -2,7 +2,7 @@
 <% page_title page_heading, errors: @risk_validation_form.errors.any? %>
 <% content_for :back_link do %>
   <%= govukBackLink(
-    text: "Back to #{@investigation.description.downcase}",
+    text: "Back",
     href: investigation_path(@investigation)
   ) %>
 <% end %>

--- a/app/views/investigations/risk_validations/edit.html.erb
+++ b/app/views/investigations/risk_validations/edit.html.erb
@@ -20,7 +20,7 @@
                          { text: "No", value: "false" }] %>
 
       <div class="govuk-form-group">
-        <%= govukButton(text: t(".submit_button")) %>
+        <%= govukButton(text: t("Continue")) %>
         <p><%= link_to "Cancel", investigation_path(@investigation), class: "govuk-link--no-visited-state" %></p>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,8 @@ en:
       validated_status: "Validated by %{risk_validated_by} on %{risk_validated_at}"
       page_title: "Risk level validated"
       success_message: "Case risk level validated"
+      activity:
+        success: "Case risk level validated"
     risk_level:
       show:
         title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,12 @@ en:
         no_label: "No, this is business as usual"
         hint: "For example, cases relating to hand sanitiser or personal protective equipment (PPE)"
       success: "Coronavirus status updated on %{case_type}"
+    risk_validation:
+      validate: "Validate"
+      not_validated: "No"
+      validated_status: "Validated by %{risk_validated_by} on %{risk_validated_at}"
+      page_title: "Risk level validated"
+      success_message: "Case risk level validated"
     risk_level:
       show:
         title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
 
     resource :coronavirus_related, only: %i[update show], path: "edit-coronavirus-related", controller: "investigations/coronavirus_related"
     resource :risk_level, only: %i[update show], path: "edit-risk-level", controller: "investigations/risk_level"
+    resource :risk_validations, only: %i[edit update], path: "validate-risk-level", controller: "investigations/risk_validations"
     resources :images, controller: "investigations/images", only: %i[index], path: "images"
     resources :supporting_information, controller: "investigations/supporting_information", path: "supporting-information", as: :supporting_information, only: %i[index new create]
 

--- a/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
+++ b/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
@@ -1,6 +1,10 @@
 class AddIsRiskValidatedToInvestigation < ActiveRecord::Migration[6.0]
   def change
-    add_column :investigations, :risk_validated_by, :string
-    add_column :investigations, :risk_validated_at, :datetime
+    safety_assured do
+      change_table :investigations, bulk: true do |t|
+        t.string :risk_validated_by
+        t.datetime :risk_validated_at
+      end
+    end
   end
 end

--- a/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
+++ b/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
@@ -1,5 +1,6 @@
 class AddIsRiskValidatedToInvestigation < ActiveRecord::Migration[6.0]
   def change
-    add_column :investigations, :is_risk_validated, :boolean
+    add_column :investigations, :risk_validated_by, :string
+    add_column :investigations, :risk_validated_at, :datetime
   end
 end

--- a/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
+++ b/db/migrate/20201207173507_add_is_risk_validated_to_investigation.rb
@@ -1,0 +1,5 @@
+class AddIsRiskValidatedToInvestigation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :investigations, :is_risk_validated, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,13 +184,14 @@ ActiveRecord::Schema.define(version: 2020_12_07_173507) do
     t.string "hazard_type"
     t.boolean "is_closed", default: false
     t.boolean "is_private", default: false, null: false
-    t.boolean "is_risk_validated"
     t.text "non_compliant_reason"
     t.string "pretty_id", null: false
     t.string "product_category"
     t.string "received_type"
     t.enum "reported_reason", as: "reported_reasons"
     t.enum "risk_level", as: "risk_levels"
+    t.datetime "risk_validated_at"
+    t.string "risk_validated_by"
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.string "user_title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_171036) do
+ActiveRecord::Schema.define(version: 2020_12_07_173507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 2020_11_25_171036) do
     t.string "hazard_type"
     t.boolean "is_closed", default: false
     t.boolean "is_private", default: false, null: false
+    t.boolean "is_risk_validated"
     t.text "non_compliant_reason"
     t.string "pretty_id", null: false
     t.string "product_category"

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Validate risk level", :with_elasticsearch, :with_stubbed_mailer, 
       choose "Yes"
     end
 
-    click_on "Submit Button"
+    click_on "Continue"
 
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
     expect(page).to have_content("Case risk level validated")
@@ -41,7 +41,7 @@ RSpec.feature "Validate risk level", :with_elasticsearch, :with_stubbed_mailer, 
       choose "No"
     end
 
-    click_on "Submit Button"
+    click_on "Continue"
 
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
     expect(page).not_to have_content("Case risk level validated")

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.feature "Validate risk level", :with_elasticsearch, :with_stubbed_mailer, type: :feature do
+  let(:investigation) { create(:project, creator: user) }
+  let(:user) { create(:user, :activated) }
+  let(:other_user) { create(:user, :activated) }
+
+  scenario "validate the level" do
+    sign_in user
+    visit investigation_path(investigation)
+
+    click_link "Validate"
+
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/validate-risk-level/edit")
+
+    click_on "Submit Button"
+
+    expect(page).to have_content("Select yes if you have validated the case risk level")
+
+    within_fieldset("Have you validated the case risk level?") do
+      choose "Yes"
+    end
+
+    click_on "Submit Button"
+
+
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
+    expect(page).to have_content("Case risk level validated")
+    expect(page).to have_content("Validated by #{user.team.name} on #{investigation.risk_validated_at}")
+    expect(page).not_to have_link("Validate")
+  end
+
+  scenario "do not validate the level" do
+    sign_in user
+    visit investigation_path(investigation)
+
+    click_link "Validate"
+
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}/validate-risk-level/edit")
+
+    within_fieldset("Have you validated the case risk level?") do
+      choose "No"
+    end
+
+    click_on "Submit Button"
+
+    expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
+    expect(page).not_to have_content("Case risk level validated")
+    expect(page).not_to have_content("Validated by #{user.team.name} on #{investigation.risk_validated_at}")
+    expect(page).to have_link("Validate")
+  end
+end

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Validate risk level", :with_elasticsearch, :with_stubbed_mailer, 
 
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/validate-risk-level/edit")
 
-    click_on "Submit Button"
+    click_on "Continue"
 
     expect(page).to have_content("Select yes if you have validated the case risk level")
 

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "Validate risk level", :with_elasticsearch, :with_stubbed_mailer, 
 
     click_on "Submit Button"
 
-
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}")
     expect(page).to have_content("Case risk level validated")
     expect(page).to have_content("Validated by #{user.team.name} on #{investigation.risk_validated_at}")


### PR DESCRIPTION
Allow users to validate risk level of an investigation (Not edit it yet!) https://trello.com/c/DU95hA6H/842-add-validation-status

## Description
- Added new fields to investigation `"risk_validated_at", "risk_validated_by"`
- Add a new row in the risk section of show investigation page to represent risk validation
- Link to new page for user to confirm risk is validated
- Tests

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
