### PR TITLE
Restrict sending of email alerts to users/teams with a new specified role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,6 +87,10 @@ class User < ApplicationRecord
     has_role? :risk_level_validator
   end
 
+  def can_send_email_alert?
+    has_role? :email_alert_sender
+  end
+
   def has_role?(role)
     roles.exists?(name: role) || team.roles.exists?(name: role)
   end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -41,7 +41,7 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def send_email_alert?(user: @user)
-    user.is_opss?
+    user.can_send_email_alert?
   end
 
   def investigation_restricted?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -75,6 +75,12 @@ FactoryBot.define do
       end
     end
 
+    trait :email_alert_sender do
+      transient do
+        roles { %i[email_alert_sender] }
+      end
+    end
+
     after(:create) do |user, evaluator|
       evaluator.roles.each do |role|
         create(:role, name: role, entity: user)

--- a/spec/features/send_alert_spec.rb
+++ b/spec/features/send_alert_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Sending a product safety alert", :with_stubbed_elasticsearch, :with_test_queue_adapter, :with_stubbed_mailer, type: :feature do
-  let(:user) { create(:user, :activated, :opss_user, email: "user@example.com") }
+  let(:user) { create(:user, :activated, :opss_user, :email_alert_sender, email: "user@example.com") }
   let(:investigation) { create(:allegation, creator: user) }
 
   let(:restricted_investigation) { create(:allegation, :restricted, creator: user) }

--- a/spec/forms/investigation_actions_form_spec.rb
+++ b/spec/forms/investigation_actions_form_spec.rb
@@ -55,18 +55,17 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
       let(:investigation) { create(:allegation, creator: user) }
       let(:form) { described_class.new(investigation: investigation, current_user: user) }
 
-      it "contains four possible actions" do
+      it "contains three possible actions" do
         expect(form.actions).to eq({
           change_case_status: "Close case",
           change_case_owner: "Change case owner",
-          change_case_visibility: "Restrict this case",
-          send_email_alert: "Send email alert"
+          change_case_visibility: "Restrict this case"
         })
       end
     end
 
-    context "when the user is not involved with the investigation but is an OPSS user" do
-      let(:user) { create(:user, :activated, :opss_user) }
+    context "when the user is not involved with the investigation but can send email alerts" do
+      let(:user) { create(:user, :activated, :email_alert_sender) }
       let(:investigation) { create(:allegation) }
       let(:form) { described_class.new(investigation: investigation, current_user: user) }
 

--- a/spec/policies/investigation_policy_spec.rb
+++ b/spec/policies/investigation_policy_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe InvestigationPolicy, :with_stubbed_elasticsearch, :with_stubbed_m
 
   let(:team) { create(:team) }
   let(:user) { create(:user, team: team) }
+  let(:investigation) { create(:allegation, is_private: false) }
 
   context "when the investigation is not restricted" do
-    let(:investigation) { create(:allegation, is_private: false) }
-
     context "when the user’s team has not been added to the case" do
       it "cannot update the case" do
         expect(policy.update?).to be false
@@ -144,6 +143,22 @@ RSpec.describe InvestigationPolicy, :with_stubbed_elasticsearch, :with_stubbed_m
 
       it "cannot view all details about the case" do
         expect(policy.view_protected_details?).to be false
+      end
+    end
+  end
+
+  describe "#send_email_alert?" do
+    context "when the user has the email_alert_sender role" do
+      before { user.team.roles.create!(name: "email_alert_sender") }
+
+      it "returns true" do
+        expect(policy).to be_send_email_alert
+      end
+    end
+
+    context "when the user does not have the email_alert_sender role" do
+      it "returns false" do
+        expect(policy).not_to be_send_email_alert
       end
     end
   end

--- a/spec/requests/investigations/send_alert_spec.rb
+++ b/spec/requests/investigations/send_alert_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Sending a product safety alert", :with_stubbed_elasticsearch, :with_stubbed_mailer, type: :request do
-  let(:user) { create(:user, :activated, :opss_user) }
+  let(:user) { create(:user, :activated, :email_alert_sender) }
 
   before { sign_in user }
 


### PR DESCRIPTION
https://trello.com/c/UU5PlIdv/567-restrict-send-alert-to-just-imt-team

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Creates a new role called `email_alert_sender` which will be added to the OPSS Incident Management Team post-deployment. The 'send email alert' functionality will be restricted to those users with this new role only, rather than all OPSS users as currently.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
