### PR TITLE
Fix corrective action added audit with empty decided date

### DIFF
--- a/app/models/audit_activity/corrective_action/add.rb
+++ b/app/models/audit_activity/corrective_action/add.rb
@@ -56,6 +56,8 @@ class AuditActivity::CorrectiveAction::Add < AuditActivity::CorrectiveAction::Ba
         corrective_action_attributes[:legislation] = Regexp.last_match(1)
       when /\ADate came into effect: \*\*(.*)\*\*\z/
         corrective_action_attributes[:date_decided] = Date.parse(Regexp.last_match(1))
+      when /\ADate decided: \*\*(.*)\*\*\z/
+        corrective_action_attributes[:date_decided] = Date.parse(Regexp.last_match(1))
       when /\AType of measure: \*\*(.*)\*\*\z/
         corrective_action_attributes[:measure_type] = Regexp.last_match(1)
       when /\ADuration of action: \*\*(.*)\*\*\z/

--- a/db/migrate/20210309114228_fix_empty_decided_date_in_corrective_action_audit_added.rb
+++ b/db/migrate/20210309114228_fix_empty_decided_date_in_corrective_action_audit_added.rb
@@ -1,0 +1,24 @@
+class FixEmptyDecidedDateInCorrectiveActionAuditAdded < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      reversible do |dir|
+        dir.up { migrate_legacy_audit_record }
+      end
+    end
+  end
+
+private
+
+  def migrate_legacy_audit_record
+    unmigrated_audits = []
+    AuditActivity::CorrectiveAction::Add.where(metadata: nil).find_each do |audit_activity|
+      audit_activity.update!(metadata: AuditActivity::CorrectiveAction::Add.metadata_from_legacy_audit_activity(audit_activity))
+    rescue StandardError => e
+      Rails.logger.error(e)
+      unmigrated_audits << audit_activity.id
+    end
+
+    Rails.logger.info("Audit not migrated:")
+    Rails.logger.info(unmigrated_audits.join(", "))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_113829) do
+ActiveRecord::Schema.define(version: 2021_03_09_114228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Description 

In the previous audit log migration some of the newest audit recorded in the `body` field had `Date decided: `  instead of the previous `Date came into effect: `

This PR address those 200 records