### PR TITLE
Fix change case owner form throwing exception when there are validation errors

### DIFF
--- a/app/controllers/investigations/ownership_controller.rb
+++ b/app/controllers/investigations/ownership_controller.rb
@@ -19,7 +19,11 @@ class Investigations::OwnershipController < ApplicationController
   end
 
   def update
-    return render_wizard unless form.valid?
+    unless form.valid?
+      get_potential_assignees if step == :"select-owner"
+      @investigation = @investigation.decorate
+      return render_wizard
+    end
 
     session[session_store_key] = form.attributes.compact
     redirect_to next_wizard_path
@@ -50,20 +54,20 @@ private
   end
 
   def form_params
-    params[:investigation] ||= {}
-    params[:investigation][:owner_id] = case params[:investigation][:owner_id]
-                                        when "someone_in_your_team"
-                                          params[:investigation][:select_team_member]
-                                        when "previous_owners"
-                                          params[:investigation][:select_previous_owner]
-                                        when "other_team"
-                                          params[:investigation][:select_other_team]
-                                        when "someone_else"
-                                          params[:investigation][:select_someone_else]
-                                        else
-                                          params[:investigation][:owner_id]
-                                        end
-    params.require(:investigation).permit(:owner_id, :owner_rationale).merge(session_params)
+    params[:change_case_owner_form] ||= {}
+    params[:change_case_owner_form][:owner_id] = case params[:change_case_owner_form][:owner_id]
+                                                 when "someone_in_your_team"
+                                                   params[:change_case_owner_form][:select_team_member]
+                                                 when "previous_owners"
+                                                   params[:change_case_owner_form][:select_previous_owner]
+                                                 when "other_team"
+                                                   params[:change_case_owner_form][:select_other_team]
+                                                 when "someone_else"
+                                                   params[:change_case_owner_form][:select_someone_else]
+                                                 else
+                                                   params[:change_case_owner_form][:owner_id]
+                                                 end
+    params.require(:change_case_owner_form).permit(:owner_id, :owner_rationale).merge(session_params)
   end
 
   def session_params

--- a/app/views/investigations/ownership/_owner_form.html.erb
+++ b/app/views/investigations/ownership/_owner_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(scope: :investigation, model: investigation, method: :put, url: wizard_path, local: true) do |form| %>
+<%= form_with(model: change_case_owner_form, method: :put, url: wizard_path, local: true) do |form| %>
   <%= render "form_components/govuk_error_summary", form: form %>
   <%= yield %>
 

