### PR TITLE
Test result fail box

### DIFF
--- a/app/controllers/investigations/test_results_controller.rb
+++ b/app/controllers/investigations/test_results_controller.rb
@@ -86,6 +86,7 @@ private
       :legislation,
       :product_id,
       :result,
+      :failure_details,
       :standards_product_was_tested_against,
       :existing_document_file_id,
       :test_result_file,

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -706,6 +706,7 @@ private
       :result,
       :standards_product_was_tested_against,
       :existing_document_file_id,
+      :failure_details,
       date: %i[day month year],
       document_form: %i[description file]
     )

--- a/app/decorators/test/result_decorator.rb
+++ b/app/decorators/test/result_decorator.rb
@@ -44,5 +44,11 @@ class Test < ApplicationRecord
     def standards_product_was_tested_against
       object.standards_product_was_tested_against&.join(", ")
     end
+
+    def failure_details
+      return "Not provided" if object.failure_details.nil?
+
+      object.failure_details
+    end
   end
 end

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -18,7 +18,7 @@ class TestResultForm
   attribute :existing_document_file_id
   attribute :filename
   attribute :file_description
-  attribute :failed_details
+  attribute :failure_details
 
   validates :details, length: { maximum: 50_000 }
   validates :legislation, inclusion: { in: Rails.application.config.legislation_constants["legislation"] }
@@ -31,6 +31,7 @@ class TestResultForm
             real_date: true,
             complete_date: true,
             not_in_future: true
+  validates :failure_details, presence: true, if: -> { result.inquiry.failed? }
 
   before_validation { trim_line_endings(:details, :file_description) }
 

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -36,7 +36,7 @@ class TestResultForm
   before_validation { trim_line_endings(:details, :file_description) }
 
   ATTRIBUTES_FROM_TEST_RESULT = %i[
-    id date details legislation result standards_product_was_tested_against product_id
+    id date details legislation result failure_details standards_product_was_tested_against product_id
   ].freeze
 
   def self.from(test_result)

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -18,6 +18,7 @@ class TestResultForm
   attribute :existing_document_file_id
   attribute :filename
   attribute :file_description
+  attribute :failed_details
 
   validates :details, length: { maximum: 50_000 }
   validates :legislation, inclusion: { in: Rails.application.config.legislation_constants["legislation"] }

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -31,7 +31,7 @@ class TestResultForm
             real_date: true,
             complete_date: true,
             not_in_future: true
-  validates :failure_details, presence: true, if: -> { result.inquiry.failed? }
+  validates :failure_details, presence: true, if: -> { result == "failed" }
 
   before_validation { trim_line_endings(:details, :file_description) }
 

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -47,7 +47,7 @@ module TestsHelper
   def result_items(form)
     [
       { text: Test::Result.results["passed"], value: "passed" },
-      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_input(:failed_details, label: "How the product failed") } }
+      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_text_area(:failure_details, label: "How the product failed", hint: "Describe how the product was tested and how it failed to meet the requirements") } }
     ]
   end
 end

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -43,4 +43,11 @@ module TestsHelper
 
     rows
   end
+
+  def result_items(form)
+    [
+      { text: Test::Result.results["passed"], value: "passed" },
+      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_input(:failed_details, label: "How the product failed") } }
+    ]
+  end
 end

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -54,7 +54,8 @@ module TestsHelper
   def result_items(form)
     [
       { text: Test::Result.results["passed"], value: "passed" },
-      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_text_area(:failure_details, label: "How the product failed", hint: "Describe how the product was tested and how it failed to meet the requirements") } }
+      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_text_area(:failure_details, label: "How the product failed", hint: "Describe how the product was tested and how it failed to meet the requirements") } },
+      { text: Test::Result.results["other"], value: "other" }
     ]
   end
 end

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -54,7 +54,7 @@ module TestsHelper
   def result_items(form)
     [
       { text: Test::Result.results["passed"], value: "passed" },
-      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_text_area(:failure_details, label: "How the product failed", hint: "Describe how the product was tested and how it failed to meet the requirements") } },
+      { text: Test::Result.results["failed"], value: "failed", conditional: { html: form.govuk_text_area(:failure_details, label: "How the product failed", hint: "Describe how the product was tested and how it failed to meet the requirements", label_classes: "govuk-label") } },
       { text: Test::Result.results["other"], value: "other" }
     ]
   end

--- a/app/helpers/tests_helper.rb
+++ b/app/helpers/tests_helper.rb
@@ -26,6 +26,13 @@ module TestsHelper
       value: { text: test_result.result.upcase_first }
     }
 
