### PR TITLE
Add peterborough.gov.uk to email domain whitelist

### DIFF
--- a/config/constants/whitelisted_emails.yml
+++ b/config/constants/whitelisted_emails.yml
@@ -138,6 +138,7 @@ email_domains:
   - "orkney.gov.uk"
   - "oxfordshire.gov.uk"
   - "pembrokeshire.gov.uk"
+  - "peterborough.gov.uk"
   - "pkc.gov.uk"
   - "plymouth.gov.uk"
   - "portsmouthcc.gov.uk"


### PR DESCRIPTION
https://trello.com/c/6qcVMZ43/966-add-email-domain-to-approved-list-15-3

## Description
Adds the peterborough.gov.uk domain to the email address whitelist.