--- a/app/views/investigations/ownership/confirm.html.erb
+++ b/app/views/investigations/ownership/confirm.html.erb
@@ -10,8 +10,8 @@
 <%= render "investigations/pages_top", investigation: @investigation %>
 
 <%= form_with(
-      scope: :investigation,
-      model: @investigation,
+      scope: :change_case_owner_form,
+      model: @form,
       local: true,
       url: investigation_ownership_index_path(@investigation),
       method: :post

--- a/app/views/investigations/ownership/select-owner.html.erb
+++ b/app/views/investigations/ownership/select-owner.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= render "investigations/ownership/owner_form", investigation: @investigation do %>
+    <%= render "investigations/ownership/owner_form", investigation: @investigation, change_case_owner_form: @form do %>
       <%= render "minimal_investigation_heading", investigation: @investigation, title: page_heading %>
       <% if @investigation.owner.present? %>
         <p>Current case owner: <strong><%= @investigation.owner.decorate.display_name(viewer: current_user) %></strong></p>

--- a/spec/features/change_ownership_for_investigation_spec.rb
+++ b/spec/features/change_ownership_for_investigation_spec.rb
@@ -17,14 +17,14 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
   end
 
   scenario "does not show inactive users or teams" do
-    expect(page).to have_css("#investigation_select_team_member option[value=\"#{another_active_user.id}\"]")
-    expect(page).not_to have_css("#investigation_select_team_member option[value=\"#{another_inactive_user.id}\"]")
+    expect(page).to have_css("#change_case_owner_form_select_team_member option[value=\"#{another_active_user.id}\"]")
+    expect(page).not_to have_css("#change_case_owner_form_select_team_member option[value=\"#{another_inactive_user.id}\"]")
 
-    expect(page).to have_css("#investigation_select_other_team option[value=\"#{another_active_user_another_team.team.id}\"]")
-    expect(page).not_to have_css("#investigation_select_other_team option[value=\"#{deleted_team.id}\"]")
+    expect(page).to have_css("#change_case_owner_form_select_other_team option[value=\"#{another_active_user_another_team.team.id}\"]")
+    expect(page).not_to have_css("#change_case_owner_form_select_other_team option[value=\"#{deleted_team.id}\"]")
 
-    expect(page).to have_css("#investigation_select_someone_else option[value=\"#{another_active_user_another_team.id}\"]")
-    expect(page).not_to have_css("#investigation_select_someone_else option[value=\"#{another_inactive_user_another_team.id}\"]")
+    expect(page).to have_css("#change_case_owner_form_select_someone_else option[value=\"#{another_active_user_another_team.id}\"]")
+    expect(page).not_to have_css("#change_case_owner_form_select_someone_else option[value=\"#{another_inactive_user_another_team.id}\"]")
   end
 
   scenario "change owner to the same user" do
@@ -37,8 +37,15 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
   end
 
   scenario "change owner to other user in same team" do
+    # Test validation errors
     choose("Someone in your team")
-    select another_active_user.name, from: "investigation_select_team_member"
+
+    click_button "Continue"
+
+    expect(page).to have_summary_error("Select case owner")
+
+    choose("Someone in your team")
+    select another_active_user.name, from: "change_case_owner_form_select_team_member"
     click_button "Continue"
 
     fill_and_submit_change_owner_reason_form
@@ -61,7 +68,7 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
 
   scenario "a case owned by someone else in another team can no longer have ownership changed by original owner" do
     choose("Someone else")
-    select another_active_user_another_team.name, from: "investigation_select_someone_else"
+    select another_active_user_another_team.name, from: "change_case_owner_form_select_someone_else"
     click_button "Continue"
 
     fill_and_submit_change_owner_reason_form
@@ -74,7 +81,7 @@ RSpec.feature "Changing ownership for an investigation", :with_stubbed_elasticse
   end
 
   def fill_and_submit_change_owner_reason_form
-    fill_in "investigation_owner_rationale", with: "Test assign"
+    fill_in "change_case_owner_form_owner_rationale", with: "Test assign"
     click_button "Confirm change"
   end
 

--- a/spec/requests/investigations/changing_owner_spec.rb
+++ b/spec/requests/investigations/changing_owner_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
       sign_in user_from_owner_team
       put investigation_ownership_path(investigation, "select-owner"),
           params: {
-            investigation: {
+            change_case_owner_form: {
               owner_id: "someone_else",
               select_someone_else: other_user.id
             }
@@ -41,7 +41,7 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
       sign_in user_from_collaborator_team
       put investigation_ownership_path(investigation, "select-owner"),
           params: {
-            investigation: {
+            change_case_owner_form: {
               owner_id: "someone_else",
               select_someone_else: other_user.id
             }
@@ -58,7 +58,7 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
       sign_in other_user
       put investigation_ownership_path(investigation, "select-owner"),
           params: {
-            investigation: {
+            change_case_owner_form: {
               owner_id: "someone_else",
               select_someone_else: other_user.id
             }


### PR DESCRIPTION
https://trello.com/c/18nh0SjX/944-500-error-on-change-case-owner-form-when-submitted-incomplete

Bug fix for the form when validation errors are present.

Example exception thrown:

https://sentry.io/organizations/beis/issues/2246201384

In this case it appears the user submitted the form having selected 'someone in your team' without selecting a user from the dropdown.

The controller and view were not set up correctly to display the relevant error. This is now fixed.

I have also expanded the relevant feature spec to cover error handling.

Note: there is another bug with this form where the previous input is not pre-filled when showing errors. For example, select 'Someone in your team' but do not select anything from the dropdown. 'Someone in your team' is no longer checked. I think this would need a much bigger refactoring of the code so I've not fixed that here as it can be tackled separately.