### PR TITLE
Remove deprecated Sidekiq::Web config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 require "sidekiq/web"
 require "sidekiq/cron/web"
 
-Sidekiq::Web.set :session_secret, Rails.application.secret_key_base
-
 if Rails.env.production?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     ActiveSupport::SecurityUtils.secure_compare(username, ENV["SIDEKIQ_USERNAME"]) &&


### PR DESCRIPTION
Resolves a deprecation warning, e.g. `WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /Users/steve/.rvm/gems/ruby-2.7.3/gems/sidekiq-6.2.1/lib/sidekiq/web.rb:75:in `set'`

Prior to and after merging, test that 'delete' actions working in Sidekiq web interface as this config was added to resolve errors that occurred when trying to perform this action. Test on the review app as well as staging and production after deployment.

UPDATE: Tested working in  review apps.