### PR TITLE
Fix GitHub deployments not being deactivated when PR closed

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -36,7 +36,10 @@ jobs:
         cf delete-service -f psd-db-pr-$PR_NUMBER
         cf logout
 
-    - name: Deactivate Github deploy
+    - name: Checkout code to get deploy functions
+      uses: actions/checkout@v2
+
+    - name: Deactivate GitHub deployment
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
       run: |


### PR DESCRIPTION
Fixes an issue introduced by changes in #1302.

Checking out the code is not necessary for the CloudFoundry interactions, and blocks the whole action running if the PR was closed but not merged, since the checkout action is looking for the merge commit with the master branch. This doesn't exist if the PR was closed without merging. This results in the unwanted review app left running.

I've moved the checkout action to the last step which requires the file in the codebase. This will still fail if the PR was closed without merging, but it will not prevent the review app being deleted. Perhaps this cloud be mitigated in future by setting the `GITHUB_REF` to the master branch, but that would also come with downsides if the file or the action definition was modified or deleted in a PR.

Tested on an other PR: https://github.com/UKGovernmentBEIS/beis-opss-psd/actions/runs/752502324