### PR TITLE
Resend link invite bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
   end
 
   def has_filled_out_account_setup_form?
-    !name.blank? && !email.blank?
+    name.present? && email.present?
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,6 +148,10 @@ class User < ApplicationRecord
     !mobile_number_verified?
   end
 
+  def has_filled_out_account_setup_form?
+    !name.blank? && !email.blank?
+  end
+
 private
 
   def lock_two_factor!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
   end
 
   def has_filled_out_account_setup_form?
-    name.present? && email.present?
+    name.present? && mobile_number.present?
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,8 +148,8 @@ class User < ApplicationRecord
     !mobile_number_verified?
   end
 
-  def has_filled_out_account_setup_form?
-    name.present? && mobile_number.present?
+  def has_filled_out_account_setup_form_and_verified?
+    name.present? && mobile_number_verified?
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,7 +148,7 @@ class User < ApplicationRecord
     !mobile_number_verified?
   end
 
-  def has_filled_out_account_setup_form_and_verified?
+  def has_filled_out_account_setup_form_and_verified_number?
     name.present? && mobile_number_verified?
   end
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -11,7 +11,7 @@
     <ul class="teams--list">
       <% @team.users.not_deleted.sort_by(&:name).each do |user| %>
         <li class="teams--user govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0">
-          <% if !user.has_filled_out_account_setup_form_and_verified? && current_user.is_team_admin? %>
+          <% if !user.has_filled_out_account_setup_form_and_verified_number? && current_user.is_team_admin? %>
 
             <%= button_to resend_team_invitation_path(@team, user), method: :put, class: "button-link right", role: "link" do %>
               Resend invitation<span class="govuk-visually-hidden"> to <%= user.email %></span>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -11,7 +11,7 @@
     <ul class="teams--list">
       <% @team.users.not_deleted.sort_by(&:name).each do |user| %>
         <li class="teams--user govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0">
-          <% if !user.account_activated? && current_user.is_team_admin? %>
+          <% if !user.has_filled_out_account_setup_form? && current_user.is_team_admin? %>
 
             <%= button_to resend_team_invitation_path(@team, user), method: :put, class: "button-link right", role: "link" do %>
               Resend invitation<span class="govuk-visually-hidden"> to <%= user.email %></span>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -11,7 +11,7 @@
     <ul class="teams--list">
       <% @team.users.not_deleted.sort_by(&:name).each do |user| %>
         <li class="teams--user govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0">
-          <% if !user.has_filled_out_account_setup_form? && current_user.is_team_admin? %>
+          <% if !user.has_filled_out_account_setup_form_and_verified? && current_user.is_team_admin? %>
 
             <%= button_to resend_team_invitation_path(@team, user), method: :put, class: "button-link right", role: "link" do %>
               Resend invitation<span class="govuk-visually-hidden"> to <%= user.email %></span>

--- a/spec/features/team_spec.rb
+++ b/spec/features/team_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
 
   let!(:another_active_user) { create(:user, :activated, email: "active.sameteam@example.com", organisation: user.organisation, team: team, has_viewed_introduction: true) }
   let!(:another_inactive_user) { create(:user, email: "inactive.sameteam@example.com", invited_at: 1.year.ago, organisation: user.organisation, team: team) }
+  let!(:user_without_details) { create(:user, name: nil, email: "mr.no.details.sameteam@example.com", invited_at: 1.year.ago, organisation: user.organisation, team: team) }
   let!(:another_user_another_team) { create(:user, :activated, email: "active.otherteam@example.com", organisation: user.organisation, team: create(:team)) }
 
   context "when signed in as a member of another team" do
@@ -38,21 +39,21 @@ RSpec.feature "Your team page", :with_stubbed_mailer, :with_stubbed_elasticsearc
     context "when the user is a team admin" do
       let(:user) { create(:user, :activated, :team_admin, team: team, has_viewed_introduction: true) }
 
-      scenario "displays the invite a team member link and only displays the resend invite link for inactive users" do
+      scenario "displays the invite a team member link and only displays the resend invite link for inactive users that have not yet filled out their details" do
         expect(page).to have_link("Invite a team member")
-        expect(page).to have_resend_invite_button_for(another_inactive_user)
+        expect(page).to have_resend_invite_button_for(user_without_details)
         expect(page).not_to have_resend_invite_button_for(another_active_user)
       end
 
       scenario "resending an invitation sends an email to the user and shows a confirmation message" do
