### PR TITLE
Update bundler version in Gemfile.lock to reflect new CloudFoundry Ruby buildpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,4 +664,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.1


### PR DESCRIPTION
Bumps the version number following RubyGems and Bundler version updates in https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/1099