### PR TITLE
Customs codes new

### DIFF
--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -22,7 +22,8 @@ class ProductDecorator < ApplicationDecorator
       { key: { text: "Other product identifiers" }, value: { text: product_code } },
       { key: { text: "Webpage" }, value: { text: object.webpage } },
       { key: { text: "Description" }, value: { text: description } },
-      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } }
+      { key: { text: "Country of origin" }, value: { text: country_from_code(country_of_origin) } },
+      { key: { text: "Customs code" }, value: { text: object.customs_code } }
     ]
     rows.compact!
     h.render "components/govuk_summary_list", rows: rows

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -22,6 +22,7 @@ class ProductForm
   attribute :number_of_affected_units
   attribute :has_markings
   attribute :markings
+  attribute :customs_code
 
   attr_accessor :approx_units
   attr_accessor :exact_units

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -6,7 +6,7 @@ module ProductsHelper
   # Never trust parameters from the scary internet, only allow the white list through.
   def product_params
     params.require(:product).permit(
-      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :when_placed_on_market, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units, :has_markings, markings: []
+      :brand, :name, :subcategory, :category, :product_code, :webpage, :description, :batch_number, :country_of_origin, :gtin13, :authenticity, :when_placed_on_market, :affected_units_status, :number_of_affected_units, :exact_units, :approx_units, :customs_code, :has_markings, markings: []
     ).with_defaults(markings: [])
   end
 

--- a/app/services/add_product_to_case.rb
+++ b/app/services/add_product_to_case.rb
@@ -23,6 +23,7 @@ class AddProductToCase
            :exact_units,
            :approx_units,
            :when_placed_on_market,
+           :customs_code,
            to: :context
 
   def call
@@ -48,7 +49,8 @@ class AddProductToCase
         source: build_user_source,
         affected_units_status: affected_units_status,
         number_of_affected_units: number_of_affected_units,
-        when_placed_on_market: when_placed_on_market
+        when_placed_on_market: when_placed_on_market,
+        customs_code: customs_code
       )
 
       context.activity = create_audit_activity_for_product_added

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -101,6 +101,13 @@
   label: { text: "Country of origin", classes: label_class },
   hint: { text: "Where the product was manufactured" } %>
 
+  <%= render "form_components/govuk_input",
+    key: :customs_code,
+    form: form,
+    classes: "app-!-max-width-three-quarters",
+    label: { text: "Customs code", classes: label_class },
+    hint: { text: "For example, CN code (8 digits) or TARIC code (10 digits). Use a comma to separate multiple codes" } %>
+
 <%= render "form_components/govuk_textarea",
   key: :description,
   form: form,

--- a/db/migrate/20210104153742_add_customs_code_to_product.rb
+++ b/db/migrate/20210104153742_add_customs_code_to_product.rb
@@ -1,0 +1,7 @@
+class AddCustomsCodeToProduct < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_column :products, :customs_code, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_30_134737) do
+ActiveRecord::Schema.define(version: 2021_01_04_153742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -238,6 +238,7 @@ ActiveRecord::Schema.define(version: 2020_12_30_134737) do
     t.string "category"
     t.string "country_of_origin"
     t.datetime "created_at", null: false
+    t.text "customs_code"
     t.text "description"
     t.string "gtin13", limit: 13
     t.enum "has_markings", as: "has_markings_values"

--- a/spec/features/add_product_spec.rb
+++ b/spec/features/add_product_spec.rb
@@ -5,7 +5,8 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
   let(:investigation) { create(:enquiry, creator: user) }
   let(:attributes)    do
     attributes_for(:product_iphone, authenticity: Product.authenticities.keys.without("missing").sample,
-                                    affected_units_status: Product.affected_units_statuses.keys.sample)
+                                    affected_units_status: Product.affected_units_statuses.keys.sample,
+                                    customs_code: "12345678, abc123, xyz987")
   end
   let(:other_user) { create(:user, :activated) }
 
@@ -42,6 +43,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     fill_in "Other product identifiers",         with: attributes[:product_code]
     fill_in "Batch number",                      with: attributes[:batch_number]
     fill_in "Webpage",                           with: attributes[:webpage]
+    fill_in "Customs code",                      with: attributes[:customs_code]
 
     within_fieldset("Was the product placed on the market before 1 January 2021?") do
       choose when_placed_on_market_answer(attributes[:when_placed_on_market])
