### PR TITLE
Fix randomly failing spec where OTP code is the same when reversed

### DIFF
--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -59,12 +59,15 @@ RSpec.feature "Signing in", :with_elasticsearch, :with_stubbed_mailer, :with_stu
   end
 
   scenario "user attempts to sign in with wrong two factor authentication code" do
+    # Ensure the OTP code is generated with a known value
+    allow(SecureRandom).to receive(:random_number).and_return(12_345)
+
     visit "/sign-in"
     fill_in_credentials
 
     expect(page).to have_css("h1", text: "Check your phone")
 
-    fill_in "Enter security code", with: otp_code.reverse
+    fill_in "Enter security code", with: "54321"
     click_on "Continue"
 
     expect(page).to have_css("h1", text: "Check your phone")


### PR DESCRIPTION
This fixes a surprisingly common randomly failing spec (and the only one I am aware of now).

When the user's OTP code is generated it can sometimes be the same value when reversed, e.g. `12321`. This test was therefore not reliable, so I have ensured the OTP code will always be a known value for this spec, in exactly the same way the subsequent spec does.