### PR TITLE
Team roles

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,5 @@
+class Role < ApplicationRecord
+  belongs_to :entity, polymorphic: true
+  validates :name, presence: true
+  validates :name, uniqueness: { scope: :entity }
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,6 +10,8 @@ class Team < ApplicationRecord
 
   has_many :owner_collaborations, class_name: "Collaboration::Access::OwnerTeam", as: :collaborator
 
+  has_many :roles, dependent: :destroy, as: :entity
+
   validates :name, presence: true
 
   def display_name(*)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,10 @@ class User < ApplicationRecord
     has_role? :risk_level_validator
   end
 
+  def has_role?(role)
+    roles.exists?(name: role) || team.roles.exists?(name: role)
+  end
+
   def has_completed_registration?
     encrypted_password.present? && name.present? && mobile_number.present? && mobile_number_verified
   end
@@ -169,10 +173,6 @@ private
 
   def current_user?
     User.current&.id == id
-  end
-
-  def has_role?(role)
-    roles.exists?(name: role)
   end
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :investigations, through: :owner_user_collaborations, dependent: :nullify, as: :user
   has_many :activities, through: :investigations
   has_many :user_sources, dependent: :destroy
-  has_many :user_roles, dependent: :destroy
+  has_many :roles, dependent: :destroy, as: :entity
   has_many :collaborations, dependent: :destroy, as: :collaborator
 
   belongs_to :team
@@ -172,7 +172,7 @@ private
   end
 
   def has_role?(role)
-    user_roles.exists?(name: role)
+    roles.exists?(name: role)
   end
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   end
 
   def is_opss?
-    has_role? :opss_user
+    has_role? :opss
   end
 
   def is_team_admin?

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,5 +1,0 @@
-class UserRole < ApplicationRecord
-  belongs_to :user
-  validates :name, presence: true
-  validates :name, uniqueness: { scope: :user }
-end

--- a/app/services/create_organisation_with_team_and_admin_user.rb
+++ b/app/services/create_organisation_with_team_and_admin_user.rb
@@ -16,7 +16,7 @@ class CreateOrganisationWithTeamAndAdminUser
         team: context.team
       )
 
-      context.user.user_roles.create!(name: "team_admin")
+      context.user.roles.create!(name: "team_admin")
 
       SendUserInvitationJob.perform_later(context.user.id)
     end

--- a/app/services/invite_user_to_team.rb
+++ b/app/services/invite_user_to_team.rb
@@ -27,7 +27,7 @@ private
       team: team
     )
 
-    user.user_roles.create!(name: "opss_user") if inviting_user&.is_opss?
+    user.roles.create!(name: "opss_user") if inviting_user&.is_opss?
     user
   end
 

--- a/app/services/invite_user_to_team.rb
+++ b/app/services/invite_user_to_team.rb
@@ -20,15 +20,12 @@ private
   end
 
   def create_user
