### PR TITLE
Bump CloudFoundry Ruby buildpack and dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -680,4 +680,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.4
+   2.2.9

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
   yarn \
   unzip
 
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.2.9
 
 WORKDIR /psd
 

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.28
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.31
   path: .
   stack: cflinuxfs3
   routes:

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.28
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.31
   path: .
   stack: cflinuxfs3
   routes:


### PR DESCRIPTION
Bumps the Ruby buildpack to the latest version 1.8.31 as per https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.31

Consequently the Bundler version has been updated which resolves an error caused by a previous dependency update bumping the Bundler version erroneously.