### PR TITLE
Fix order of errors on other files and attachment page in ts flow

### DIFF
--- a/app/views/investigations/ts_investigations/_file_page.html.slim
+++ b/app/views/investigations/ts_investigations/_file_page.html.slim
@@ -10,12 +10,13 @@ fieldset.govuk-fieldset
     = form.fields_for :file do |subform|
       - if @file_blob.blank?
         .govuk-form-group class=("govuk-form-group--error" if form.object.errors[:file].any?)
-          = subform.label :file, "Upload a file", class: "govuk-label"
+          = subform.label :file, "Upload a file", class: "govuk-label", id: "file"
           = subform.file_field :file, class: "govuk-file-upload"
       hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
       = render "form_components/govuk_input",
                key: :title,
                form: subform,
+               id: "title",
                value: @file_title,
                classes: "govuk-!-width-two-thirds",
                label: { text: "Title" }
@@ -24,6 +25,7 @@ fieldset.govuk-fieldset
       = render "form_components/govuk_textarea",
                key: :description,
                form: subform,
+               id: "description",
                value: @file_description,
                attributes: { maxlength: 10_000 },
                label: { text: "Description" },

--- a/app/views/investigations/ts_investigations/evidence_images.html.slim
+++ b/app/views/investigations/ts_investigations/evidence_images.html.slim
@@ -4,6 +4,7 @@
         model: @investigation,
         hide_break: true,
         other_text: "Are there other evidence images to report?",
+        error_order: %i[file title description further_product_images],
         further_key: :further_evidence_images do |form|
   = render "file_page",
            form: form,

--- a/app/views/investigations/ts_investigations/product_images.html.slim
+++ b/app/views/investigations/ts_investigations/product_images.html.slim
@@ -4,6 +4,7 @@
         model: @investigation,
         hide_break: true,
         other_text: "Are there other product images to report?",
+        error_order: [:file, :title, :description, :further_product_images],
         further_key: :further_product_images do |form|
   = render "file_page",
            form: form,

--- a/app/views/investigations/ts_investigations/product_images.html.slim
+++ b/app/views/investigations/ts_investigations/product_images.html.slim
@@ -4,7 +4,7 @@
         model: @investigation,
         hide_break: true,
         other_text: "Are there other product images to report?",
-        error_order: [:file, :title, :description, :further_product_images],
+        error_order: %i[file title description further_product_images],
         further_key: :further_product_images do |form|
   = render "file_page",
            form: form,

--- a/spec/features/report_product_spec.rb
+++ b/spec/features/report_product_spec.rb
@@ -241,8 +241,9 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
         expect_to_be_on_product_image_page
 
-        # trigger validation to verify errors are handled correctly
         click_on "Continue"
+
+        expect_correctly_ordered_product_image_errors
 
         product_images.each do |product_image|
           fill_in_product_image_page(with: product_image)
@@ -755,5 +756,13 @@ RSpec.feature "Reporting a product", :with_stubbed_elasticsearch, :with_stubbed_
 
   def expect_product_reported_unsafe_and_non_compliant
     expect(page.find("h2", text: "Summary")).to have_sibling("p", text: "Product reported because it is unsafe and non-compliant.")
+  end
+
+  def expect_correctly_ordered_product_image_errors
+    errors_list = page.find(".govuk-error-summary__list").all("li")
+    expect(errors_list[0].text).to eq "You must upload a file"
+    expect(errors_list[1].text).to eq "Enter file title"
+    expect(errors_list[2].text).to eq "Enter file description"
+    expect(errors_list[3].text).to eq "Select whether or not you have further product images to record"
   end
 end


### PR DESCRIPTION
https://trello.com/c/ZHYvSo9y/823-fix-error-order-on-other-files-and-attachments-page-in-ts-flow

## Description
Fix order of errors on other files and attachment page in ts flow

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
