### PR TITLE
Bump CloudFoundry Ruby buildpack to v1.8.28

### DIFF
--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.27
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.28
   path: .
   stack: cflinuxfs3
   routes:

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.27
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.28
   path: .
   stack: cflinuxfs3
   routes:


### PR DESCRIPTION
This is a minor update which only bumps the RubyGems version to 3.2.1.

See https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.28 for full details.

Run `gem update --system '3.2.1'` locally to reproduce this setup.