### PR TITLE
Fix yanked gem version breaking rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "image_processing"
 gem "interactor", "~> 3.1"
 gem "jbuilder", "~> 2.11"
 gem "lograge", "~> 0.11"
+gem "mimemagic", "~> 0.3.6" # TODO: Remove when Rails dependency on yanked 0.3.5 version gets fixed.
 gem "mini_magick", "~> 4.11"
 gem "pg", "~> 1.2"
 gem "pghero", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -626,6 +626,7 @@ DEPENDENCIES
   listen (~> 3.4)
   lograge (~> 0.11)
   m (~> 1.5)
+  mimemagic (~> 0.3.6)
   mini_magick (~> 4.11)
   pg (~> 1.2)
   pghero (~> 2.8)


### PR DESCRIPTION
Due to some licensing issue[1], a gem version that Rails depends on was
yanked, breaking Rails installation.
This is currently blocking our deployment pipeline.

Mimemagic released a new 0.3.6 version[2] so we can manually enforce it
until a new patch on Rails fixing the dependency is released.

1: rails/rails#41750
2: minad/mimemagic#98 (comment)

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
