### PR TITLE
Show an error message on the add corrective action form if no product is selected

### DIFF
--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -16,7 +16,7 @@ module Investigations
       @corrective_action_form = CorrectiveActionForm.new(corrective_action_params)
 
       @investigation = investigation.decorate
-      return render :new if @corrective_action_form.invalid?
+      return render :new if @corrective_action_form.invalid?(:add_corrective_action)
 
       result = AddCorrectiveActionToCase.call(
         @corrective_action_form
@@ -57,7 +57,7 @@ module Investigations
 
       @corrective_action_form.assign_attributes(corrective_action_params)
 
-      return render :edit if @corrective_action_form.invalid?
+      return render :edit if @corrective_action_form.invalid?(:edit_corrective_action)
 
       result = UpdateCorrectiveAction.call(
         @corrective_action_form

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -29,6 +29,7 @@ class CorrectiveActionForm
   attribute :file_description
   attribute :further_corrective_action, :boolean
 
+  validates :product_id, presence: true
   validates :date_decided,
             presence: true,
             real_date: true,

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -29,7 +29,7 @@ class CorrectiveActionForm
   attribute :file_description
   attribute :further_corrective_action, :boolean
 
-  validates :product_id, presence: true
+  validates :product_id, presence: true, on: %i[add_corrective_action edit_corrective_action]
   validates :date_decided,
             presence: true,
             real_date: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,8 +453,8 @@ en:
               in_future: Date of call must be today or in the past
         corrective_action_form:
           attributes:
-            product:
-              required: "Select the product the corrective action relates to"
+            product_id:
+              blank: "Select the product the corrective action relates to"
             date_decided:
               blank: "Enter date the corrective action was decided"
               must_be_real: "Enter a real date when the corrective action was decided"

--- a/spec/features/add_corrective_action_spec.rb
+++ b/spec/features/add_corrective_action_spec.rb
@@ -13,6 +13,23 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     end
   end
 
+  context "with no product added to the case" do
+    let(:products) { [] }
+
+    scenario "shows errors" do
+      sign_in(user)
+
+      visit "/cases/#{investigation.pretty_id}/corrective-actions/new"
+
+      expect(page).to have_text("There are no products on this case.")
+
+      click_button "Continue"
+
+      expect(page).to have_error_messages
+      expect(page).to have_error_summary "Select the product the corrective action relates to"
+    end
+  end
+
   scenario "Adding a corrective action (with validation errors)" do
     sign_in(user)
 

--- a/spec/forms/corrective_action_form_spec.rb
+++ b/spec/forms/corrective_action_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
       geographic_scopes: geographic_scopes,
       details: details,
       related_file: related_file,
-      product_id: create(:product).id,
+      product_id: product_id,
       business_id: create(:business).id,
       has_online_recall_information: has_online_recall_information,
       online_recall_information: online_recall_information,
@@ -21,6 +21,7 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
     ).tap(&:valid?)
   end
 
+  let(:product_id) { create(:product).id }
   let(:file) { fixture_file_upload(file_fixture("corrective_action.txt")) }
   let(:file_description) { Faker::Hipster.sentence }
   let(:file_form) { { file: file, description: file_description } }
@@ -63,6 +64,14 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
     context "with valid input" do
       it "returns true" do
         expect(corrective_action_form).to be_valid
+      end
+    end
+
+    context "without a product" do
+      let(:product_id) { nil }
+
+      it "returns false" do
+        expect(corrective_action_form).not_to be_valid
       end
     end
 

--- a/spec/forms/corrective_action_form_spec.rb
+++ b/spec/forms/corrective_action_form_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
       business_id: create(:business).id,
       has_online_recall_information: has_online_recall_information,
       online_recall_information: online_recall_information,
-      file: file_form
+      file: file_form,
+      further_corrective_action: further_corrective_action
     ).tap(&:valid?)
   end
 
@@ -37,6 +38,7 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
   let(:investigation) { build(:allegation) }
   let(:has_online_recall_information) { CorrectiveAction.has_online_recall_informations["has_online_recall_information_no"] }
   let(:online_recall_information) { nil }
+  let(:further_corrective_action) { false }
 
   describe ".from" do
     subject(:corrective_action_form) { described_class.from(corrective_action) }
@@ -70,8 +72,28 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
     context "without a product" do
       let(:product_id) { nil }
 
-      it "returns false" do
-        expect(corrective_action_form).not_to be_valid
+      context "with add_corrective_action custom context" do
+        it "returns false" do
+          expect(corrective_action_form).not_to be_valid(:add_corrective_action)
+        end
+      end
+
+      context "with edit_corrective_action custom context" do
+        it "returns false" do
+          expect(corrective_action_form).not_to be_valid(:edit_corrective_action)
+        end
+      end
+
+      context "with ts_flow custom context" do
+        it "returns true" do
+          expect(corrective_action_form).to be_valid(:ts_flow)
+        end
+      end
+
+      context "with no custom context" do
+        it "returns true" do
+          expect(corrective_action_form).to be_valid
+        end
       end
     end
 

--- a/spec/support/shared_contexts/add_corrective_action_context.rb
+++ b/spec/support/shared_contexts/add_corrective_action_context.rb
@@ -1,7 +1,8 @@
 RSpec.shared_context "with add corrective action setup" do
   let(:user) { create(:user, :activated, has_viewed_introduction: true) }
   let(:product) { create(:product_washing_machine, name: "MyBrand Washing Machine") }
-  let(:investigation) { create(:allegation, :with_business, products: [product], creator: user, read_only_teams: read_only_team) }
+  let(:products) { [product] }
+  let(:investigation) { create(:allegation, :with_business, products: products, creator: user, read_only_teams: read_only_team) }
   let(:business) { investigation.businesses.first }
   let(:action_key) { (CorrectiveAction.actions.keys - %w[other]).sample }
   let(:action) { CorrectiveAction.actions[action_key] }


### PR DESCRIPTION
https://trello.com/c/BMudIxj2/928-corrective-action-without-product-returns-422-error
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
It appears this validation was not implemented on the form object.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