+    if test_result.result == "failed"
+      rows << {
+        key: { text: "Reason for failure" },
+        value: { text: test_result.failure_details }
+      }
+    end
+
     if test_result.details.present?
       rows << {
         key: { text: "Further details" },

--- a/app/models/audit_activity/test/result.rb
+++ b/app/models/audit_activity/test/result.rb
@@ -35,6 +35,10 @@ class AuditActivity::Test::Result < AuditActivity::Test::Base
     metadata["test_result"]["result"]
   end
 
+  def failure_details
+    metadata["test_result"]["failure_details"]
+  end
+
   def details
     metadata["test_result"]["details"]
   end

--- a/app/models/audit_activity/test/test_result_updated.rb
+++ b/app/models/audit_activity/test/test_result_updated.rb
@@ -51,6 +51,14 @@ class AuditActivity::Test::TestResultUpdated < AuditActivity::Test::Base
     updates["standards_product_was_tested_against"]&.second
   end
 
+  def new_failure_details
+    updates["failure_details"]&.second
+  end
+
+  def show_new_failure_details?
+    new_failure_details && test_result.result == "failed"
+  end
+
   def new_product
     @new_product ||=
       if updates["product_id"]

--- a/app/services/add_test_result_to_investigation.rb
+++ b/app/services/add_test_result_to_investigation.rb
@@ -2,7 +2,7 @@ class AddTestResultToInvestigation
   include Interactor
   include EntitiesToNotify
 
-  delegate :user, :investigation, :document, :date, :details, :legislation, :result, :standards_product_was_tested_against, :product_id, to: :context
+  delegate :user, :investigation, :document, :date, :details, :legislation, :result, :standards_product_was_tested_against, :product_id, :failure_details, to: :context
 
   def call
     context.fail!(error: "No investigation supplied") unless investigation.is_a?(Investigation)
@@ -14,6 +14,7 @@ class AddTestResultToInvestigation
         details: details,
         legislation: legislation,
         result: result,
+        failure_details: failure_details,
         standards_product_was_tested_against: standards_product_was_tested_against,
         product_id: product_id
       )

--- a/app/services/update_test_result.rb
+++ b/app/services/update_test_result.rb
@@ -2,7 +2,7 @@ class UpdateTestResult
   include Interactor
   include EntitiesToNotify
 
-  delegate :test_result, :user, :investigation, :document, :date, :details, :legislation, :result, :standards_product_was_tested_against, :product_id, :changes, to: :context
+  delegate :test_result, :user, :investigation, :document, :date, :details, :legislation, :result, :failure_details, :standards_product_was_tested_against, :product_id, :changes, to: :context
 
   def call
     context.fail!(error: "No test result supplied")   unless test_result.is_a?(Test::Result)
@@ -14,6 +14,7 @@ class UpdateTestResult
       details: details,
       legislation: legislation,
       result: result,
+      failure_details: failure_details,
       standards_product_was_tested_against: standards_product_was_tested_against,
       product_id: product_id,
     )

--- a/app/services/update_test_result.rb
+++ b/app/services/update_test_result.rb
@@ -14,7 +14,7 @@ class UpdateTestResult
       details: details,
       legislation: legislation,
       result: result,
-      failure_details: failure_details,
+      failure_details: updated_failure_details,
       standards_product_was_tested_against: standards_product_was_tested_against,
       product_id: product_id,
     )
@@ -55,5 +55,11 @@ private
         "Test result edited for #{test_result.investigation.case_type.upcase_first}"
       ).deliver_later
     end
+  end
+
+  def updated_failure_details
+    return if result == "passed"
+
+    failure_details
   end
 end

--- a/app/views/investigations/activities/test/_result.html.erb
+++ b/app/views/investigations/activities/test/_result.html.erb
@@ -9,6 +9,10 @@
   <br />
   Result: <strong><%= activity.result %></strong>
   <br />
+  <% if activity.result == "Failed" %>
+    Reason for failure: <strong><%= activity.failure_details %></strong>
+    <br />
+  <% end %>
   Attached: <strong><%= link_to activity.attached_file_name, url_for(activity.attached_file) %></strong>
   <br />
   <br />

--- a/app/views/investigations/activities/test/_test_result_updated.html.erb
+++ b/app/views/investigations/activities/test/_test_result_updated.html.erb
@@ -10,6 +10,10 @@
     Result: <strong><%= activity.new_result %></strong><br>
   <% end %>
 
+  <% if activity.new_failure_details && activity.show_new_failure_details? %>
+    Reason for failure: <strong><%= activity.new_failure_details %></strong><br>
+  <% end %>
+
   <% if activity.new_details %>
     Further details: <strong><%= activity.new_details %></strong><br>
   <% end %>

--- a/app/views/investigations/test_results/_form.html.erb
+++ b/app/views/investigations/test_results/_form.html.erb
@@ -25,7 +25,7 @@
 <%= form.govuk_input :standards_product_was_tested_against, label_classes: "govuk-label--m", hint: "For example, EN71. Use a comma to separate multiple standards.", label: "Which standard was the product tested against?", value: form.object.standards_product_was_tested_against&.join(", ")  %>
 <%= form.govuk_date_input :date, legend: "Date of test", hint: "For example, 12 7 2019" %>
 
-<%= form.govuk_radios :result, legend: "What was the result?", items: Test::Result.results.map { |result, label| { text: label, value: result } } %>
+<%= form.govuk_radios :result, legend: "What was the result?", items: result_items(form) %>
 
 <%= form.govuk_text_area :details, label: "Further details", attributes: { maxlength: 50_000 } %>
 

