### PR TITLE
Allow restricted case viewing with role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,10 @@ class User < ApplicationRecord
     has_role? :email_alert_sender
   end
 
+  def can_view_restricted_cases?
+    has_role? :restricted_case_viewer
+  end
+
   def has_role?(role)
     roles.exists?(name: role) || team.roles.exists?(name: role)
   end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -32,12 +32,11 @@ class InvestigationPolicy < ApplicationPolicy
   def view_non_protected_details?(user: @user, private: @record.is_private)
     return true unless private
 
-    # Has the user's team been added to the case as a collaborator?
-    @record.teams_with_access.include?(user.team)
+    user.can_view_restricted_cases? || @record.teams_with_access.include?(user.team)
   end
 
   def view_protected_details?(user: @user)
-    @record.teams_with_access.include?(user.team)
+    user.can_view_restricted_cases? || @record.teams_with_access.include?(user.team)
   end
 
   def send_email_alert?(user: @user)

--- a/app/views/collaborators/edit.html.erb
+++ b/app/views/collaborators/edit.html.erb
@@ -19,7 +19,7 @@
 
     <%= form_with model: @edit_form, url: investigation_collaborator_path(@investigation, @collaboration), method: :put, local: true do |form| %>
 
-      <% remove_hint = @investigation.is_private? ? "Will not be able to view case details as it is restricted" :  "Will have default view rights"%>
+      <% remove_hint = @investigation.is_private? ? "Will not ordinarily be able to view case details as it is restricted" :  "Will have default view rights"%>
       <%= render "form_components/govuk_radios",
         form: form,
         key: :permission_level,

--- a/app/views/help/about.html.erb
+++ b/app/views/help/about.html.erb
@@ -317,6 +317,10 @@
     </p>
 
     <p>
+      Please note that certain teams within OPSS can also view restricted cases, even if they are not specifically added to the case. This is in order to support the market intelligence role of OPSS.
+    </p>
+
+    <p>
       Products and businesses attached to restricted cases will remain visible to all users.
     </p>
     

--- a/app/views/help/about.html.erb
+++ b/app/views/help/about.html.erb
@@ -43,7 +43,7 @@
         </li>
       </ol>
     </nav>
-    
+
     <h2 class="govuk-heading-m" id="introduction">
       1. An introduction to the PSD
     </h2>
@@ -51,7 +51,7 @@
     <p>
       The Product safety database enables market surveillance authorities to report and share information relating to unsafe and noncompliant products by creating ‘cases’. It replaces the EU databases RAPEX and ICSMS in the UK. The PSD was rolled out to all local authorities in November 2019.
     </p>
-    
+
     <p>
       The PSD is not an intelligence database; current procedures for the recording and dissemination of intelligence are not impacted by this guidance and continue to be in line with legislative and national guidelines.
     </p>
@@ -79,11 +79,11 @@
     <p>
       As more evidence is gathered (such as test results, risk assessments and/or additional measures) it can be added to existing cases.
     </p>
-    
+
     <p>
       All users should share information at an early stage so that it’s possible to see when other market surveillance authorities have:
     </p>
-    
+
     <ul class="govuk-list govuk-list--bullet">
       <li>
         raised concerns about a product or business and/or
@@ -101,7 +101,7 @@
     <p>
       You must use the PSD to notify OPSS when you:
     </p>
-    
+
      <ul class="govuk-list govuk-list--bullet">
       <li>
         find a product on the market which presents a risk to the health and safety of consumers
@@ -117,16 +117,16 @@
     <p>
       For further information on circumstances in which you should report on the PSD, please view the following guidance: <%= link_to "https://www.gov.uk/guidance/notification-of-unsafe-and-noncompliant-products-and-cosmetics", "https://www.gov.uk/guidance/notification-of-unsafe-and-noncompliant-products-and-cosmetics", class: "govuk-link" %>
     </p>
