### PR TITLE
run only elasticsearch test in one matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -48,17 +48,14 @@ jobs:
         rspec-folder:
           - spec/active_model
           - spec/decorators
+          - spec/forms
+          - spec/helpers spec/jobs spec/mailers spec/policies
+          - spec/models spec/validators
+          - spec/requests
           - --tag with_elasticsearch spec/features
           - --tag ~with_elasticsearch spec/features
-          - spec/forms
-          - spec/helpers
-          - spec/jobs
-          - spec/mailers
-          - spec/models
-          - spec/policies
-          - spec/requests
-          - spec/services
-          - spec/validators
+          - --tag with_elasticsearch spec/services
+          - --tag ~with_elasticsearch spec/services
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Run Specs
       run: |
-        bundle exec rspec {{ matrix.rspec-folder }}
+        bundle exec rspec ${{ matrix.rspec-folder }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -46,19 +46,19 @@ jobs:
       fail-fast: false
       matrix:
         rspec-folder:
-          - active_model
-          - decorators
-          - --tag with_elasticsearch features
-          - --tag ~with_elasticsearch features
-          - forms
-          - helpers
-          - jobs
-          - mailers
-          - models
-          - policies
-          - requests
-          - services
-          - validators
+          - spec/active_model
+          - spec/decorators
+          - --tag with_elasticsearch spec/features
+          - --tags ~with_elasticsearch spec/features
+          - spec/forms
+          - spec/helpers
+          - spec/jobs
+          - spec/mailers
+          - spec/models
+          - spec/policies
+          - spec/requests
+          - spec/services
+          - spec/validators
 
     steps:
     - uses: actions/checkout@v1
@@ -109,7 +109,7 @@ jobs:
 
     - name: Run Specs
       run: |
-        bundle exec rspec spec/${{ matrix.rspec-folder }}
+        bundle exec rspec {{ matrix.rspec-folder }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -103,7 +103,7 @@ jobs:
       run: yarn install
 
     - name: Prepare database
-      run: bin/rails parallel:setup
+      run: bin/rails parallel:create parallel:prepare
 
     - name: Run Specs
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,6 +13,7 @@ env:
   PSD_HOST: example.com
   EMAIL_WHITELIST_ENABLED: false
   TWO_FACTOR_AUTHENTICATION_ENABLED: false
+  NOTIFY_API_KEY: 5a2d20e1-2ddc-42d7-820e-d0b2af5a16dc.293785d2-7f4d-47bf-978b-5f316c5cc62f
   CI: true
 
 jobs:
@@ -103,7 +104,7 @@ jobs:
       run: yarn install
 
     - name: Prepare database
-      run: bin/rails parallel:create parallel:prepare
+      run: bin/rails parallel:setup
 
     - name: Run Specs
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # Each group of tests affected by the following tags will run in a different job in parallel.
-        rspec-tag: ["type:feature", "~type:feature"]
+        rspec-tag: ["type:feature", "~type:feature", "with_elasticsearch"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -48,8 +48,8 @@ jobs:
         rspec-folder:
           - active_model
           - decorators
-          - --tag @with_elasticsearch features
-          - --tag ~@with_elasticsearch features
+          - --tag with_elasticsearch features
+          - --tag ~with_elasticsearch features
           - forms
           - helpers
           - jobs

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # Each group of tests affected by the following tags will run in a different job in parallel.
-        rspec-tag: ["type:feature --tag ~with_elasticsearch", "~type:feature --tag ~with_elasticsearch", "--tag with_elasticsearch"]
+        rspec-tag: ["type:feature --tag ~with_elasticsearch", "~type:feature --tag ~with_elasticsearch", "with_elasticsearch"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -103,7 +103,7 @@ jobs:
       run: yarn install
 
     - name: Prepare database
-      run: bin/rails db:create db:schema:load
+      run: bin/rails parallel:setup
 
     - name: Run Specs
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -104,7 +104,7 @@ jobs:
       run: yarn install
 
     - name: Prepare database
-      run: bin/rails parallel:setup
+      run: bin/rails parallel:load_schema
 
     - name: Run Specs
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -48,7 +48,8 @@ jobs:
         rspec-folder:
           - active_model
           - decorators
-          - features
+          - --tag @with_elasticsearch features
+          - --tag ~@with_elasticsearch features
           - forms
           - helpers
           - jobs

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -49,7 +49,7 @@ jobs:
           - spec/active_model
           - spec/decorators
           - --tag with_elasticsearch spec/features
-          - --tags ~with_elasticsearch spec/features
+          - --tag ~with_elasticsearch spec/features
           - spec/forms
           - spec/helpers
           - spec/jobs

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -44,8 +44,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each group of tests affected by the following tags will run in a different job in parallel.
-        rspec-tag: ["type:feature --tag ~with_elasticsearch", "~type:feature --tag ~with_elasticsearch", "with_elasticsearch"]
+        rspec-folder:
+          - active_model
+          - decorators
+          - features
+          - forms
+          - helpers
+          - jobs
+          - mailers
+          - models
+          - policies
+          - requests
+          - services
+          - validators
 
     steps:
     - uses: actions/checkout@v1
@@ -96,7 +107,7 @@ jobs:
 
     - name: Run Specs
       run: |
-        bundle exec rspec spec --tag ${{ matrix.rspec-tag }}
+        bundle exec rspec spec/${{ matrix.rspec-folder }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # Each group of tests affected by the following tags will run in a different job in parallel.
-        rspec-tag: ["type:feature", "~type:feature", "with_elasticsearch"]
+        rspec-tag: ["type:feature --tag ~with_elasticsearch", "~type:feature --tag ~with_elasticsearch", "--tag with_elasticsearch"]
 
     steps:
     - uses: actions/checkout@v1

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "pry", "~> 0.13"
   gem "pry-byebug", "~> 3.9"
   gem "pry-doc", "~> 1.1"
+  gem "parallel_tests"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -52,10 +52,10 @@ group :development, :test do
   gem "awesome_print", "~> 1.9", require: "ap"
   gem "byebug", "~> 11.1"
   gem "dotenv-rails", "~> 2.7"
+  gem "parallel_tests"
   gem "pry", "~> 0.13"
   gem "pry-byebug", "~> 3.9"
   gem "pry-doc", "~> 1.1"
-  gem "parallel_tests"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,8 @@ GEM
     optimist (3.0.1)
     orm_adapter (0.5.0)
     parallel (1.20.1)
+    parallel_tests (3.6.0)
+      parallel
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pastel (0.8.0)
@@ -628,6 +630,7 @@ DEPENDENCIES
   lograge (~> 0.11)
   m (~> 1.5)
   mini_magick (~> 4.11)
+  parallel_tests
   pg (~> 1.2)
   pghero (~> 2.8)
   pry (~> 0.13)

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
   database: psd_development
 test:
   <<: *default
-  database: psd_test
+  database: psd_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   adapter: postgresql


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Split test by folders  and run with `parallel_test` gems, GitHub action severs have two cores so this further parallelise the tests.
We now run the whole suite in more or less 10 minutes.