### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/features/export_businesses_spec.rb
+++ b/spec/features/export_businesses_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Exporting businesses", :with_elasticsearch, :with_stubbed_antivir
   let(:contact) { build(:contact, business: nil) }
 
   scenario "all businesses" do
-    Business.import(force: true)
+    Business.import(force: true, refresh: :wait_for)
 
     sign_in user
     visit "/businesses"


### PR DESCRIPTION
This one keeps failing regularly because the ElasticSearch index has not finished re-indexing before the test has run. This forces the spec to wait for the response from ElasticSearch before continuing.