--- a/app/views/investigations/test_results/new.html.erb
+++ b/app/views/investigations/test_results/new.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <%= error_summary(@test_result_form.errors, %i[legislation standards_product_was_tested_against date result base])%>
+      <%= error_summary(@test_result_form.errors, %i[legislation standards_product_was_tested_against date result failure_details base])%>
 
       <span class="govuk-caption-l"><%= @investigation.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= page_title %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,8 @@ en:
               must_be_real: Date sent must be a real date
               incomplete: Date sent must include a %{missing_date_parts}
               in_future: Date sent must be today or in the past
+            failure_details:
+              blank: Enter details about how the product failed to meet the requirements
         product_form:
           attributes:
             authenticity:

--- a/db/migrate/20210217142322_add_failure_details_to_tests.rb
+++ b/db/migrate/20210217142322_add_failure_details_to_tests.rb
@@ -1,0 +1,5 @@
+class AddFailureDetailsToTests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tests, :failure_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,6 +326,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_113829) do
     t.datetime "created_at", null: false
     t.date "date"
     t.text "details"
+    t.text "failure_details"
     t.integer "investigation_id"
     t.string "legislation"
     t.integer "product_id"

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
   let(:file) { Rails.root + "test/fixtures/files/test_result.txt" }
   let(:other_user) { create(:user, :activated) }
   let(:legislation) { "General Product Safety Regulations 2005" }
+  let(:failure_details) { "Something went wrong" }
 
-  scenario "Adding a test result (with validation errors)" do
+  scenario "Adding a passing test result (with validation errors)" do
     travel_to Date.parse("2 April 2020") do
       sign_in(user)
       visit "/cases/#{investigation.pretty_id}/supporting-information"
@@ -71,6 +72,78 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     end
   end
 
+  scenario "Adding a failing test result (with validation errors)" do
+    travel_to Date.parse("2 April 2020") do
+      sign_in(user)
+      visit "/cases/#{investigation.pretty_id}/supporting-information"
+
+      click_link "Add supporting information"
+
+      expect_to_be_on_add_supporting_information_page
+
+      within_fieldset "What type of information are you adding?" do
+        page.choose "Test result"
+      end
+      click_button "Continue"
+
+      expect_to_be_on_record_test_result_page
+      expect_test_result_form_to_be_blank
+
+      click_button "Add test result"
+
+      errors_list = page.find(".govuk-error-summary__list").all("li")
+      expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
+      expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
+      expect(errors_list[2].text).to eq "Enter date of the test"
+      expect(errors_list[3].text).to eq "Select result of the test"
+      expect(errors_list[4].text).to eq "Provide the test results file"
+
+      within_fieldset "What was the result?" do
+        choose "Fail"
+      end
+
+      click_button "Add test result"
+
+      errors_list = page.find(".govuk-error-summary__list").all("li")
+      expect(errors_list[3].text).to eq "Enter details about how the product failed to meet the requirements"
+
+      fill_in "Further details", with: "Test result includes certificate of conformity"
+      fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date: date, test_result: "Fail", failure_details: failure_details, file: file, standards: "EN71, EN73")
+
+      expect_confirmation_banner("Test result was successfully recorded.")
+      expect_page_to_have_h1("Supporting information")
+
+      click_link "Activity"
+
+      expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
+      expect(page).to have_text("Failed test: MyBrand washing machine")
+      expect(page).to have_link(product.name, href: product_path(product))
+      expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
+      expect(page).to have_text("Standards: EN71, EN73")
+      expect(page).to have_text("Date of test: 1 January 2020")
+      expect(page).to have_text("Test result includes certificate of conformity")
+      expect(page).to have_link("test_result.txt")
+      expect(page).to have_link("View product details", href: product_path(product))
+
+      click_link "View test result"
+
+      expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
+
+      expect(page).to have_summary_item(key: "Date of test", value: "1 January 2020")
+      expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
+      expect(page).to have_summary_item(key: "Standards", value: "EN71, EN73")
+      expect(page).to have_summary_item(key: "Result", value: "Failed")
+      expect(page).to have_summary_item(key: "Reason for failure", value: failure_details)
+      expect(page).to have_summary_item(key: "Further details", value: "Test result includes certificate of conformity")
+      expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
+
+      expect(page).to have_text("test_result.txt")
+
+      visit "/cases/#{investigation.pretty_id}/test-results/new"
+      expect_test_result_form_to_be_blank
+    end
+  end
+
   scenario "Not being able to add test results to another team’s case" do
     sign_in(other_user)
     visit "/cases/#{investigation.pretty_id}/activity"
@@ -78,7 +151,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     expect(page).not_to have_link("Add supporting information")
   end
 
-  def fill_in_test_result_submit_form(legislation:, date:, test_result:, file:, standards:)
+  def fill_in_test_result_submit_form(legislation:, date:, test_result:, failure_details: nil, file:, standards:)
     select legislation, from: "Against which legislation?"
     fill_in "Day",   with: date.day if date
     fill_in "Month", with: date.month if date
@@ -86,6 +159,9 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     fill_in "Which standard was the product tested against?", with: standards
     within_fieldset "What was the result?" do
       choose test_result
