### PR TITLE
Fix migration against production data

### DIFF
--- a/db/migrate/20210125111313_fix_test_result_audit_activity_metadata.rb
+++ b/db/migrate/20210125111313_fix_test_result_audit_activity_metadata.rb
@@ -4,7 +4,7 @@ class FixTestResultAuditActivityMetadata < ActiveRecord::Migration[6.1]
       test_result = resolve_test_result(activity)
       new_metadata = AuditActivity::Test::Result.build_metadata(test_result)
 
-      activity.metadata = rewind_metadata_changes(new_metadata)
+      activity.metadata = rewind_metadata_changes(new_metadata, activity)
       activity.save!
     end
   end
@@ -36,24 +36,42 @@ class FixTestResultAuditActivityMetadata < ActiveRecord::Migration[6.1]
     investigation.test_results.first if investigation.test_results.count.one?
   end
 
-  def rewind_metadata_changes(new_metadata)
+  def rewind_metadata_changes(new_metadata, activity)
     updated_activities = AuditActivity::Test::TestResultUpdated.where("metadata->>'test_result_id' = ?", new_metadata["test_result"]["id"].to_s).order(created_at: :desc)
+    file_to_find = nil
+    file_description = nil
 
-    updated_activities.each do |activity|
-      activity.metadata["updates"].except("filename", "file_description").each_pair do |attribute, values|
+    updated_activities.each do |updated_activity|
+      updated_activity.metadata["updates"].except("filename", "file_description").each_pair do |attribute, values|
         new_metadata["test_result"][attribute] = values.first
       end
 
-      if activity.metadata["updates"]["filename"].present?
-        new_metadata["test_result"]["document"] = get_blob_metadata_by_filename(activity.metadata["updates"]["filename"].first)
+      if updated_activity.metadata["updates"]["filename"].present?
+        file_to_find = updated_activity.metadata["updates"]["filename"].first
       end
 
-      if activity.metadata["updates"]["file_description"].present?
-        new_metadata["test_result"]["document"]["metadata"]["description"] = activity.metadata["updates"]["file_description"].first
+      if updated_activity.metadata["updates"]["file_description"].present?
+        file_description = updated_activity.metadata["updates"]["file_description"].first
       end
     end
 
+    if file_to_find
+      new_metadata["test_result"]["document"] = get_blob_metadata(file_to_find, activity)
+    end
+
+    if file_description
+      new_metadata["test_result"]["document"]["metadata"]["description"] = file_description
+    end
+
     new_metadata
+  end
+
+  def get_blob_metadata(file_to_find, activity)
+    if activity.attachment.blob && activity.attachment.blob.filename.to_s == file_to_find
+      return activity.attachment.blob.attributes
+    end
+
+    get_blob_metadata_by_filename(file_to_find)
   end
 
   def get_blob_metadata_by_filename(filename)


### PR DESCRIPTION
Fixes some issues with the migration against production data. Two activities reference filenames which were not unique. In this case both of them were attached to the original activity so we can resolve them that way. Unfortunately it was not possible to resolve all of them this way, as many of the blobs were `nil`. Hence all the extra file resolution code needed.

Also, we do not need to attempt to resolve every file if there are multiple updated activities. We only need the one that was originally attached.