### PR TITLE
add validation for ean8 and upc-3

### DIFF
--- a/app/helpers/sanitization_helper.rb
+++ b/app/helpers/sanitization_helper.rb
@@ -31,8 +31,7 @@ module SanitizationHelper
         gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :ean8) unless gtin.valid?
       end
 
-      code = gtin.valid? ? gtin.gtin13 : nil
-      write_attribute(key, code)
+      write_attribute(key, gtin.gtin13) if gtin.valid?
     end
   end
 end

--- a/app/helpers/sanitization_helper.rb
+++ b/app/helpers/sanitization_helper.rb
@@ -20,13 +20,19 @@ module SanitizationHelper
   end
 
   def convert_gtin_to_13_digits(*keys)
+    gtin = nil
     keys.each do |key|
       gtin = Barkick::GTIN.new(attribute(key)&.strip)
-      write_attribute(key, gtin.gtin13) if gtin.valid?
     # 8 digit codes raise an ArgumentError, as a type (UPC-E or EAN-8) needs
     # to be specified in order to convert the code to a valid GTIN
     rescue ArgumentError
+      gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :ean8)
+    rescue ArgumentError
+      gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :upc_e)
+    rescue ArgumentError
       next
+    else
+      write_attribute(key, gtin.gtin13) if gtin.valid?
     end
   end
 end

--- a/app/helpers/sanitization_helper.rb
+++ b/app/helpers/sanitization_helper.rb
@@ -22,17 +22,17 @@ module SanitizationHelper
   def convert_gtin_to_13_digits(*keys)
     gtin = nil
     keys.each do |key|
-      gtin = Barkick::GTIN.new(attribute(key)&.strip)
-    # 8 digit codes raise an ArgumentError, as a type (UPC-E or EAN-8) needs
-    # to be specified in order to convert the code to a valid GTIN
-    rescue ArgumentError
-      gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :ean8)
-    rescue ArgumentError
-      gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :upc_e)
-    rescue ArgumentError
-      next
-    else
-      write_attribute(key, gtin.gtin13) if gtin.valid?
+      begin
+        gtin = Barkick::GTIN.new(attribute(key)&.strip)
+      # 8 digit codes raise an ArgumentError, as a type (UPC-E or EAN-8) needs
+      # to be specified in order to convert the code to a valid GTIN
+      rescue ArgumentError
+        gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :upc_e)
+        gtin = Barkick::GTIN.new(attribute(key)&.strip, type: :ean8) unless gtin.valid?
+      end
+
+      code = gtin.valid? ? gtin.gtin13 : nil
+      write_attribute(key, code)
     end
   end
 end

--- a/app/validators/gtin_validator.rb
+++ b/app/validators/gtin_validator.rb
@@ -9,11 +9,11 @@ class GtinValidator < ActiveModel::EachValidator
       # 8 digit codes raise an ArgumentError, as a type (UPC-E or EAN-8) needs
       # to be specified in order to convert the code to a valid GTIN
     rescue ArgumentError
-      return
+      gtin = Barkick::GTIN.new(record.public_send(attribute), type: :upc_e)
+      gtin = Barkick::GTIN.new(record.public_send(attribute), type: :ean8) unless gtin.valid?
     end
 
     unless gtin.valid?
-
       record.errors.add(attribute, :invalid) unless record.errors.of_kind?(attribute, :wrong_length)
     end
   end

--- a/app/validators/gtin_validator.rb
+++ b/app/validators/gtin_validator.rb
@@ -5,16 +5,22 @@ class GtinValidator < ActiveModel::EachValidator
     return if value.nil?
 
     begin
-      gtin = Barkick::GTIN.new(value)
+      gtin = gtin_for(value)
       # 8 digit codes raise an ArgumentError, as a type (UPC-E or EAN-8) needs
       # to be specified in order to convert the code to a valid GTIN
     rescue ArgumentError
-      gtin = Barkick::GTIN.new(record.public_send(attribute), type: :upc_e)
-      gtin = Barkick::GTIN.new(record.public_send(attribute), type: :ean8) unless gtin.valid?
+      gtin = gtin_for(record.public_send(attribute), type: :upc_e)
+      gtin = gtin_for(record.public_send(attribute), type: :ean8) unless gtin.valid?
     end
 
     unless gtin.valid?
       record.errors.add(attribute, :invalid) unless record.errors.of_kind?(attribute, :wrong_length)
     end
+  end
+
+private
+
+  def gtin_for(code, type: nil)
+    Barkick::GTIN.new(code, type: type)
   end
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -49,7 +49,7 @@
   form: form,
   classes: "app-!-max-width-one-half",
   label: { text: "Barcode number (GTIN, EAN or UPC)", classes: label_class },
-  hint: {text: "Normally 13 digits, although older products may have a 12 digit number"} %>
+  hint: {text: "Normally 13 digits, although older products may have an 8 or 12 digit number"} %>
 
 
 <%= render "form_components/govuk_input",

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe ProductForm do
     end
 
     context "when setting a 8 digit UPC-A code" do
-      before { form.gtin13 = "01234567" }
+      before { form.gtin13 = "40123455" }
 
       it "accepts a 8 digit code", :aggregate_failures do
         expect(form).to be_valid
