### PR TITLE
Resolve Brakeman warning (and improve resilience)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,8 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
@@ -584,6 +586,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   activerecord-pg_enum (~> 1.2)

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -79,7 +79,7 @@ class InvestigationsController < ApplicationController
 private
 
   def update!
-    return if request.get?
+    return unless request.patch?
 
     respond_to do |format|
       if @investigation.update(update_params)


### PR DESCRIPTION

## Description
Fixes a Brakeman warning, and improves the controller so that other request methods other than `GET` will not trigger an update erroneously.

This really needs refactoring properly to a separate controller.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