-        click_button "Resend invitation to #{another_inactive_user.email}"
-        expect_confirmation_banner "Invite sent to #{another_inactive_user.email}"
+        click_button "Resend invitation to #{user_without_details.email}"
+        expect_confirmation_banner "Invite sent to #{user_without_details.email}"
 
         email = delivered_emails.last
 
         expect(email.action_name).to eq("invitation_email")
-        expect(email.recipient).to eq(another_inactive_user.email)
-        expect(email.personalization[:invitation_url]).to eq("http://www.example.com/users/#{another_inactive_user.id}/complete-registration?invitation=#{another_inactive_user.invitation_token}")
+        expect(email.recipient).to eq(user_without_details.email)
+        expect(email.personalization[:invitation_url]).to eq("http://www.example.com/users/#{user_without_details.id}/complete-registration?invitation=#{user_without_details.invitation_token}")
         expect(email.personalization[:inviting_team_member_name]).to eq(user.name)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe User do
     end
   end
 
+  describe "#has_filled_out_account_setup_form?" do
+    it "returns true if user mobile_number and name details are present" do
+      user = create(:user)
+
+      expect(user.has_filled_out_account_setup_form?).to eq true
+    end
+
+    it "returns false if name is nil" do
+      user = create(:user, name: nil)
+
+      expect(user.has_filled_out_account_setup_form?).to eq false
+    end
+
+    it "returns false if mobile_number is nil" do
+      user = create(:user, mobile_number: nil)
+
+      expect(user.has_filled_out_account_setup_form?).to eq false
+    end
+  end
+
   describe ".not_deleted" do
     it "returns only users without deleted timestamp" do
       create(:user, :deleted)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,23 +116,23 @@ RSpec.describe User do
     end
   end
 
-  describe "#has_filled_out_account_setup_form_and_verified?" do
+  describe "#has_filled_out_account_setup_form_and_verified_number?" do
     it "returns true if user mobile_number_verified and name details are present" do
       user = create(:user)
 
-      expect(user.has_filled_out_account_setup_form_and_verified?).to eq true
+      expect(user.has_filled_out_account_setup_form_and_verified_number?).to eq true
     end
 
     it "returns false if name is nil" do
       user = create(:user, name: nil)
 
-      expect(user.has_filled_out_account_setup_form_and_verified?).to eq false
+      expect(user.has_filled_out_account_setup_form_and_verified_number?).to eq false
     end
 
     it "returns false if mobile_number_verified is not verified" do
       user = create(:user, mobile_number_verified: false)
 
-      expect(user.has_filled_out_account_setup_form_and_verified?).to eq false
+      expect(user.has_filled_out_account_setup_form_and_verified_number?).to eq false
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,23 +116,23 @@ RSpec.describe User do
     end
   end
 
-  describe "#has_filled_out_account_setup_form?" do
-    it "returns true if user mobile_number and name details are present" do
+  describe "#has_filled_out_account_setup_form_and_verified?" do
+    it "returns true if user mobile_number_verified and name details are present" do
       user = create(:user)
 
-      expect(user.has_filled_out_account_setup_form?).to eq true
+      expect(user.has_filled_out_account_setup_form_and_verified?).to eq true
     end
 
     it "returns false if name is nil" do
       user = create(:user, name: nil)
 
-      expect(user.has_filled_out_account_setup_form?).to eq false
+      expect(user.has_filled_out_account_setup_form_and_verified?).to eq false
     end
 
-    it "returns false if mobile_number is nil" do
-      user = create(:user, mobile_number: nil)
+    it "returns false if mobile_number_verified is not verified" do
+      user = create(:user, mobile_number_verified: false)
 
-      expect(user.has_filled_out_account_setup_form?).to eq false
+      expect(user.has_filled_out_account_setup_form_and_verified?).to eq false
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/8cqGiWhN/521-resend-link-invite-should-not-displayed-once-account-set-up-is-complete

## Description
Before this change, if a user received an email invite and entered their details, but signed out before accepting the declaration then the inviting user had the option to resend an email invitation. This is not what we want as it could confuse the user, and possibly cause them to sign up multiple accounts.

This change only shows the 'resend invitation' button if the user has not yet visited the site and entered in their necessary details. 

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