-        expect(form.gtin13).to eq "01234567"
+        expect(form.gtin13).to eq "0000040123455"
       end
     end
 

--- a/spec/forms/product_form_spec.rb
+++ b/spec/forms/product_form_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe ProductForm do
       end
     end
 
+    context "when setting a 8 digit UPC-A code" do
+      before { form.gtin13 = "01234567" }
+
+      it "accepts a 8 digit code", :aggregate_failures do
+        expect(form).to be_valid
+        expect(form.gtin13).to eq "01234567"
+      end
+    end
+
     context "when setting a 12 digit UPC-A code" do
       before { form.gtin13 = "012345678912" }
 

--- a/spec/helpers/sanitization_helper_spec.rb
+++ b/spec/helpers/sanitization_helper_spec.rb
@@ -22,15 +22,15 @@ RSpec.describe SanitizationHelper do
     context "with a short code code" do
       let(:code) { "12" }
 
-      it "sucessfully set the gtin field" do
-        expect(model.gtin).to eq(nil)
+      it "does not convert the field" do
+        expect(model.gtin).to eq("12")
       end
     end
 
     context "with a nil code" do
       let(:code) { nil }
 
-      it "sucessfully set the gtin field" do
+      it "does not convert the field" do
         expect(model.gtin).to eq(nil)
       end
     end

--- a/spec/helpers/sanitization_helper_spec.rb
+++ b/spec/helpers/sanitization_helper_spec.rb
@@ -27,11 +27,18 @@ RSpec.describe SanitizationHelper do
       end
     end
 
+    context "when setting a UPC-E code" do
+      let(:code) { "425261" }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq("425261")
+      end
+    end
     context "when setting a 12 digit UPC-A code" do
       let(:code) { "012345678912" }
 
       it "sucessfully set the gtin field" do
-        expect(model.gtin).to eq("`0012345678912")
+        expect(model.gtin).to eq("0012345678912")
       end
     end
 
@@ -40,6 +47,14 @@ RSpec.describe SanitizationHelper do
 
       it "sucessfully set the gtin field" do
         expect(model.gtin).to eq("0012345678912")
+      end
+    end
+
+    context "when setting a 14 digit GTIN number" do
+      let(:code) { "00016000275263" }
+
+      it "gets converted to a 13 digit code on validation", :aggregate_failures do
+        expect(model.gtin).to eq("0016000275263")
       end
     end
   end

--- a/spec/helpers/sanitization_helper_spec.rb
+++ b/spec/helpers/sanitization_helper_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SanitizationHelper do
+  let(:model_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include SanitizationHelper
+
+      attribute :gtin
+
+      def initialize(*args)
+        super
+        convert_gtin_to_13_digits(:gtin)
+      end
+    end
+  end
+
+  describe "#convert_gtin_to_13_digits" do
+    subject(:model) { model_class.new(gtin: code) }
+
+    context "with a valid ean13 code" do
+      let(:code) { "01234567" }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq(code)
+      end
+    end
+
+    context "when setting a 12 digit UPC-A code" do
+      let(:code) { "012345678912" }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq("`0012345678912")
+      end
+    end
+
+    context "when setting a 13 digit EAN code with a trailing space" do
+      let(:code) { "0012345678912 " }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq("0012345678912")
+      end
+    end
+  end
+end

--- a/spec/helpers/sanitization_helper_spec.rb
+++ b/spec/helpers/sanitization_helper_spec.rb
@@ -19,21 +19,38 @@ RSpec.describe SanitizationHelper do
   describe "#convert_gtin_to_13_digits" do
     subject(:model) { model_class.new(gtin: code) }
 
-    context "with a valid ean13 code" do
-      let(:code) { "01234567" }
+    context "with a short code code" do
+      let(:code) { "12" }
 
       it "sucessfully set the gtin field" do
-        expect(model.gtin).to eq(code)
+        expect(model.gtin).to eq(nil)
+      end
+    end
+
+    context "with a nil code" do
+      let(:code) { nil }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq(nil)
+      end
+    end
+
+    context "with a valid ean13 code" do
+      let(:code) { "978020137962" }
+
+      it "sucessfully set the gtin field" do
+        expect(model.gtin).to eq("0978020137962")
       end
     end
 
     context "when setting a UPC-E code" do
-      let(:code) { "425261" }
+      let(:code) { "02345673" }
 
       it "sucessfully set the gtin field" do
-        expect(model.gtin).to eq("425261")
+        expect(model.gtin).to eq("0023456000073")
       end
     end
+
     context "when setting a 12 digit UPC-A code" do
       let(:code) { "012345678912" }
 

--- a/spec/validators/gtin_validator_spec.rb
+++ b/spec/validators/gtin_validator_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe GtinValidator do
     }.new
   end
 
+  context "with a valid 8 digits UPC-E" do
+    before { record.gtin = "02345673" }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "with a valid 8 digits EAN8" do
+    before { record.gtin = "40123455" }
+
+    it { is_expected.to be_valid }
+  end
+
   context "with a valid 12 digit UPC-A number" do
     before { record.gtin = "012345678912" }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Allow EAN-A and UPC-E, 8 or  12 digits barcodes to be validated and then converted to gtin13 when saved.

## Checklist:
- [X] Have you documented your changes in the pull request description?
- [ ] Has acceptance criteria been tested by a peer?

