### PR TITLE
Fix error being thrown currently when trying to export Case_Creator_T…

### DIFF
--- a/app/views/investigations/index.xlsx.axlsx
+++ b/app/views/investigations/index.xlsx.axlsx
@@ -31,7 +31,7 @@ book.add_worksheet name: "Cases" do |sheet_investigations| # rubocop:disable Met
       investigation.updated_at,
       investigation.date_closed,
       investigation.risk_validated_at,
-      investigation.creator_user&.team.name
+      investigation.creator_user&.team&.name
     ], types: :text
   end
 end

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -164,18 +164,37 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
         end
       end
 
-      it "exports Case_Creator_Team" do
-        team = create(:team)
-        creator_user = create(:user, team: team)
-        create(:allegation, creator: creator_user)
+      context "when creator user does not have a team" do
+        it "exports Case_Creator_Team as nil" do
+          creator_user = build(:user)
+          create(:allegation, creator: creator_user)
+          allow(creator_user).to receive(:team).and_return(nil)
 
-        Investigation.import refresh: true, force: true
+          Investigation.import refresh: true, force: true
 
-        get investigations_path format: :xlsx
+          get investigations_path format: :xlsx
 
-        aggregate_failures do
-          expect(exported_data.cell(1, 24)).to eq "Case_Creator_Team"
-          expect(exported_data.cell(2, 24)).to eq creator_user.team.name
+          aggregate_failures do
+            expect(exported_data.cell(1, 24)).to eq "Case_Creator_Team"
+            expect(exported_data.cell(2, 24)).to eq nil
+          end
+        end
+      end
+
+      context "when creator user has a team" do
+        it "exports Case_Creator_Team" do
+          team = create(:team)
+          creator_user = create(:user, team: team)
+          create(:allegation, creator: creator_user)
+
+          Investigation.import refresh: true, force: true
+
+          get investigations_path format: :xlsx
+
+          aggregate_failures do
+            expect(exported_data.cell(1, 24)).to eq "Case_Creator_Team"
+            expect(exported_data.cell(2, 24)).to eq creator_user.team.name
+          end
         end
       end
 

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -164,11 +164,11 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
         end
       end
 
-      context "when creator user does not have a team" do
+      context "when case does not have a creator_user" do
         it "exports Case_Creator_Team as nil" do
           creator_user = build(:user)
-          create(:allegation, creator: creator_user)
-          allow(creator_user).to receive(:team).and_return(nil)
+          allegation = create(:allegation, creator: creator_user)
+          allow(allegation).to receive(:creator_user).and_return(nil)
 
           Investigation.import refresh: true, force: true
 
@@ -181,7 +181,7 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
         end
       end
 
-      context "when creator user has a team" do
+      context "when case has a creator user" do
         it "exports Case_Creator_Team" do
           team = create(:team)
           creator_user = create(:user, team: team)


### PR DESCRIPTION
…eam when user does not have a team

## Description
https://sentry.io/organizations/beis/issues/1624184106/?project=1329381&referrer=slack

The above error was seen on prod when a user without a team has created an investigation and data was exported. This PR fixes the issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
