### PR TITLE
Change copy for corrective action form validation messages

### DIFF
--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -33,8 +33,7 @@ class CorrectiveActionForm
   validates :date_decided,
             presence: true,
             real_date: true,
-            complete_date: true,
-            not_in_future: true
+            complete_date: true
   validates :legislation, presence: { message: "Select the legislation relevant to the corrective action" }
   validates :related_file, inclusion: { in: [true, false], message: "Select whether you want to upload a related file" }
   validate :related_file_attachment_validation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -458,10 +458,10 @@ en:
             product_id:
               blank: "Select the product the corrective action relates to"
             date_decided:
-              blank: "Enter date the corrective action was decided"
-              must_be_real: "Enter a real date when the corrective action was decided"
-              incomplete: "Enter date the corrective action was decided and include %{missing_date_parts}"
-              in_future: "Date decided must be today or in the past"
+              blank: "Enter the date the corrective action came into effect"
+              must_be_real: "Enter a real date when the corrective action came into effect"
+              incomplete: "The date the corrective action came into effect must include a %{missing_date_parts}"
+              in_future: "The date the corrective action came into effect must be today or in the past"
             further_corrective_action:
               inclusion: "Select whether or not you have further corrective action to record"
             measure_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,7 +461,6 @@ en:
               blank: "Enter the date the corrective action came into effect"
               must_be_real: "Enter a real date when the corrective action came into effect"
               incomplete: "The date the corrective action came into effect must include a %{missing_date_parts}"
-              in_future: "The date the corrective action came into effect must be today or in the past"
             further_corrective_action:
               inclusion: "Select whether or not you have further corrective action to record"
             measure_type:

--- a/spec/features/add_corrective_action_spec.rb
+++ b/spec/features/add_corrective_action_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_elasticsearc
     expect(page).to have_error_messages
     errors_list = page.find(".govuk-error-summary__list").all("li")
     expect(errors_list[0].text).to eq "Select type of corrective action"
-    expect(errors_list[1].text).to eq "Enter date the corrective action was decided"
+    expect(errors_list[1].text).to eq "Enter the date the corrective action came into effect"
     expect(errors_list[2].text).to eq "Select the legislation relevant to the corrective action"
     expect(errors_list[3].text).to eq "Select yes if the business responsible has published recall information online"
     expect(errors_list[4].text).to eq "You must state whether the action is mandatory or voluntary"

--- a/spec/features/edit_corrective_action_spec.rb
+++ b/spec/features/edit_corrective_action_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Edit corrective action", :with_stubbed_elasticsearch, :with_stubb
       fill_in "Year", with: ""
       click_on "Update corrective action"
 
-      expect(page).to have_error_summary("Enter date the corrective action was decided and include year")
+      expect(page).to have_error_summary("The date the corrective action came into effect must include a year")
 
       within_fieldset("Are there any files related to the action?") do
         expect(page).to have_checked_field("Yes")

--- a/spec/forms/corrective_action_form_spec.rb
+++ b/spec/forms/corrective_action_form_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
   describe "#valid?" do
     let(:form) { corrective_action_form }
 
-    it_behaves_like "it does not allow dates in the future", :date_decided
     it_behaves_like "it does not allow malformed dates", :date_decided
     it_behaves_like "it does not allow an incomplete", :date_decided
 
@@ -132,14 +131,6 @@ RSpec.describe CorrectiveActionForm, :with_stubbed_elasticsearch, :with_stubbed_
 
     context "with details longer than 50,000 characters" do
       let(:details) { Faker::Lorem.characters(number: 50_001) }
-
-      it "returns false" do
-        expect(corrective_action_form).not_to be_valid
-      end
-    end
-
-    context "with future date_decided" do
-      let(:date_decided) { Faker::Date.forward(days: 14) }
 
       it "returns false" do
         expect(corrective_action_form).not_to be_valid


### PR DESCRIPTION
https://trello.com/c/CSCz4DV5/943-fix-date-field-validation-in-corrective-action-form

## Description
Changes the copy to better reflect the naming of the field. Also removes the incorrect validation requiring the date to not be in the future, contradicting the hint text.