### PR TITLE
Fix migration being jammed on team_id.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
 development:
   <<: *default
-  database: psd_development
+  database: psd_development_seed
 test:
   <<: *default
   database: psd_test<%= ENV['TEST_ENV_NUMBER'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
 development:
   <<: *default
-  database: psd_development_seed
+  database: psd_development
 test:
   <<: *default
   database: psd_test<%= ENV['TEST_ENV_NUMBER'] %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@ end
 run_seeds = (Product.count.zero? || Complainant.count.zero?)
 
 if run_seeds
-
+  User.reset_column_information
   Rails.logger.info("Running seeds.rb")
 
   organisation = Organisation.create!(name: "Seed Organisation")


### PR DESCRIPTION
## Description
this is a fix for the following sentry error. Preventing the seeds from being populated.
https://sentry.io/organizations/beis/issues/2299480785/?environment=psd-pr-1319&project=1329381&query=is%3Aunresolved

I have not found what is causing this, however reseting the columns information before seeding the DB seems to fix the issue.
