### PR TITLE
fix duration and measure type ƒor corrective action added audit

### DIFF
--- a/db/migrate/20210223151528_fix_duration.rb
+++ b/db/migrate/20210223151528_fix_duration.rb
@@ -1,0 +1,14 @@
+class FixDuration < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up do
+          AuditActivity::CorrectiveAction::Add.where("metadata->'corrective_action'->>'duration' IN (?)", CorrectiveAction::DURATION_TYPES.map(&:titleize)).find_each do |audit_activity|
+            audit_activity.metadata["corrective_action"]["duration"] = audit_activity.metadata["corrective_action"]["duration"].downcase
+            audit_activity.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210223155926_fix_measure_type.rb
+++ b/db/migrate/20210223155926_fix_measure_type.rb
@@ -1,0 +1,14 @@
+class FixMeasureType < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up do
+          AuditActivity::CorrectiveAction::Add.where("metadata->'corrective_action'->>'measure' IN (?)", CorrectiveAction::MEASURE_TYPES.map(&:titleize)).find_each do |audit_activity|
+            audit_activity.metadata["corrective_action"]["measure_type"] = audit_activity.metadata["corrective_action"]["measure"].downcase
+            audit_activity.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_151528) do
+ActiveRecord::Schema.define(version: 2021_02_23_155926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_134638) do
+ActiveRecord::Schema.define(version: 2021_02_23_151528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Couple fixes: 

1. previous migration migrated `measure_type` under the key measure and used the capitalised value. This now migrated to the correct key and the downcased value.
2. Downcase values for duration