### PR TITLE
Fix test result bug

### DIFF
--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -707,6 +707,7 @@ private
       :standards_product_was_tested_against,
       :existing_document_file_id,
       :failure_details,
+      :further_test_results,
       date: %i[day month year],
       document_form: %i[description file]
     )

--- a/app/controllers/investigations/ts_investigations_controller.rb
+++ b/app/controllers/investigations/ts_investigations_controller.rb
@@ -414,7 +414,7 @@ private
   end
 
   def test_valid?
-    @test_result_form.valid?
+    @test_result_form.valid?(:ts_user_create)
     repeat_step_valid?(@test_result_form)
     @test_result_form.errors.empty?
   end
@@ -543,7 +543,7 @@ private
       end
       return false
     when :test_results
-      return @test_result_form.valid?
+      return @test_result_form.valid?(:ts_user_create)
     when :reference_number
       if reference_number_params[:has_complainant_reference].blank?
         @investigation.errors.add(:has_complainant_reference, "Choose whether you want to add your own reference number")

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -19,6 +19,7 @@ class TestResultForm
   attribute :filename
   attribute :file_description
   attribute :failure_details
+  attribute :further_test_results
 
   validates :details, length: { maximum: 50_000 }
   validates :legislation, inclusion: { in: Rails.application.config.legislation_constants["legislation"] }

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -26,6 +26,7 @@ class TestResultForm
   validates :result, inclusion: { in: Test::Result.results.keys }
   validates :document, presence: true
   validates :product_id, presence: true, on: :create_with_product
+  validates :further_test_results, presence: true, on: :ts_user_create
   validates :date,
             presence: true,
             real_date: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,8 @@ en:
               in_future: Date of test must be today or in the past
             failure_details:
               blank: Enter details about how the product failed to meet the requirements
+            further_test_results:
+              blank: Select yes if there are other test results to report
         product_form:
           attributes:
             authenticity:

--- a/spec/forms/test_result_form_spec.rb
+++ b/spec/forms/test_result_form_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe TestResultForm, :with_stubbed_elasticsearch, :with_stubbed_mailer
     it { is_expected.to validate_inclusion_of(:result).in_array(Test::Result.results.keys).with_message("Select result of the test") }
     it { is_expected.to validate_presence_of(:document).with_message("Provide the test results file") }
     it { is_expected.to validate_presence_of(:product_id).with_message("Select the product which was tested").on(:create_with_product) }
+    it { is_expected.to validate_presence_of(:further_test_results).on(:ts_user_create) }
     it { is_expected.to validate_presence_of(:standards_product_was_tested_against).with_message("Enter the standard the product was tested against") }
 
     it_behaves_like "it does not allow dates in the future", :date_form_params, :date


### PR DESCRIPTION
https://trello.com/c/64VjkgMm/881-regression-test-result-in-ts-flow-is-not-being-recored

## Description
Raise an error when further_test_results field is not populated by a ts user.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