-    
-    
+
+
     <h3 class="govuk-heading-s">
       Information you should provide when notifying OPSS
     </h3>
-    
+
     <p>
       Notifications should provide all available details, and for products found to pose a serious risk, at least the following information. This will ensure that the notification is of greatest benefit to other market surveillance authorities and to protect consumers.
     </p>
-    
+
      <ul class="govuk-list govuk-list--bullet">
       <li>
         information enabling the product to be identified, including images of the product and any labelling and packaging. This may include product names, model numbers, batch codes and whether the product is counterfeit
@@ -141,11 +141,11 @@
         information on supply chains and distribution of the product, such as name and address of manufacturers, importers and/or distributors
       </li>
      </ul>
-    
+
     <p>
       If you have them, you may also add information and attachments relating to:
     </p>
-    
+
     <ul class="govuk-list govuk-list--bullet">
       <li>
         test results
@@ -154,48 +154,48 @@
         compliance documentation
       </li>
     </ul>
-    
+
     <p>
       You must only add personal data and other information on the database that is required by law (for example by regulation 33 of the General Product Safety Regulation 2005) or is necessary for the performance of your function as a market surveillance authority.
     </p>
-    
-    
+
+
     <h3 class="govuk-heading-s">
       How to assess risk
     </h3>
-    
+
     <p>
       Typically, UK market surveillance authorities that regulate consumer product safety will continue to use the RAPEX risk assessment methodology to conduct the assessment of the risk posed by an unsafe product.
       The <%= link_to "risk assessment guidelines tool", "https://ec.europa.eu/rag/#/screen/home", class: "govuk-link" %> includes a number of standard templates and supporting guidance that can assist risk assessors throughout the process of devising an appropriate risk assessment, including how to calculate probability scores.
       Guidance on using the current risk assessment guidelines tool can be found <%= link_to "here", "https://eur-lex.europa.eu/eli/dec/2019/417", class: "govuk-link" %>.
     </p>
-    
-    
+
+
     <h3 class="govuk-heading-s">
       How to notify OPSS
     </h3>
-    
+
     <p>
       You can add a case to the Product safety database to notify an unsafe and/or noncompliant product to the Secretary of State. You should only notify one product per case.
     </p>
-    
+
     <p>
       If the product poses a <strong>less than serious risk</strong> and has not been recalled, you should close the case once the measures taken are completed, add OPSS Incident Management to the case to ensure access to all relevant information for reporting purposes and there is no further activity anticipated.
     </p>
-    
+
     <p>
       If the product has been <strong>recalled</strong>, you should add the OPSS Incident Management Team to the case which will ensure the recall can be added to the Government Recall Site and the OECD Global Recall Portal.
     </p>
-    
+
     <p>
       If the product poses a <strong>serious risk</strong> to the health and safety of consumers as determined by a risk assessment, you should add the OPSS Incident Management Team (IMT) to the case or make them the case owner.  OPSS IMT will then validate (for consumer products), publish the notifications on the Gov.uk unsafe products page (for all products where agreed with MSAs), and undertake any further required reporting as part of agreements with other countries. The Gov.uk unsafe products page can be found at the following link: <%= link_to "https://www.gov.uk/guidance/product-safety-database-unsafe-products", "https://www.gov.uk/guidance/product-safety-database-unsafe-products", class: "govuk-link" %>
     </p>
-      
+
     <p>
-      Risk assessments are not required where the product poses a chemical risk; the notification is submitted in circumstances where there is well-documented evidence that certain features of certain products consistently lead to a specified risk and risk level; or the notification is for a cosmetic product containing a banned or restricted substance. However, the risk level should be identified on each case. 
+      Risk assessments are not required where the product poses a chemical risk; the notification is submitted in circumstances where there is well-documented evidence that certain features of certain products consistently lead to a specified risk and risk level; or the notification is for a cosmetic product containing a banned or restricted substance. However, the risk level should be identified on each case.
     </p>