+      if test_result == "Fail"
+        fill_in "How the product failed", with: failure_details
+      end
     end
     within_fieldset "Test report attachment" do
       attach_file file

--- a/spec/features/add_test_results_spec.rb
+++ b/spec/features/add_test_results_spec.rb
@@ -29,12 +29,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
 
       click_button "Add test result"
 
-      errors_list = page.find(".govuk-error-summary__list").all("li")
-      expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
-      expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
-      expect(errors_list[2].text).to eq "Enter date of the test"
-      expect(errors_list[3].text).to eq "Select result of the test"
-      expect(errors_list[4].text).to eq "Provide the test results file"
+      expect_full_error_list
 
       fill_in "Further details", with: "Test result includes certificate of conformity"
       fill_in_test_result_submit_form(legislation: "General Product Safety Regulations 2005", date: date, test_result: "Pass", file: file, standards: "EN71, EN73")
@@ -45,25 +40,13 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
       click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect(page).to have_text("Passed test: MyBrand washing machine")
-      expect(page).to have_link(product.name, href: product_path(product))
-      expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
-      expect(page).to have_text("Standards: EN71, EN73")
-      expect(page).to have_text("Date of test: 1 January 2020")
-      expect(page).to have_text("Test result includes certificate of conformity")
-      expect(page).to have_link("test_result.txt")
-      expect(page).to have_link("View product details", href: product_path(product))
+      expect_activity_page_to_show_created_test_result_values(result: "Passed")
 
       click_link "View test result"
 
       expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
 
-      expect(page).to have_summary_item(key: "Date of test", value: "1 January 2020")
-      expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
-      expect(page).to have_summary_item(key: "Standards", value: "EN71, EN73")
-      expect(page).to have_summary_item(key: "Result", value: "Passed")
-      expect(page).to have_summary_item(key: "Further details", value: "Test result includes certificate of conformity")
-      expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
+      expect_summary_to_reflect_values(result: "Passed")
 
       expect(page).to have_text("test_result.txt")
 
@@ -91,12 +74,7 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
 
       click_button "Add test result"
 
-      errors_list = page.find(".govuk-error-summary__list").all("li")
-      expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
-      expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
-      expect(errors_list[2].text).to eq "Enter date of the test"
-      expect(errors_list[3].text).to eq "Select result of the test"
-      expect(errors_list[4].text).to eq "Provide the test results file"
+      expect_full_error_list
 
       within_fieldset "What was the result?" do
         choose "Fail"
@@ -116,26 +94,13 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
       click_link "Activity"
 
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect(page).to have_text("Failed test: MyBrand washing machine")
-      expect(page).to have_link(product.name, href: product_path(product))
-      expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
-      expect(page).to have_text("Standards: EN71, EN73")
-      expect(page).to have_text("Date of test: 1 January 2020")
-      expect(page).to have_text("Test result includes certificate of conformity")
-      expect(page).to have_link("test_result.txt")
-      expect(page).to have_link("View product details", href: product_path(product))
+      expect_activity_page_to_show_created_test_result_values(result: "Failed")
 
       click_link "View test result"
 
       expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
 
-      expect(page).to have_summary_item(key: "Date of test", value: "1 January 2020")
-      expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
-      expect(page).to have_summary_item(key: "Standards", value: "EN71, EN73")
-      expect(page).to have_summary_item(key: "Result", value: "Failed")
-      expect(page).to have_summary_item(key: "Reason for failure", value: failure_details)
-      expect(page).to have_summary_item(key: "Further details", value: "Test result includes certificate of conformity")
-      expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
+      expect_summary_to_reflect_values(result: "Failed")
 
       expect(page).to have_text("test_result.txt")
 
@@ -198,5 +163,34 @@ RSpec.feature "Adding a test result", :with_stubbed_elasticsearch, :with_stubbed
     within_fieldset "Test report attachment" do
       expect(page).to have_field("Attachment description", with: "\r\ntest result file")
     end
+  end
+
+  def expect_full_error_list
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "Select the legislation that relates to this test"
+    expect(errors_list[1].text).to eq "Enter the standard the product was tested against"
+    expect(errors_list[2].text).to eq "Enter date of the test"
+    expect(errors_list[3].text).to eq "Select result of the test"
+    expect(errors_list[4].text).to eq "Provide the test results file"
+  end
+
+  def expect_summary_to_reflect_values(result:)
+    expect(page).to have_summary_item(key: "Date of test", value: "1 January 2020")
+    expect(page).to have_summary_item(key: "Legislation", value: "General Product Safety Regulations 2005")
+    expect(page).to have_summary_item(key: "Standards", value: "EN71, EN73")
+    expect(page).to have_summary_item(key: "Result", value: result)
+    expect(page).to have_summary_item(key: "Further details", value: "Test result includes certificate of conformity")
+    expect(page).to have_summary_item(key: "Attachment description", value: "test result file")
+  end
+
+  def expect_activity_page_to_show_created_test_result_values(result:)
+    expect(page).to have_text("#{result} test: MyBrand washing machine")
+    expect(page).to have_link(product.name, href: product_path(product))
+    expect(page).to have_text("Legislation: General Product Safety Regulations 2005")
+    expect(page).to have_text("Standards: EN71, EN73")
+    expect(page).to have_text("Date of test: 1 January 2020")
+    expect(page).to have_text("Test result includes certificate of conformity")
+    expect(page).to have_link("test_result.txt")
+    expect(page).to have_link("View product details", href: product_path(product))
   end
 end

