### PR TITLE
Update ffi gem to fix CI issues

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -22,9 +22,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
+      uses: ruby/setup-ruby@v1
     - name: install dependencies
       run: |
         gem install bundler --no-doc

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -51,9 +51,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
+      uses: ruby/setup-ruby@v1
 
     - name: Set up Node
       uses: actions/setup-node@v1

--- a/.github/workflows/security-warnings.yml
+++ b/.github/workflows/security-warnings.yml
@@ -10,8 +10,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
     - name: Install brakeman
       run: gem install brakeman
     - name: Run brakeman

--- a/.github/workflows/security-warnings.yml
+++ b/.github/workflows/security-warnings.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.x
     - name: Install brakeman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    ffi (1.14.2)
+    ffi (1.15.0)
     fugit (1.3.4)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)


### PR DESCRIPTION
## Description
Manually updated the ffi gem. Fixes a problem with it not finding required libraries when running the Rspec suite in GitHub actions.

The [actions/setup-ruby](https://github.com/actions/setup-ruby) GitHub action has been deprecated in favour of [ruby/setup-ruby](https://github.com/ruby/setup-ruby) so I have also updated this.

Specifying the Ruby version is not necessary due to the presence of the .ruby-version file.