-      
-    <p> 
+
+    <p>
       Further information on notifying product safety risks and/or noncompliance can be found at the following link: <%= link_to "https://www.gov.uk/guidance/notification-of-unsafe-and-noncompliant-products-and-cosmetics", "https://www.gov.uk/guidance/notification-of-unsafe-and-noncompliant-products-and-cosmetics", class: "govuk-link" %>
     </p>
 
@@ -206,11 +206,11 @@
     <p>
       Notifications for products found to pose a serious risk to the health and safety of consumers go through additional processes. Since 1 January 2021, OPSS undertake the validation and publication of serious risk notifications which was previously undertaken by the European Commission when the UK was a member of the EU and throughout the Transition Period. This validation will consist of quality assurance of information and data provided, ensuring public-facing fields are completed comprehensively and effectively. The validation will also include a review of the risk model and the supporting information, intended to ensure risk is being considered and applied consistently by different market surveillance authorities. This process may also include a consideration of whether the product safety issues identified may be national, novel or contentious, as outlined in the OPSS Incident Management Plan (https://www.gov.uk/government/publications/incident-management-plan).
     </p>
-    
+
     <p>
       OPSS also uses information added to the PSD to undertake required information exchanges under the EU-UK Withdrawal Agreement and any trade agreements with other countries. OPSS will report information provided on the PSD in respect of Northern Ireland to report to the European Commission, as required by the Northern Ireland Protocol.
     </p>
-    
+
     <p>
       OPSS may also monitor the PSD for recalls and add them to the UK Government Recall Site and the OECD Global Recall Portal. You can also request addition by adding OPSS Incident Management to the case.
     </p>
@@ -220,7 +220,7 @@
     </p>
 
 
-    
+
     <h2 class="govuk-heading-m" id="organisations-with-access-to-the-psd">
       5. Organisations with access to the PSD
     </h2>
@@ -259,8 +259,8 @@
       </li>
     </ul>
 
-    
-    
+
+
     <h2 class="govuk-heading-m" id="viewing-cases">
       6. Viewing and restricting cases
     </h2>
@@ -295,7 +295,7 @@
       If further case details need to be protected, the case should be restricted so that it cannot be viewed by teams not added to a case.
     </p>
 
-    
+
     <h3 class="govuk-heading-s">
       Restricting access to cases
     </h3>
@@ -317,17 +317,13 @@
     </p>
 
     <p>
-      Please note that certain teams within OPSS can also view restricted cases, even if they are not specifically added to the case. This is in order to support the market intelligence role of OPSS.
+      Products and businesses attached to restricted cases will remain visible to all users.
     </p>
 
     <p>
-      Products and businesses attached to restricted cases will remain visible to all users.
+      You can restrict a case from the 'Sharing and collaboration' section of the case overview.
     </p>
-    
-    <p>
-      You can restrict a case from the 'Sharing and collaboration' section of the case overview. 
-    </p>
-    
+
     <h3 class="govuk-heading-s">
       Administrator access
     </h3>
@@ -351,11 +347,11 @@
         export details of cases added to the PSD
       </li>
     </ul>
-    
+
     <p>
       This level of access is provided to a small number of people to ensure that OPSS can view all product safety information on the PSD. This ensures that, as an evidence-based regulator, strategic intelligence assessments and market surveillance activity is as robust and targeted as possible.
     </p>
-    
+
     <h2 class="govuk-heading-m" id="collaborating-on-cases">
       7. Collaborating with other market surveillance authorities and teams
     </h2>
@@ -392,12 +388,12 @@
      <p>
       Teams can be added to a case with 'view' or 'edit' permissions. Teams added with edit permissions will be able to make changes to the case and will be able to view protected details, like correspondence. Teams added with view only permissions will be able to view protected details but will not be able to make changes to the case.
     </p>
-    
+
     <p>
       You should add a team to a case if you want them to be able to view the full case or add further details. If a team no longer needs access to the case, you can remove them.
     </p>
-    
-    
+
+
     <h3 class="govuk-heading-s">
       Changing the case owner
     </h3>
@@ -405,11 +401,11 @@
     <p>
       Only the current case owner can assign a new owner.
     </p>
-    
+
     <p>
       To change the case owner to another authority or team, navigate to the ‘Sharing and collaboration’ section of the case overview. The new case owner will be notified that they’ve been made the case owner via email. You can also include a message that will be sent to them - so you can let them know why you’re assigning them the case.
     </p>
-    
+
     <p>
       When the case owner changes, the previous case owner’s team remains added to the case.
     </p>
@@ -441,16 +437,16 @@
     <p>
       You can update your name yourself by going to the ‘Your account’ part of the service.
     </p>
-    
+
     <p>
       To update your password, sign out of the service and use the ‘Forgot your password’ link when signing in.
     </p>
-    
+
     <p>
       You can update your contact details, your team or organisation’s details, or delete your account by emailing <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %> to:
     </p>
 
-   
+
 
     <h2 class="govuk-heading-m" id="more-support">
       9. More support

--- a/app/views/investigations/visibility.html.erb
+++ b/app/views/investigations/visibility.html.erb
@@ -18,7 +18,7 @@
                  key: :is_private,
                  fieldset: { legend: { text: "Visibility",
                                        classes: "govuk-label--m" } },
-                 hint: { text: "Restricted cases are visible only to the organisation that created them and the organisation of the current case owner." },
+                 hint: { text: "Restricted cases are visible only to teams added to the case, as well as certain OPSS users." },
                  items: [{ text: t(false, scope: "case.is_private"),
                            value: "false" },
                          { text: t(true, scope: "case.is_private"),

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -81,6 +81,12 @@ FactoryBot.define do
       end
     end
 
+    trait :restricted_case_viewer do
+      transient do
+        roles { %i[restricted_case_viewer] }
+      end
+    end
+
     after(:create) do |user, evaluator|
       evaluator.roles.each do |role|
         create(:role, name: role, entity: user)

--- a/spec/policies/investigation_policy_spec.rb
+++ b/spec/policies/investigation_policy_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe InvestigationPolicy, :with_stubbed_elasticsearch, :with_stubbed_m
       it "cannot view all details about the case" do
         expect(policy.view_protected_details?).to be false
       end
+
+      context "when the user has the restricted_case_viewer role" do
+        let(:user) { create(:user, :restricted_case_viewer, team: team) }
+
+        it "can view non-protected details" do
+          expect(policy.view_non_protected_details?).to be true
+        end
+
+        it "can view all details about the case" do
+          expect(policy.view_protected_details?).to be true
+        end
+      end
     end
   end
 

--- a/spec/requests/investigations/viewing_a_restricted_case_spec.rb
+++ b/spec/requests/investigations/viewing_a_restricted_case_spec.rb
@@ -65,4 +65,13 @@ RSpec.describe "Viewing a restricted case", :with_stubbed_elasticsearch, :with_s
       expect(response).to have_http_status(:ok)
     end
   end
+
+  context "when the case is owned by a team from another organisation and the user has the restricted_case_viewer role" do
+    let(:investigation) { create(:allegation, is_private: true, creator: other_user) }
+    let(:user) { create(:user, :activated, :restricted_case_viewer, organisation: users_organisation, team: users_team,) }
+
+    it "renders the page" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/4PxoZ72O/698-enable-opss-intelligence-team-to-view-restricted-cases

## Description
Allows users with the new `restricted_case_viewer` role (introduced in this PR) to view all restricted cases, even if their team has not been added to the case.

On deployment the role will be added to the OPSS Intelligence team.

I have updated copy in the service to reflect the changes. The copy has not yet been reviewed and should not be merged until the copy changes have been reviewed.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [x] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