@@ -93,6 +95,7 @@ RSpec.feature "Adding a product", :with_stubbed_mailer, :with_stubbed_elasticsea
     expect(page).to have_summary_item(key: "Country of origin",         value: attributes[:country])
     expect(page).to have_summary_item(key: "Description",               value: attributes[:description])
     expect(page).to have_summary_item(key: "When placed on market",     value: I18n.t(attributes[:when_placed_on_market], scope: Product.model_name.i18n_key))
+    expect(page).to have_summary_item(key: "Customs code",              value: attributes[:customs_code])
   end
 
   scenario "Not being able to add a product to another team’s case" do

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -15,7 +15,9 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
            product_code: product_code,
            webpage: webpage,
            country_of_origin: country_of_origin,
-           has_markings: "markings_yes")
+           has_markings: "markings_yes",
+           customs_code: "initial, customs, code123"
+         )
   end
   let(:product_with_no_affected_units_status) do
     create(:product,
@@ -45,6 +47,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
   let(:new_webpage)           { Faker::Internet.url }
   let(:new_country_of_origin) { "South Korea" }
   let(:new_when_placed_on_market) { (Product.when_placed_on_markets.keys - [product.when_placed_on_market]).sample }
+  let(:new_customs_code) { "12345678, abc, 987" }
 
   before { sign_in user }
 
@@ -119,6 +122,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     fill_in "Webpage",                  with: new_webpage
     select new_country_of_origin,       from: "Country of origin"
     fill_in "Description of product",   with: new_description
+    fill_in "Customs code",             with: new_customs_code
 
     click_on "Save product"
 
@@ -143,6 +147,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
     expect(page).to have_summary_item(key: "Webpage",                   value: new_webpage)
     expect(page).to have_summary_item(key: "Country of origin",         value: new_country_of_origin)
     expect(page).to have_summary_item(key: "Description",               value: new_description)
+    expect(page).to have_summary_item(key: "Customs code",              value: new_customs_code)
   end
 
   it "allows to edit a product without an affected_units_status" do

--- a/spec/features/edit_a_product_spec.rb
+++ b/spec/features/edit_a_product_spec.rb
@@ -16,8 +16,7 @@ RSpec.feature "Editing a product", :with_stubbed_elasticsearch, :with_product_fo
            webpage: webpage,
            country_of_origin: country_of_origin,
            has_markings: "markings_yes",
-           customs_code: "initial, customs, code123"
-         )
+           customs_code: "initial, customs, code123")
   end
   let(:product_with_no_affected_units_status) do
     create(:product,

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -110,7 +110,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           number_of_affected_units: 22,
           has_markings: "markings_yes",
           markings: [Product::MARKINGS.sample],
-          when_placed_on_market: "Yes"
+          when_placed_on_market: "Yes",
+          customs_code: 'abc, def, 1234567'
         }
       end
       let(:coronavirus) { false }
@@ -424,6 +425,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
       expect(page.find("dt", text: "Webpage")).to have_sibling("dd", text: info[:webpage]) if info[:webpage]
       expect(page.find("dt", text: "Country of origin")).to have_sibling("dd", text: info[:country_of_origin]) if info[:country_of_origin]
       expect(page.find("dt", text: "Description")).to have_sibling("dd", text: info[:description]) if info[:description]
+      expect(page.find("dt", text: "Customs code")).to have_sibling("dd", text: info[:customs_code]) if info[:customs_code]
       expect(page).to have_css("img[alt=\"#{images.first[:title]}\"]") unless images.empty?
     end
   end
@@ -533,6 +535,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     fill_in "Other product identifiers",         with: with[:product_code] if with[:product_code]
     fill_in "Webpage",                           with: with[:webpage] if with[:webpage]
     fill_in "Description of product",            with: with[:description] if with[:description]
+    fill_in "Customs code",                      with: with[:customs_code] if with[:customs_code]
     click_button "Continue"
   end
 

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
           has_markings: "markings_yes",
           markings: [Product::MARKINGS.sample],
           when_placed_on_market: "Yes",
-          customs_code: 'abc, def, 1234567'
+          customs_code: "abc, def, 1234567"
         }
       end
       let(:coronavirus) { false }


### PR DESCRIPTION
https://trello.com/c/6pBWKRqW/854-3-add-customs-code-field-to-product-page

## Description
Add a text input for the user to add customs code to a product.

## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
