### PR TITLE
populate missing corrective action id in corrective action added audit

### DIFF
--- a/db/migrate/20210223114010_fix_corrective_action_audit_activity.rb
+++ b/db/migrate/20210223114010_fix_corrective_action_audit_activity.rb
@@ -2,17 +2,17 @@ class FixCorrectiveActionAuditActivity < ActiveRecord::Migration[6.1]
   def change
     safety_assured do
       reversible do |dir|
-        dir.up {
+        dir.up do
           AuditActivity::CorrectiveAction::Add.where("metadata->'corrective_action'->>'id' IS NULL").find_each do |audit_activity|
-          if audit_activity.corrective_action.present?
-            audit_activity.metadata["corrective_action"]["id"] = audit_activity.corrective_action.id
-            audit_activity.save!
-          elsif audit_activity.investigation.corrective_actions.one?
-            audit_activity.metadata["corrective_action"]["id"] = audit_activity.investigation.corrective_action_ids.first
-            audit_activity.save!
+            if audit_activity.corrective_action.present?
+              audit_activity.metadata["corrective_action"]["id"] = audit_activity.corrective_action.id
+              audit_activity.save!
+            elsif audit_activity.investigation.corrective_actions.one?
+              audit_activity.metadata["corrective_action"]["id"] = audit_activity.investigation.corrective_action_ids.first
+              audit_activity.save!
+            end
           end
         end
-        }
       end
     end
   end

--- a/db/migrate/20210223114010_fix_corrective_action_audit_activity.rb
+++ b/db/migrate/20210223114010_fix_corrective_action_audit_activity.rb
@@ -1,0 +1,19 @@
+class FixCorrectiveActionAuditActivity < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up {
+          AuditActivity::CorrectiveAction::Add.where("metadata->'corrective_action'->>'id' IS NULL").find_each do |audit_activity|
+          if audit_activity.corrective_action.present?
+            audit_activity.metadata["corrective_action"]["id"] = audit_activity.corrective_action.id
+            audit_activity.save!
+          elsif audit_activity.investigation.corrective_actions.one?
+            audit_activity.metadata["corrective_action"]["id"] = audit_activity.investigation.corrective_action_ids.first
+            audit_activity.save!
+          end
+        end
+        }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_134638) do
+ActiveRecord::Schema.define(version: 2021_02_23_114010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
back populate corrective action id in audit activity.

This only addresses audit activities for which we can find the corrective action

I will address the others in a separate PR 