### PR TITLE
Fix test that fails due to difference in ActiveRecord and Rails Timez…

### DIFF
--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
 
       context "when investigation is closed" do
         it "date_closed column is empty" do
-          closed_at_date = Date.new(2021, 01, 01)
+          closed_at_date = Date.new(2021, 0o1, 0o1)
           create(:allegation, is_closed: true, date_closed: closed_at_date)
 
           Investigation.import refresh: true, force: true

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -240,7 +240,8 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
 
       context "when investigation is closed" do
         it "date_closed column is empty" do
-          create(:allegation, is_closed: true, date_closed: Date.yesterday)
+          closed_at_date = Date.new(2021, 01, 01)
+          create(:allegation, is_closed: true, date_closed: closed_at_date)
 
           Investigation.import refresh: true, force: true
 
@@ -248,7 +249,7 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
 
           aggregate_failures do
             expect(exported_data.cell(1, 23)).to eq "Date_Closed"
-            expect(exported_data.cell(2, 23)).to eq Date.yesterday.strftime("%Y-%m-%d %H:%M:%S %z")
+            expect(exported_data.cell(2, 23)).to eq closed_at_date.strftime("%Y-%m-%d %H:%M:%S %z")
           end
         end
       end

--- a/spec/requests/export_investigations_spec.rb
+++ b/spec/requests/export_investigations_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Export investigations as XLSX file", :with_elasticsearch, :with_
 
       context "when investigation is closed" do
         it "date_closed column is empty" do
-          closed_at_date = Date.new(2021, 0o1, 0o1)
+          closed_at_date = Date.new(2021, 1, 1)
           create(:allegation, is_closed: true, date_closed: closed_at_date)
 
           Investigation.import refresh: true, force: true


### PR DESCRIPTION
…ones

Our application has the timezone set to "Europe/London" within application.rb, however,
as noted in the same file, ActiveRecord is set to stay in UTC. This seems like it is a decision
that has been made deliberately so I have used a date outside of British Summer Time in order
to respect this and not changed the timezone in the test in order to not artificially manipulate
the interaction between Rails and AR in this case.

https://trello.com/c/iRbYnTzh/989-fix-failing-test-due-to-timezone-issue

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
