### PR TITLE
Add risk validation field to export

### DIFF
--- a/app/views/investigations/index.xlsx.axlsx
+++ b/app/views/investigations/index.xlsx.axlsx
@@ -4,7 +4,7 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
   sheet_investigations.add_row %w[ID Status Title Type Description Product_Category Hazard_Type Coronavirus_Related
                                   Risk_Level Case_Owner_Team Case_Owner_User Source Complainant_Type
                                   Products Businesses Activities Correspondences Corrective_Actions Tests
-                                  Date_Created Last_Updated Date_Closed]
+                                  Date_Created Last_Updated Date_Closed Date_Validated]
   @investigations.each do |investigation|
     complainant = investigation.complainant
     sheet_investigations.add_row [
@@ -29,7 +29,8 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
       @test_counts[investigation.id] || 0,
       investigation.created_at,
       investigation.updated_at,
-      investigation.date_closed
+      investigation.date_closed,
+      investigation.risk_validated_at
     ], types: :text
   end
 end

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -151,6 +151,19 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
         end
       end
 
+      it "exports risk_validated_at" do
+        investigation = create(:allegation, risk_validated_at: Date.current)
+
+        Investigation.import refresh: true, force: true
+
+        get investigations_path format: :xlsx
+
+        aggregate_failures do
+          expect(exported_data.cell(1, 23)).to eq "Date_Validated"
+          expect(exported_data.cell(2, 23)).to eq investigation.risk_validated_at.strftime("%Y-%m-%d %H:%M:%S %z")
+        end
+      end
+
       context "when investigation is open" do
         it "date_closed column is empty" do
           create(:allegation)


### PR DESCRIPTION
https://trello.com/c/d2PJaeag/844-export-validation-status

## Description
Add the date_validated field to the csv export to show when the investigation had it's risk level validated.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
