### PR TITLE
Sentry should ignore Pundit::NotAuthorizedError exceptions

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,5 +8,6 @@ Rails.application.configure do
     config.dsn = ENV["SENTRY_DSN"]
     config.send_default_pii = false
     config.breadcrumbs_logger << :sentry_logger
+    config.excluded_exceptions += ["Pundit::NotAuthorizedError"]
   end
 end


### PR DESCRIPTION
The majority of exceptions we receive on production are of type `Pundit::NotAuthorizedError` which just means someone was trying to access a page they're not permitted to. These exceptions are rescued by ActionDispatch to show a friendly error message, but Sentry is still reporting them.

We don't need to be alerted to every instance of this error as it is likely to derive from normal usage. All instances are logged in any case.

Tested in the review app.