--- a/spec/features/edit_test_result_spec.rb
+++ b/spec/features/edit_test_result_spec.rb
@@ -26,8 +26,6 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
   end
 
   def go_edit_test_result
-    sign_in(user)
-
     visit "/cases/#{investigation.pretty_id}/test-results/#{test_result.id}"
 
     click_link "Edit test result"
@@ -41,22 +39,99 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
   end
 
   scenario "Editing a passed test result (with validation errors)" do
+    sign_in(user)
     go_edit_test_result
 
-    # Check that form is pre-filled with existing values
-    expect(page).to have_field("Against which legislation?", with: "General Product Safety Regulations 2005")
-    within_fieldset "Date of test" do
-      expect(page).to have_field("Day", with: "1")
-      expect(page).to have_field("Month", with: "5")
-      expect(page).to have_field("Year", with: "2019")
-    end
-    within_fieldset "What was the result?" do
-      expect(page).to have_checked_field("Pass")
-    end
-    expect(page).to have_field("Further details", with: /\A\s*Provisional\z/)
+    expect_edit_form_to_have_fields_populated_by_original_test_result_values(result: "Pass")
 
-    expect(page).to have_text("Currently selected file: test_result.txt")
+    change_values_in_form
 
+    expect_result_page_to_show_updated_values
+
+    click_link "Back to #{investigation.decorate.pretty_description.downcase}"
+    click_link "Activity"
+
+    expect_activity_page_to_show_edited_test_result_values
+    expect_activity_page_to_show_original_details_from_when_test_result_was_created(original_result: "Passed")
+  end
+
+  context "when editing a failed test result (with validation errors)" do
+    let(:result) { "failed" }
+
+    it "handles old test results with no failure_details" do
+      sign_in(user)
+
+      expect_failed_test_without_failure_details_to_show_not_provided
+
+      go_edit_test_result
+
+      expect_edit_form_to_have_fields_populated_by_original_test_result_values(result: "Fail")
+
+      change_values_in_form
+
+      expect_result_page_to_show_updated_values
+
+      click_link "Back to #{investigation.decorate.pretty_description.downcase}"
+      click_link "Activity"
+
+      expect_activity_page_to_show_edited_test_result_values
+      expect_activity_page_to_show_original_details_from_when_test_result_was_created(original_result: "Failed")
+    end
+  end
+
+  context "with legacy test result" do
+    let(:standards_product_was_tested_against) { nil }
+
+    scenario "legacy test results with no standard tested against should enforce adding the standard" do
+      sign_in(user)
+
+      go_edit_test_result
+
+      click_button "Update test result"
+      expect(page).to have_error_summary "Enter the standard the product was tested against"
+    end
+  end
+
+  def expect_failed_test_without_failure_details_to_show_not_provided
+    visit "/cases/#{investigation.pretty_id}/test-results/#{test_result.id}"
+    expect(page).to have_summary_item(key: "Reason for failure", value: "Not provided")
+  end
+
+  def expect_result_page_to_show_updated_values
+    expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
+
+    expect(page).to have_summary_item(key: "Date of test", value: "2 June 2019")
+    expect(page).to have_summary_item(key: "Legislation", value: "Consumer Protection Act 1987")
+    expect(page).to have_summary_item(key: "Standards", value: "EN72, EN73")
+    expect(page).to have_summary_item(key: "Result", value: "Failed")
+    expect(page).to have_summary_item(key: "Reason for failure", value: failure_details)
+    expect(page).to have_summary_item(key: "Further details", value: "Final result")
+    expect(page).to have_summary_item(key: "Attachment description", value: "Final test result certificate")
+    expect(page).to have_link("test_result_2.txt")
+  end
+
+  def expect_activity_page_to_show_edited_test_result_values
+    activity_card_body = page.find("p", text: "Edited by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
+    expect(activity_card_body).to have_text("Date of test: 2 June 2019")
+    expect(activity_card_body).to have_text("Legislation: Consumer Protection Act 1987")
+    expect(activity_card_body).to have_text("Standards: EN72, EN73")
+    expect(activity_card_body).to have_text("Reason for failure: #{failure_details}")
+    expect(activity_card_body).to have_text("Further details: Final result")
+    expect(activity_card_body).to have_text("Attached: test_result_2.txt")
+    expect(activity_card_body).to have_text("Attachment description: Final test result certificate")
+  end
+
+  def expect_activity_page_to_show_original_details_from_when_test_result_was_created(original_result:)
+    activity_card_body = page.find("p", text: "Test result recorded by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
+    expect(activity_card_body).to have_text("Date of test: 1 May 2019")
+    expect(activity_card_body).to have_text("Legislation: General Product Safety Regulations 2005")
+    expect(activity_card_body).to have_text("Standards: test")
+    expect(activity_card_body).to have_text("Result: #{original_result}")
+    expect(activity_card_body).to have_text("Provisional")
+    expect(activity_card_body).to have_text("Attached: test_result.txt")
+  end
+
+  def change_values_in_form
     # Change some of the fields
     select "Consumer Protection Act 1987", from: "Against which legislation?"
     fill_in "Which standard was the product tested against?", with: "EN72,EN73"
@@ -79,134 +154,20 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
     fill_in "Attachment description", with: "Final test result certificate"
 
     click_button "Update test result"
-
-    expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
-
-    expect(page).to have_summary_item(key: "Date of test", value: "2 June 2019")
-    expect(page).to have_summary_item(key: "Legislation", value: "Consumer Protection Act 1987")
-    expect(page).to have_summary_item(key: "Standards", value: "EN72, EN73")
-    expect(page).to have_summary_item(key: "Result", value: "Failed")
-    expect(page).to have_summary_item(key: "Further details", value: "Final result")
-    expect(page).to have_summary_item(key: "Attachment description", value: "Final test result certificate")
-
-    expect(page).to have_link("test_result_2.txt")
-
-    click_link "Back to #{investigation.decorate.pretty_description.downcase}"
-    click_link "Activity"
-
-    activity_card_body = page.find("p", text: "Edited by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
-    expect(activity_card_body).to have_text("Date of test: 2 June 2019")
-    expect(activity_card_body).to have_text("Legislation: Consumer Protection Act 1987")
-    expect(activity_card_body).to have_text("Standards: EN72, EN73")
-    expect(activity_card_body).to have_text("Result: failed")
-    expect(activity_card_body).to have_text("Further details: Final result")
-    expect(activity_card_body).to have_text("Attached: test_result_2.txt")
-    expect(activity_card_body).to have_text("Attachment description: Final test result certificate")
-
-    # The original result added activity should display the original values
-    activity_card_body = page.find("p", text: "Test result recorded by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
-    expect(activity_card_body).to have_text("Date of test: 1 May 2019")
-    expect(activity_card_body).to have_text("Legislation: General Product Safety Regulations 2005")
-    expect(activity_card_body).to have_text("Standards: test")
-    expect(activity_card_body).to have_text("Result: Passed")
-    expect(activity_card_body).to have_text("Provisional")
-    expect(activity_card_body).to have_text("Attached: test_result.txt")
   end
 
-  context "when editing a failed test result (with validation errors)" do
-    let(:result) { "failed" }
-
-    it "handles old test results with no failure_details" do
-      sign_in(user)
-
-      visit "/cases/#{investigation.pretty_id}/test-results/#{test_result.id}"
-
-      expect(page).to have_summary_item(key: "Reason for failure", value: "Not provided")
-
-      sign_out
-
-      go_edit_test_result
-
-      # Check that form is pre-filled with existing values
-      expect(page).to have_field("Against which legislation?", with: "General Product Safety Regulations 2005")
-      within_fieldset "Date of test" do
-        expect(page).to have_field("Day", with: "1")
-        expect(page).to have_field("Month", with: "5")
-        expect(page).to have_field("Year", with: "2019")
-      end
-      within_fieldset "What was the result?" do
-        expect(page).to have_checked_field("Fail")
-      end
-      expect(page).to have_field("Further details", with: /\A\s*Provisional\z/)
-
-      expect(page).to have_text("Currently selected file: test_result.txt")
-
-      # Change some of the fields
-      select "Consumer Protection Act 1987", from: "Against which legislation?"
-      fill_in "Which standard was the product tested against?", with: "EN72,EN73"
-
-      within_fieldset "Date of test" do
-        fill_in "Day",   with: "2"
-        fill_in "Month", with: "6"
-      end
-
-      within_fieldset "What was the result?" do
-        choose "Fail"
-        fill_in "How the product failed", with: failure_details
-      end
-
-      fill_in "Further details", with: "Final result"
-
-      find("details > summary", text: "Replace this file").click
-
-      attach_file "Upload a file", Rails.root + "test/fixtures/files/test_result_2.txt"
-      fill_in "Attachment description", with: "Final test result certificate"
-
-      click_button "Update test result"
-
-      expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
-
-      expect(page).to have_summary_item(key: "Date of test", value: "2 June 2019")
-      expect(page).to have_summary_item(key: "Legislation", value: "Consumer Protection Act 1987")
-      expect(page).to have_summary_item(key: "Standards", value: "EN72, EN73")
-      expect(page).to have_summary_item(key: "Result", value: "Failed")
-      expect(page).to have_summary_item(key: "Reason for failure", value: failure_details)
-      expect(page).to have_summary_item(key: "Further details", value: "Final result")
-      expect(page).to have_summary_item(key: "Attachment description", value: "Final test result certificate")
-
-      expect(page).to have_link("test_result_2.txt")
-
-      click_link "Back to #{investigation.decorate.pretty_description.downcase}"
-      click_link "Activity"
-
-      activity_card_body = page.find("p", text: "Edited by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
-      expect(activity_card_body).to have_text("Date of test: 2 June 2019")
-      expect(activity_card_body).to have_text("Legislation: Consumer Protection Act 1987")
-      expect(activity_card_body).to have_text("Standards: EN72, EN73")
-      expect(activity_card_body).to have_text("Reason for failure: #{failure_details}")
-      expect(activity_card_body).to have_text("Further details: Final result")
-      expect(activity_card_body).to have_text("Attached: test_result_2.txt")
-      expect(activity_card_body).to have_text("Attachment description: Final test result certificate")
-
-      # The original result added activity should display the original values
-      activity_card_body = page.find("p", text: "Test result recorded by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
-      expect(activity_card_body).to have_text("Date of test: 1 May 2019")
-      expect(activity_card_body).to have_text("Legislation: General Product Safety Regulations 2005")
-      expect(activity_card_body).to have_text("Standards: test")
-      expect(activity_card_body).to have_text("Result: Failed")
-      expect(activity_card_body).to have_text("Provisional")
-      expect(activity_card_body).to have_text("Attached: test_result.txt")
+  def expect_edit_form_to_have_fields_populated_by_original_test_result_values(result:)
+    expect(page).to have_field("Against which legislation?", with: "General Product Safety Regulations 2005")
+    within_fieldset "Date of test" do
+      expect(page).to have_field("Day", with: "1")
+      expect(page).to have_field("Month", with: "5")
+      expect(page).to have_field("Year", with: "2019")
     end
-  end
-
-  context "with legacy test result" do
-    let(:standards_product_was_tested_against) { nil }
-
-    scenario "legacy test results with no standard tested against should enforce adding the standard" do
-      go_edit_test_result
-
-      click_button "Update test result"
-      expect(page).to have_error_summary "Enter the standard the product was tested against"
+    within_fieldset "What was the result?" do
+      expect(page).to have_checked_field(result)
     end
+    expect(page).to have_field("Further details", with: /\A\s*Provisional\z/)
+
+    expect(page).to have_text("Currently selected file: test_result.txt")
   end
 end

--- a/spec/features/edit_test_result_spec.rb
+++ b/spec/features/edit_test_result_spec.rb
@@ -68,6 +68,7 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
 
     within_fieldset "What was the result?" do
       choose "Fail"
+      fill_in "How the product failed", with: failure_details
     end
 
     fill_in "Further details", with: "Final result"

--- a/spec/features/edit_test_result_spec.rb
+++ b/spec/features/edit_test_result_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
   let(:product2) { create(:product_washing_machine, name: "MyBrand blue washing machine") }
   let(:investigation) { create(:allegation, products: [product1, product2], creator: user) }
   let(:standards_product_was_tested_against) { %w[test] }
+  let(:failure_details) { "Something terrible happened" }
+  let(:result) { "passed" }
 
   let!(:test_result) do
     AddTestResultToInvestigation.call!(
@@ -16,7 +18,7 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
       date: Date.parse("2019-05-01"),
       legislation: "General Product Safety Regulations 2005",
       details: "Provisional",
-      result: "passed",
+      result: result,
       product_id: product1.id,
       document: fixture_file_upload("test_result.txt"),
       standards_product_was_tested_against: standards_product_was_tested_against
@@ -38,7 +40,7 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
     click_link "Edit test result"
   end
 
-  scenario "Editing a test result (with validation errors)" do
+  scenario "Editing a passed test result (with validation errors)" do
     go_edit_test_result
 
     # Check that form is pre-filled with existing values
@@ -108,6 +110,102 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
     expect(activity_card_body).to have_text("Result: Passed")
     expect(activity_card_body).to have_text("Provisional")
     expect(activity_card_body).to have_text("Attached: test_result.txt")
+  end
+
+  context "with legacy test result" do
+    let(:standards_product_was_tested_against) { nil }
+
+    scenario "legacy test results with no standard tested against should enforce adding the standard" do
+      go_edit_test_result
+
+      click_button "Update test result"
+      expect(page).to have_error_summary "Enter the standard the product was tested against"
+    end
+  end
+
+  context "Editing a failed test result (with validation errors)" do
+    let(:result) { "failed" }
+    it 'handles old test results with no failure_details' do
+      sign_in(user)
+
+      visit "/cases/#{investigation.pretty_id}/test-results/#{test_result.id}"
+
+      expect(page).to have_summary_item(key: "Reason for failure", value: "Not provided")
+
+      sign_out
+
+      go_edit_test_result
+
+      # Check that form is pre-filled with existing values
+      expect(page).to have_field("Against which legislation?", with: "General Product Safety Regulations 2005")
+      within_fieldset "Date of test" do
+        expect(page).to have_field("Day", with: "1")
+        expect(page).to have_field("Month", with: "5")
+        expect(page).to have_field("Year", with: "2019")
+      end
+      within_fieldset "What was the result?" do
+        expect(page).to have_checked_field("Fail")
+      end
+      expect(page).to have_field("Further details", with: /\A\s*Provisional\z/)
+
+      expect(page).to have_text("Currently selected file: test_result.txt")
+
+      # Change some of the fields
+      select "Consumer Protection Act 1987", from: "Against which legislation?"
+      fill_in "Which standard was the product tested against?", with: "EN72,EN73"
+
+      within_fieldset "Date of test" do
+        fill_in "Day",   with: "2"
+        fill_in "Month", with: "6"
+      end
+
+      within_fieldset "What was the result?" do
+        choose "Fail"
+        fill_in "How the product failed", with: failure_details
+      end
+
+      fill_in "Further details", with: "Final result"
+
+      find("details > summary", text: "Replace this file").click
+
+      attach_file "Upload a file", Rails.root + "test/fixtures/files/test_result_2.txt"
+      fill_in "Attachment description", with: "Final test result certificate"
+
+      click_button "Update test result"
+
+      expect_to_be_on_test_result_page(case_id: investigation.pretty_id)
+
+      expect(page).to have_summary_item(key: "Date of test", value: "2 June 2019")
+      expect(page).to have_summary_item(key: "Legislation", value: "Consumer Protection Act 1987")
+      expect(page).to have_summary_item(key: "Standards", value: "EN72, EN73")
+      expect(page).to have_summary_item(key: "Result", value: "Failed")
+      expect(page).to have_summary_item(key: "Reason for failure", value: failure_details)
+      expect(page).to have_summary_item(key: "Further details", value: "Final result")
+      expect(page).to have_summary_item(key: "Attachment description", value: "Final test result certificate")
+
+      expect(page).to have_link("test_result_2.txt")
+
+      click_link "Back to #{investigation.decorate.pretty_description.downcase}"
+      click_link "Activity"
+
+      activity_card_body = page.find("p", text: "Edited by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
+      expect(activity_card_body).to have_text("Date of test: 2 June 2019")
+      expect(activity_card_body).to have_text("Legislation: Consumer Protection Act 1987")
+      expect(activity_card_body).to have_text("Standards: EN72, EN73")
+      expect(activity_card_body).to have_text("Reason for failure: #{failure_details}")
+      expect(activity_card_body).to have_text("Further details: Final result")
+      expect(activity_card_body).to have_text("Attached: test_result_2.txt")
+      expect(activity_card_body).to have_text("Attachment description: Final test result certificate")
+
+      # The original result added activity should display the original values
+      activity_card_body = page.find("p", text: "Test result recorded by #{UserSource.new(user: investigation.creator_user).show(user)}").find(:xpath, "..")
+      expect(activity_card_body).to have_text("Date of test: 1 May 2019")
+      expect(activity_card_body).to have_text("Legislation: General Product Safety Regulations 2005")
+      expect(activity_card_body).to have_text("Standards: test")
+      expect(activity_card_body).to have_text("Result: Failed")
+      expect(activity_card_body).to have_text("Provisional")
+      expect(activity_card_body).to have_text("Attached: test_result.txt")
+    end
   end
 
   context "with legacy test result" do

--- a/spec/features/edit_test_result_spec.rb
+++ b/spec/features/edit_test_result_spec.rb
@@ -113,20 +113,10 @@ RSpec.feature "Editing a test result", :with_stubbed_elasticsearch, :with_stubbe
     expect(activity_card_body).to have_text("Attached: test_result.txt")
   end
 
-  context "with legacy test result" do
-    let(:standards_product_was_tested_against) { nil }
-
-    scenario "legacy test results with no standard tested against should enforce adding the standard" do
-      go_edit_test_result
-
-      click_button "Update test result"
-      expect(page).to have_error_summary "Enter the standard the product was tested against"
-    end
-  end
-
-  context "Editing a failed test result (with validation errors)" do
+  context "when editing a failed test result (with validation errors)" do
     let(:result) { "failed" }
-    it 'handles old test results with no failure_details' do
+
+    it "handles old test results with no failure_details" do
       sign_in(user)
 
       visit "/cases/#{investigation.pretty_id}/test-results/#{test_result.id}"

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -90,7 +90,8 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
       legislation: Rails.application.config.legislation_constants["legislation"].sample,
       standards_product_was_tested_against: "EN71, EN73",
       date: Faker::Date.backward(days: 14),
-      result: "Pass",
+      result: %w[Pass Fail].sample,
+      failure_details: "Additional details",
       details: Faker::Lorem.sentence,
       file: Rails.root + "test/fixtures/files/test_result.txt"
     }
@@ -673,6 +674,10 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
     fill_in "Month", with: with[:date].month
     fill_in "Year", with: with[:date].year
     choose with[:result] if with[:result]
+
+    if with[:result] == "Fail"
+      fill_in "How the product failed", with: with[:failure_details]
+    end
 
     fill_in "Further details", with: with[:details]
 

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
       legislation: Rails.application.config.legislation_constants["legislation"].sample,
       standards_product_was_tested_against: "EN71, EN73",
       date: Faker::Date.backward(days: 14),
-      result: %w[Pass Fail].sample,
+      result: "Pass",
       details: Faker::Lorem.sentence,
       file: Rails.root + "test/fixtures/files/test_result.txt"
     }


### PR DESCRIPTION
https://trello.com/c/bJzV65vE/897-5-add-conditional-reveal-text-area-to-failed-test-result

## Description
Add a conditionally revealed text box so that users can enter information about failed text results

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
