### PR TITLE
Allow export of products as CSV

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -12,7 +12,18 @@ class ProductsController < ApplicationController
   # GET /products
   # GET /products.json
   def index
-    @products = search_for_products(20)
+    respond_to do |format|
+      format.html do
+        @products = search_for_products(20)
+      end
+      format.csv do
+        authorize Product, :export?
+
+        @products = search_for_products
+
+        render csv: @products, filename: "products"
+      end
+    end
   end
 
   # GET /products/1

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -78,4 +78,8 @@ class ProductDecorator < ApplicationDecorator
 
     object.markings.join(", ")
   end
+
+  def to_csv
+    attributes.keys.map { |key| send(key) }
+  end
 end

--- a/app/decorators/products_decorator.rb
+++ b/app/decorators/products_decorator.rb
@@ -1,3 +1,10 @@
 class ProductsDecorator < Draper::CollectionDecorator
   delegate :current_page, :total_entries, :total_pages, :per_page, :offset
+
+  def to_csv
+    CSV.generate do |csv|
+      csv << Product.attribute_names
+      each { |product| csv << product.to_csv }
+    end
+  end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -10,7 +10,11 @@ module ProductsHelper
     ).with_defaults(markings: [])
   end
 
-  def search_for_products(page_size)
+  def product_export_params
+    params.permit(:sort, :q)
+  end
+
+  def search_for_products(page_size = Product.count)
     ProductDecorator.decorate_collection(
       Product.full_search(search_query)
         .page(params[:page]).per_page(page_size).records

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -1,0 +1,5 @@
+class ProductPolicy < ApplicationPolicy
+  def export?
+    user.is_psd_admin?
+  end
+end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -39,5 +39,9 @@
   <div class="govuk-grid-column-three-quarters">
     <%= render "table", products: @products %>
     <%= will_paginate @products %>
+
+    <% if policy(Product).export? %>
+      <%= link_to "Export as spreadsheet", products_path(format: :csv, params: product_export_params) %>
+    <% end %>
   </div>
 </div>

--- a/config/initializers/csv_renderer.rb
+++ b/config/initializers/csv_renderer.rb
@@ -1,0 +1,8 @@
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Renderers.add :csv do |obj, options|
+    filename = options[:filename] || "data"
+    str = obj.respond_to?(:to_csv) ? obj.to_csv : obj.to_s
+    send_data str, type: Mime[:csv],
+                   disposition: "attachment; filename=#{filename}.csv"
+  end
+end

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProductDecorator do
+RSpec.describe ProductDecorator, :with_stubbed_elasticsearch do
   subject(:decorated_product) { product.decorate }
 
   let(:product) { build(:product) }
@@ -171,5 +171,35 @@ RSpec.describe ProductDecorator do
         expect(decorated_product.markings).to eq("Not provided")
       end
     end
+  end
+
+  describe "#to_csv" do
+    # rubocop:disable RSpec/ExampleLength
+    it "returns an Array of decorated attributes" do
+      decorated_product.save!
+      expect(decorated_product.to_csv).to eq([
+        decorated_product.id,
+        decorated_product.affected_units_status,
+        decorated_product.authenticity,
+        decorated_product.barcode,
+        decorated_product.batch_number,
+        decorated_product.brand,
+        decorated_product.category,
+        decorated_product.country_of_origin,
+        decorated_product.created_at,
+        decorated_product.customs_code,
+        decorated_product.description,
+        decorated_product.has_markings,
+        decorated_product.markings,
+        decorated_product.name,
+        decorated_product.number_of_affected_units,
+        decorated_product.product_code,
+        decorated_product.subcategory,
+        decorated_product.updated_at,
+        decorated_product.webpage,
+        decorated_product.when_placed_on_market
+      ])
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/decorators/products_decorator_spec.rb
+++ b/spec/decorators/products_decorator_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ProductsDecorator, :with_stubbed_elasticsearch do
+  subject(:decorated_products) { Product.all.decorate }
+
+  let!(:product_1) { create(:product, brand: "Brand 1", category: "Motor vehicles") }
+  let!(:product_2) { create(:product, brand: "Brand 2", category: "Clothing, textiles and fashion items") }
+
+  describe "#to_csv" do
+    it "returns a CSV string" do
+      expect(decorated_products.to_csv).to eq("id,affected_units_status,authenticity,barcode,batch_number,brand,category,country_of_origin,created_at,customs_code,description,has_markings,markings,name,number_of_affected_units,product_code,subcategory,updated_at,webpage,when_placed_on_market\n#{product_1.decorate.id},#{product_1.decorate.affected_units_status},#{product_1.decorate.authenticity},#{product_1.decorate.barcode},#{product_1.decorate.batch_number},#{product_1.decorate.brand},#{product_1.decorate.category},#{product_1.decorate.country_of_origin},#{product_1.decorate.created_at},#{product_1.decorate.customs_code},#{product_1.decorate.description},#{product_1.decorate.has_markings},#{product_1.decorate.markings},#{product_1.decorate.name},#{product_1.decorate.number_of_affected_units},#{product_1.decorate.product_code},#{product_1.decorate.subcategory},#{product_1.decorate.updated_at},#{product_1.decorate.webpage},#{product_1.decorate.when_placed_on_market}\n#{product_2.decorate.id},#{product_2.decorate.affected_units_status},#{product_2.decorate.authenticity},#{product_2.decorate.barcode},#{product_2.decorate.batch_number},#{product_2.decorate.brand},\"#{product_2.decorate.category}\",#{product_2.decorate.country_of_origin},#{product_2.decorate.created_at},#{product_2.decorate.customs_code},#{product_2.decorate.description},#{product_2.decorate.has_markings},#{product_2.decorate.markings},#{product_2.decorate.name},#{product_2.decorate.number_of_affected_units},#{product_2.decorate.product_code},#{product_2.decorate.subcategory},#{product_2.decorate.updated_at},#{product_2.decorate.webpage},#{product_2.decorate.when_placed_on_market}\n")
+    end
+  end
+end

--- a/spec/features/export_products_spec.rb
+++ b/spec/features/export_products_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Exporting products", :with_elasticsearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
+  let(:user) { create(:user, :activated, :psd_admin, has_viewed_introduction: true) }
+  let!(:product_1) { create(:product, description: "Battery", brand: "Brand 1", category: "Motor vehicles") }
+  let!(:product_2) { create(:product, description: "Hair dryer", brand: "Brand 2", category: "Clothing, textiles and fashion items") }
+
+  scenario "all products" do
+    sign_in user
+    visit "/products"
+
+    click_link "Export as spreadsheet"
+
+    expect(page.body).to eq("id,affected_units_status,authenticity,barcode,batch_number,brand,category,country_of_origin,created_at,customs_code,description,has_markings,markings,name,number_of_affected_units,product_code,subcategory,updated_at,webpage,when_placed_on_market\n#{product_2.decorate.id},#{product_2.decorate.affected_units_status},#{product_2.decorate.authenticity},#{product_2.decorate.barcode},#{product_2.decorate.batch_number},#{product_2.decorate.brand},\"#{product_2.decorate.category}\",#{product_2.decorate.country_of_origin},#{product_2.decorate.created_at},#{product_2.decorate.customs_code},#{product_2.decorate.description},#{product_2.decorate.has_markings},#{product_2.decorate.markings},#{product_2.decorate.name},#{product_2.decorate.number_of_affected_units},#{product_2.decorate.product_code},#{product_2.decorate.subcategory},#{product_2.decorate.updated_at},#{product_2.decorate.webpage},#{product_2.decorate.when_placed_on_market}\n#{product_1.decorate.id},#{product_1.decorate.affected_units_status},#{product_1.decorate.authenticity},#{product_1.decorate.barcode},#{product_1.decorate.batch_number},#{product_1.decorate.brand},#{product_1.decorate.category},#{product_1.decorate.country_of_origin},#{product_1.decorate.created_at},#{product_1.decorate.customs_code},#{product_1.decorate.description},#{product_1.decorate.has_markings},#{product_1.decorate.markings},#{product_1.decorate.name},#{product_1.decorate.number_of_affected_units},#{product_1.decorate.product_code},#{product_1.decorate.subcategory},#{product_1.decorate.updated_at},#{product_1.decorate.webpage},#{product_1.decorate.when_placed_on_market}\n")
+  end
+
+  scenario "searching products" do
+    sign_in user
+    visit "/products"
+
+    fill_in "Keywords", with: "Battery"
+    click_button "Search"
+
+    click_link "Export as spreadsheet"
+
+    expect(page.body).to eq("id,affected_units_status,authenticity,barcode,batch_number,brand,category,country_of_origin,created_at,customs_code,description,has_markings,markings,name,number_of_affected_units,product_code,subcategory,updated_at,webpage,when_placed_on_market\n#{product_1.decorate.id},#{product_1.decorate.affected_units_status},#{product_1.decorate.authenticity},#{product_1.decorate.barcode},#{product_1.decorate.batch_number},#{product_1.decorate.brand},#{product_1.decorate.category},#{product_1.decorate.country_of_origin},#{product_1.decorate.created_at},#{product_1.decorate.customs_code},#{product_1.decorate.description},#{product_1.decorate.has_markings},#{product_1.decorate.markings},#{product_1.decorate.name},#{product_1.decorate.number_of_affected_units},#{product_1.decorate.product_code},#{product_1.decorate.subcategory},#{product_1.decorate.updated_at},#{product_1.decorate.webpage},#{product_1.decorate.when_placed_on_market}\n")
+  end
+end

--- a/spec/policies/product_policy_spec.rb
+++ b/spec/policies/product_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe ProductPolicy do
       before { user.roles.create!(name: "psd_admin") }
 
       it "returns true" do
-        expect(policy.export?).to be true
+        expect(policy).to be_export
       end
     end
 
     context "when the user does not have the psd_admin role" do
       it "returns false" do
-        expect(policy.export?).to be false
+        expect(policy).not_to be_export
       end
     end
   end

--- a/spec/policies/product_policy_spec.rb
+++ b/spec/policies/product_policy_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ProductPolicy do
+  subject(:policy) { described_class.new(user, Product) }
+
+  let(:user) { create(:user) }
+
+  describe "#export?" do
+    context "when the user has the psd_admin role" do
+      before { user.roles.create!(name: "psd_admin") }
+
+      it "returns true" do
+        expect(policy.export?).to be true
+      end
+    end
+
+    context "when the user does not have the psd_admin role" do
+      it "returns false" do
+        expect(policy.export?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/hq74CuGh/901-csv-export-of-product-data
https://trello.com/c/5eW7fDI2/872-add-product-details-export
https://trello.com/c/2x6xL2gG/228-allow-users-to-export-product-information

## Description
I decided to make this a re-usable feature rather than a one-off, since this has been on the backlog for a while and didn't take long, and there is a need to do this regularly.

I decided to export products as a CSV rather than in Excel format as elsewhere, since CSV is more interoperable, simpler, and we are not using any specific features. The implementation used here will allow an easy switchover to CSV for the cases export in a future piece of work.

As with export of cases, if a user has the `psd_admin` role they will see a link at the bottom of the products listing which will allow them to download the CSV file.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