-    user = User.create!(
+    User.create!(
       email: email,
       organisation: team.organisation,
       skip_password_validation: true,
       team: team
     )
-
-    user.roles.create!(name: "opss_user") if inviting_user&.is_opss?
-    user
   end
 
   def send_invite

--- a/db/migrate/20201230115058_change_user_roles_to_roles.rb
+++ b/db/migrate/20201230115058_change_user_roles_to_roles.rb
@@ -6,7 +6,7 @@ class ChangeUserRolesToRoles < ActiveRecord::Migration[6.0]
       rename_column :roles, :user_id, :entity_id
       add_column :roles, :entity_type, :string, after: :entity_id, null: false, default: "User"
 
-      change_column_default :roles, :entity_type, nil
+      change_column_default :roles, :entity_type, from: "User", to: nil
     end
   end
 end

--- a/db/migrate/20201230115058_change_user_roles_to_roles.rb
+++ b/db/migrate/20201230115058_change_user_roles_to_roles.rb
@@ -1,0 +1,12 @@
+class ChangeUserRolesToRoles < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      rename_table :user_roles, :roles
+
+      rename_column :roles, :user_id, :entity_id
+      add_column :roles, :entity_type, :string, after: :entity_id, null: false, default: "User"
+
+      change_column_default :roles, :entity_type, nil
+    end
+  end
+end

--- a/db/migrate/20201230115058_change_user_roles_to_roles.rb
+++ b/db/migrate/20201230115058_change_user_roles_to_roles.rb
@@ -7,6 +7,8 @@ class ChangeUserRolesToRoles < ActiveRecord::Migration[6.0]
       add_column :roles, :entity_type, :string, after: :entity_id, null: false, default: "User"
 
       change_column_default :roles, :entity_type, from: "User", to: nil
+
+      add_index :roles, %i[entity_id entity_type]
     end
   end
 end

--- a/db/migrate/20201230134737_clean_up_roles.rb
+++ b/db/migrate/20201230134737_clean_up_roles.rb
@@ -1,0 +1,31 @@
+class CleanUpRoles < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up do
+          Role.where(name: "user").delete_all # Redundant legacy from Keycloak
+
+          team_roles = Role.where(name: ["opss_user", "risk_level_validator"], entity_type: "User")
+
+          team_roles.each do |role|
+            new_role_name = role.name == "opss_user" ? "opss" : role.name
+            role.entity.team.roles.create(name: new_role_name) # Fail silently when not unique
+          end
+
+          team_roles.delete_all
+        end
+
+        dir.down do
+          team_roles = Role.where(name: ["opss", "risk_level_validator"], entity_type: "Team")
+
+          team_roles.each do |role|
+            new_role_name = role.name == "opss" ? "opss_user" : role.name
+            role.entity.users.each { |user| user.roles.create(name: new_role_name) } # Fail silently when not unique
+          end
+
+          team_roles.delete_all
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20201230134737_clean_up_roles.rb
+++ b/db/migrate/20201230134737_clean_up_roles.rb
@@ -2,10 +2,11 @@ class CleanUpRoles < ActiveRecord::Migration[6.0]
   def change
     safety_assured do
       reversible do |dir|
+        # rubocop:disable Rails/SaveBang
         dir.up do
           Role.where(name: "user").delete_all # Redundant legacy from Keycloak
 
-          team_roles = Role.where(name: ["opss_user", "risk_level_validator"], entity_type: "User")
+          team_roles = Role.where(name: %w[opss_user risk_level_validator], entity_type: "User")
 
           team_roles.each do |role|
             new_role_name = role.name == "opss_user" ? "opss" : role.name
@@ -16,7 +17,7 @@ class CleanUpRoles < ActiveRecord::Migration[6.0]
         end
 
         dir.down do
-          team_roles = Role.where(name: ["opss", "risk_level_validator"], entity_type: "Team")
+          team_roles = Role.where(name: %w[opss risk_level_validator], entity_type: "Team")
 
           team_roles.each do |role|
             new_role_name = role.name == "opss" ? "opss_user" : role.name
@@ -25,6 +26,7 @@ class CleanUpRoles < ActiveRecord::Migration[6.0]
 
           team_roles.delete_all
         end
+        # rubocop:enable Rails/SaveBang
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_30_115058) do
+ActiveRecord::Schema.define(version: 2020_12_30_134737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -286,6 +286,7 @@ ActiveRecord::Schema.define(version: 2020_12_30_134737) do
     t.string "entity_type", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index ["entity_id", "entity_type"], name: "index_roles_on_entity_id_and_entity_type"
     t.index ["entity_id", "name"], name: "index_roles_on_entity_id_and_name", unique: true
     t.index ["entity_id"], name: "index_roles_on_entity_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_113650) do
+ActiveRecord::Schema.define(version: 2020_12_30_115058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -280,6 +280,16 @@ ActiveRecord::Schema.define(version: 2020_12_29_113650) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "entity_id"
+    t.string "entity_type", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id", "name"], name: "index_roles_on_entity_id_and_name", unique: true
+    t.index ["entity_id"], name: "index_roles_on_entity_id"
+  end
+
   create_table "sources", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
@@ -317,15 +327,6 @@ ActiveRecord::Schema.define(version: 2020_12_29_113650) do
     t.datetime "updated_at", null: false
     t.index ["investigation_id"], name: "index_tests_on_investigation_id"
     t.index ["product_id"], name: "index_tests_on_product_id"
-  end
-
-  create_table "user_roles", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "user_id"
-    t.index ["user_id", "name"], name: "index_user_roles_on_user_id_and_name", unique: true
-    t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -521,7 +521,7 @@ if run_seeds
     Team.create!(name: "OPSS Incident Management",  team_recipient_email: nil, "organisation": organisation)
     Team.create!(name: "OPSS Testing", team_recipient_email: nil, "organisation": organisation)
 
-    user1 = User.create!(
+    User.create!(
       name: "Test User",
       email: "user@example.com",
       password: "testpassword",
@@ -554,7 +554,6 @@ if run_seeds
       team: ts_team,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
-
 
     organisation = Organisation.create!(name: "Southampton Council")
     Team.create!(name: "Southampton Council", team_recipient_email: nil, "organisation": organisation)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -498,6 +498,7 @@ if run_seeds
           # the change from user_roles to roles is reviewed. This line can be
           # removed once the seed JSON structure is updated safely
           user_attributes[:roles_attributes] = user_attributes[:user_roles_attributes]
+          user_attributes.delete(:user_roles_attributes)
 
           user_attributes
         end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ if run_seeds
   )
 
   %i[opss_user user].each do |role|
-    UserRole.find_or_create_by!(user: user, name: role)
+    Role.find_or_create_by!(entity: user, name: role)
   end
 
   # First investigation
@@ -486,7 +486,7 @@ if run_seeds
     # }
 
     Team.accepts_nested_attributes_for :users
-    User.accepts_nested_attributes_for :user_roles
+    User.accepts_nested_attributes_for :roles
 
     organisations.each do |organisation_attributes|
       organisation_attributes.deep_symbolize_keys!
@@ -496,6 +496,12 @@ if run_seeds
       teams_attributes.map do |team_attributes|
         (team_attributes[:users_attributes] || []).map! do |user_attributes|
           user_attributes[:organisation] = organisation
+
+          # Temporary workaround to prevent other review apps breaking while
+          # the change from user_roles to roles is reviewed. This line can be
+          # removed once the seed JSON structure is updated safely
+          user_attributes[:roles_attributes] = user_attributes[:user_roles_attributes]
+
           user_attributes
         end
         organisation.teams.create! team_attributes
@@ -545,10 +551,10 @@ if run_seeds
     )
 
     %i[opss_user user].each do |role|
-      UserRole.create!(user: user1, name: role)
+      Role.create!(entity: user1, name: role)
     end
     %i[team_admin opss_user user].each do |role|
-      UserRole.create!(user: user2, name: role)
+      Role.create!(entity: user2, name: role)
     end
 
     organisation = Organisation.create!(name: "Southampton Council")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,7 @@ if run_seeds
 
   organisation = Organisation.create!(name: "Seed Organisation")
   team = Team.create!(name: "Seed Team", team_recipient_email: "seed@example.com", "organisation": organisation)
+  team.roles.create!(name: "opss")
 
   user = User.find_by(email: "seed_user@example.com") || User.create!(
     name: "Seed User",
@@ -31,10 +32,6 @@ if run_seeds
     organisation: organisation,
     team: team,
   )
-
-  %i[opss_user user].each do |role|
-    Role.find_or_create_by!(entity: user, name: role)
-  end
 
   # First investigation
   investigation = Investigation::Allegation.new(
@@ -510,8 +507,13 @@ if run_seeds
   else
     organisation = Organisation.create!(name: "Office for Product Safety and Standards")
     trading_standards = Organisation.create!(name: "Trading Standards")
+
     enforcement = Team.create!(name: "OPSS Enforcement", team_recipient_email: "enforcement@example.com", "organisation": organisation)
+    enforcement.roles.create!(name: "opss")
+
     operational_support = Team.create!(name: "OPSS Operational support unit", team_recipient_email: nil, "organisation": organisation)
+    operational_support.roles.create!(name: "opss")
+
     ts_team = Team.create!(name: "TS team", team_recipient_email: nil, "organisation": trading_standards)
 
     Team.create!(name: "OPSS Science and Tech", team_recipient_email: nil, "organisation": organisation)
@@ -529,6 +531,7 @@ if run_seeds
       team: enforcement,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
+
     user2 = User.create!(
       name: "Team Admin",
       email: "admin@example.com",
@@ -539,6 +542,8 @@ if run_seeds
       team: operational_support,
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
+    user2.roles.create!(name: "team_admin")
+
     User.create!(
       name: "TS User",
       email: "ts_user@example.com",
@@ -550,12 +555,6 @@ if run_seeds
       mobile_number: ENV.fetch("TWO_FACTOR_AUTH_MOBILE_NUMBER")
     )
 
-    %i[opss_user user].each do |role|
-      Role.create!(entity: user1, name: role)
-    end
-    %i[team_admin opss_user user].each do |role|
-      Role.create!(entity: user2, name: role)
-    end
 
     organisation = Organisation.create!(name: "Southampton Council")
     Team.create!(name: "Southampton Council", team_recipient_email: nil, "organisation": organisation)

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -30,7 +30,7 @@ applications:
     - psd-sidekiq-env
     - psd-two-factor-auth-env
     - antivirus-auth-env
-    - psd-seeds
+    - psd-seeds-v2
   processes:
     - type: web
       env:

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,4 +1,4 @@
 FactoryBot.define do
-  factory :user_role do
+  factory :role do
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -4,8 +4,18 @@ FactoryBot.define do
     team_recipient_email { "#{name.downcase.gsub(/\s/, '.')}@example.com" }
     organisation
 
+    transient do
+      roles { [] }
+    end
+
     trait :deleted do
       deleted_at { Time.zone.now }
+    end
+
+    after(:create) do |team, evaluator|
+      evaluator.roles.each do |role|
+        create(:role, name: role, entity: team)
+      end
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
 
     after(:create) do |user, evaluator|
       evaluator.roles.each do |role|
-        create(:user_role, name: role, user: user)
+        create(:role, name: role, entity: user)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
 
     transient do
       roles { [] }
+      team_roles { [] }
     end
 
     trait :activated do
@@ -70,13 +71,17 @@ FactoryBot.define do
 
     trait :opss_user do
       transient do
-        roles { %i[opss_user] }
+        team_roles { %i[opss] }
       end
     end
 
     after(:create) do |user, evaluator|
       evaluator.roles.each do |role|
         create(:role, name: role, entity: user)
+      end
+
+      evaluator.team_roles.each do |role|
+        create(:role, name: role, entity: user.team)
       end
     end
   end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Admin Panel", :with_elasticsearch, :with_stubbed_mailer, :with_st
       visit "/admin"
       expect(page).to have_css("h2", text: "Your cases")
 
-      user.user_roles.create!(name: "superuser")
+      user.roles.create!(name: "superuser")
 
       visit "/admin"
       expect(page).to have_css("h1", text: "Site Administration")

--- a/spec/features/validate_risk_level_spec.rb
+++ b/spec/features/validate_risk_level_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Validate risk level", :with_stubbed_elasticsearch, :with_stubbed_
         collaboration_class: Collaboration::Access::Edit
       )
 
-      user.user_roles.create!(name: "risk_level_validator")
+      user.roles.create!(name: "risk_level_validator")
       sign_in user
       delivered_emails.clear
     end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
-RSpec.describe UserRole do
+RSpec.describe Role do
   let(:user) { create(:user) }
 
   describe "uniqueness validation" do
     let(:role_name) { "test" }
 
     it "does not allow more than one role of the same name per user" do
-      described_class.create!(user: user, name: role_name)
-      expect { described_class.create!(user: user, name: role_name) }.to raise_error(ActiveRecord::RecordInvalid)
+      described_class.create!(entity: user, name: role_name)
+      expect { described_class.create!(entity: user, name: role_name) }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -240,24 +240,23 @@ RSpec.describe User do
   end
 
   describe "#has_role?" do
-    subject(:result) { user.has_role?(:test) }
+    subject(:user) { create(:user, team: team, organisation: team.organisation, roles: user_roles) }
 
     let(:team) { create(:team, roles: team_roles) }
-    let(:user) { create(:user, team: team, organisation: team.organisation, roles: user_roles) }
     let(:team_roles) { [] }
 
     context "when the user has no roles" do
       let(:user_roles) { [] }
 
       it "returns false" do
-        expect(result).to be false
+        expect(user).not_to have_role("test")
       end
 
       context "when the team roles include the specified role" do
         let(:team_roles) { %w[test] }
 
         it "returns true" do
-          expect(result).to be true
+          expect(user).to have_role("test")
         end
       end
 
@@ -265,7 +264,7 @@ RSpec.describe User do
         let(:team_roles) { %w[another_role] }
 
         it "returns false" do
-          expect(result).to be false
+          expect(user).not_to have_role("test")
         end
       end
     end
@@ -275,7 +274,7 @@ RSpec.describe User do
         let(:user_roles) { %w[test] }
 
         it "returns true" do
-          expect(result).to be true
+          expect(user).to have_role("test")
         end
       end
 
@@ -283,14 +282,14 @@ RSpec.describe User do
         let(:user_roles) { %w[another_role] }
 
         it "returns false" do
-          expect(result).to be false
+          expect(user).not_to have_role("test")
         end
 
         context "when the team roles include the specified role" do
           let(:team_roles) { %w[test] }
 
           it "returns true" do
-            expect(result).to be true
+            expect(user).to have_role("test")
           end
         end
 
@@ -298,7 +297,7 @@ RSpec.describe User do
           let(:team_roles) { %w[another_role] }
 
           it "returns false" do
-            expect(result).to be false
+            expect(user).not_to have_role("test")
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -240,11 +240,11 @@ RSpec.describe User do
   end
 
   describe "#has_role?" do
+    subject(:result) { user.has_role?(:test) }
+
     let(:team) { create(:team, roles: team_roles) }
     let(:user) { create(:user, team: team, organisation: team.organisation, roles: user_roles) }
     let(:team_roles) { [] }
-
-    subject(:result) { user.has_role?(:test) }
 
     context "when the user has no roles" do
       let(:user_roles) { [] }
@@ -254,7 +254,7 @@ RSpec.describe User do
       end
 
       context "when the team roles include the specified role" do
-        let(:team_roles) { ["test"] }
+        let(:team_roles) { %w[test] }
 
         it "returns true" do
           expect(result).to be true
@@ -262,7 +262,7 @@ RSpec.describe User do
       end
 
       context "when the team roles do not include the specified role" do
-        let(:team_roles) { ["another_role"] }
+        let(:team_roles) { %w[another_role] }
 
         it "returns false" do
           expect(result).to be false
@@ -272,7 +272,7 @@ RSpec.describe User do
 
     context "when the user has roles" do
       context "when the user roles include the specified role" do
-        let(:user_roles) { ["test"] }
+        let(:user_roles) { %w[test] }
 
         it "returns true" do
           expect(result).to be true
@@ -280,14 +280,14 @@ RSpec.describe User do
       end
 
       context "when the user roles do not include the specified role" do
-        let(:user_roles) { ["another_role"] }
+        let(:user_roles) { %w[another_role] }
 
         it "returns false" do
           expect(result).to be false
         end
 
         context "when the team roles include the specified role" do
-          let(:team_roles) { ["test"] }
+          let(:team_roles) { %w[test] }
 
           it "returns true" do
             expect(result).to be true
@@ -295,7 +295,7 @@ RSpec.describe User do
         end
 
         context "when the team roles do not include the specified role" do
-          let(:team_roles) { ["another_role"] }
+          let(:team_roles) { %w[another_role] }
 
           it "returns false" do
             expect(result).to be false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -238,4 +238,70 @@ RSpec.describe User do
       expect(user).not_to be_mobile_number_change_allowed
     end
   end
+
+  describe "#has_role?" do
+    let(:team) { create(:team, roles: team_roles) }
+    let(:user) { create(:user, team: team, organisation: team.organisation, roles: user_roles) }
+    let(:team_roles) { [] }
+
+    subject(:result) { user.has_role?(:test) }
+
+    context "when the user has no roles" do
+      let(:user_roles) { [] }
+
+      it "returns false" do
+        expect(result).to be false
+      end
+
+      context "when the team roles include the specified role" do
+        let(:team_roles) { ["test"] }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when the team roles do not include the specified role" do
+        let(:team_roles) { ["another_role"] }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+
+    context "when the user has roles" do
+      context "when the user roles include the specified role" do
+        let(:user_roles) { ["test"] }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when the user roles do not include the specified role" do
+        let(:user_roles) { ["another_role"] }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+
+        context "when the team roles include the specified role" do
+          let(:team_roles) { ["test"] }
+
+          it "returns true" do
+            expect(result).to be true
+          end
+        end
+
+        context "when the team roles do not include the specified role" do
+          let(:team_roles) { ["another_role"] }
+
+          it "returns false" do
+            expect(result).to be false
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/investigations/validate_risk_level_spec.rb
+++ b/spec/requests/investigations/validate_risk_level_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Validate risk level", type: :request, with_stubbed_mailer: true,
 
   context "when the user has the `risk_level_validator` role", :with_errors_rendered do
     before do
-      other_user.user_roles.create!(name: "risk_level_validator")
+      other_user.roles.create!(name: "risk_level_validator")
       sign_in other_user
       put investigation_risk_validations_url(investigation.pretty_id), params: params
     end

--- a/spec/services/invite_user_to_team_spec.rb
+++ b/spec/services/invite_user_to_team_spec.rb
@@ -50,15 +50,6 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_elasticsear
             expect(inviting_user_id).to inviting_user.id
           end
         end
-
-        context "when the inviting_user is an OPSS user" do
-          let(:inviting_user) { create(:user, :activated, :opss_user, team: team) }
-
-          it "gives the invited user the opss_user role" do
-            result
-            expect(result.user).to be_is_opss
-          end
-        end
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/mdnO2nMb/860-5-team-roles

## Description
Allows users to inherit the roles of their team.

This renders the `opss_user` role and the juggling of it for new users redundant, as we can set the role on the OPSS teams instead, and users will inherit this automatically. I have added a migration for this.

I have also migrated the `risk_level_validator` role to the relevant team. Currently we only have one team with this role, and all of their users have this role.

### Deployment

To be deployed out of hours due to changes to the user roles data and schema which might temporarily affect active users for a short time during deployment.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)
