### PR TITLE
Fix randomly failing specs related to product markings

### DIFF
--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expected_markings = case attributes[:has_markings]
                         when "markings_yes" then attributes[:markings].join(", ")
                         when "markings_no" then "None"
-                        when "markings_unknown" then "Not provided"
+                        when "markings_unknown" then "Unknown"
                         end
 
     expect(page).to have_summary_item(key: "Product brand",             value: attributes[:brand])

--- a/spec/features/create_allegation_as_opss_user_spec.rb
+++ b/spec/features/create_allegation_as_opss_user_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature "Creating cases", :with_stubbed_elasticsearch, :with_stubbed_antiv
     expected_markings = case has_markings
                         when "Yes" then markings.join(", ")
                         when "No" then "None"
-                        when "Unknown" then "Not provided"
+                        when "Unknown" then "Unknown"
                         end
 
     expect(page.find("dt", text: "Product name")).to have_sibling("dd", text: name)

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expected_markings = case new_has_markings
                         when "markings_yes" then new_markings.join(", ")
                         when "markings_no" then "None"
-                        when "markings_unknown" then "Not provided"
+                        when "markings_unknown" then "Unknown"
                         end
 
     expect(page).to have_summary_item(key: "Category", value: new_product_category)
@@ -215,7 +215,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expected_markings = case new_has_markings
                         when "markings_yes" then new_markings.join(", ")
                         when "markings_no" then "None"
-                        when "markings_unknown" then "Not provided"
+                        when "markings_unknown" then "Unknown"
                         end
 
     expect(page).to have_summary_item(key: "Category", value: new_product_category)

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -398,7 +398,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     expected_markings = case info[:has_markings]
                         when "markings_yes" then info[:markings].join(", ")
                         when "markings_no" then "None"
-                        when "markings_unknown" then "Not provided"
+                        when "markings_unknown" then "Unknown"
                         end
 
     expected_authenticity = info[:authenticity] == "Yes" ? "Counterfeit" : "Genuine"


### PR DESCRIPTION
Fixes randomly failing specs introduced by a last minute change in #1081.

I did not catch these before as the specs data is randomised.