### PR TITLE
render product removal audit title in the viewing

### DIFF
--- a/app/decorators/audit_activity/product/destroy_decorator.rb
+++ b/app/decorators/audit_activity/product/destroy_decorator.rb
@@ -1,0 +1,9 @@
+module AuditActivity
+  module Product
+    class DestroyDecorator < ActivityDecorator
+      def title(_viewing_user)
+        "#{metadata.dig('product', 'name')} removed"
+      end
+    end
+  end
+end

--- a/app/models/audit_activity/product/destroy.rb
+++ b/app/models/audit_activity/product/destroy.rb
@@ -1,4 +1,8 @@
 class AuditActivity::Product::Destroy < AuditActivity::Product::Base
+  def self.build_metadata(product, reason)
+    { reason: reason, product: product.attributes }
+  end
+
   def self.from(*)
     raise "Deprecated - use RemoveProductFromCase.call instead"
   end

--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -24,9 +24,8 @@ private
     AuditActivity::Product::Destroy.create!(
       source: UserSource.new(user: user),
       investigation: investigation,
-      title: "#{product.name} removed",
       product: product,
-      metadata: { reason: reason }
+      metadata: AuditActivity::Product::Destroy.build_metadata(product, reason)
     )
   end
 

--- a/spec/features/remove_product_from_a_case_spec.rb
+++ b/spec/features/remove_product_from_a_case_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Remove product from investigation", :with_stubbed_elasticsearch, 
 
       click_link "Remove product"
 
-      expect(page).to have_content "Remove #{product.name}"
+      expect(page).to have_css("h1", text: "Remove #{product.name}")
 
       click_on "Submit"
 
@@ -37,13 +37,14 @@ RSpec.feature "Remove product from investigation", :with_stubbed_elasticsearch, 
       expect_confirmation_banner("Product was successfully removed.")
       expect_to_be_on_investigation_products_page(case_id: investigation.pretty_id)
 
-      expect(page).not_to have_text(product.name)
-      expect(page).to have_text("No products")
+      expect(page).not_to have_css("h2", text: product.name)
+      expect(page).to have_css("p.govuk-body", text: "No products")
 
       click_link "Activity"
       expect_to_be_on_case_activity_page(case_id: investigation.pretty_id)
-      expect(page).to have_content("#{product.name} removed")
-      expect(page).to have_content(removal_reason)
+
+      expect(page.find("h3", text: "#{product.name} removed"))
+        .to have_sibling(".govuk-body", text: removal_reason)
     end
   end
 
@@ -59,8 +60,8 @@ RSpec.feature "Remove product from investigation", :with_stubbed_elasticsearch, 
       visit "/cases/#{investigation.pretty_id}/products"
       click_link "Remove product"
 
-      expect(page).not_to have_content "Remove #{product.name}"
-      expect(page).to have_content "Cannot remove the product from the case because it's associated with following supporting information"
+      expect(page).not_to have_css("h1", text: "Remove #{product.name}")
+      expect(page).to have_css(".hmcts-banner__message", text: "Cannot remove the product from the case because it's associated with following supporting information")
     end
   end
 end

--- a/spec/services/remove_product_from_case_spec.rb
+++ b/spec/services/remove_product_from_case_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe RemoveProductFromCase, :with_stubbed_elasticsearch, :with_test_queue_adapter do
-  let(:investigation) { create(:allegation, products: [product], creator: creator) }
-  let(:product) { create(:product_washing_machine) }
+  subject(:result) { described_class.call(investigation: investigation, product: product, user: user, reason: reason) }
 
-  let(:user) { create(:user) }
-  let(:creator) { user }
-  let(:owner) { user }
+  let(:investigation) { create(:allegation, products: [product], creator: creator) }
+  let(:product)       { create(:product_washing_machine) }
+  let(:reason)        { Faker::Hipster.sentence }
+  let(:user)          { create(:user) }
+  let(:creator)       { user }
+  let(:owner)         { user }
 
   describe ".call" do
     context "with no parameters" do
@@ -32,45 +34,41 @@ RSpec.describe RemoveProductFromCase, :with_stubbed_elasticsearch, :with_test_qu
         expect(result).to be_failure
       end
     end
+  end
 
-    context "with no user parameter" do
-      let(:result) { described_class.call(investigation: investigation, product: product) }
+  context "with no user parameter" do
+    let(:result) { described_class.call(investigation: investigation, product: product) }
 
-      it "returns a failure" do
-        expect(result).to be_failure
-      end
+    it "returns a failure" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "with required parameters" do
+    def expected_email_subject
+      "Allegation updated"
     end
 
-    context "with required parameters" do
-      def expected_email_subject
-        "Allegation updated"
-      end
-
-      def expected_email_body(name)
-        "Product was removed from the allegation by #{name}."
-      end
-
-      let(:result) { described_class.call(investigation: investigation, product: product, user: user) }
-
-      it "returns success" do
-        expect(result).to be_success
-      end
-
-      it "removes the product from the case" do
-        result
-        expect(investigation.reload.products).not_to include(product)
-      end
-
-      it "creates an audit activity", :aggregate_failures do
-        result
-        activity = investigation.reload.activities.first
-        expect(activity).to be_a(AuditActivity::Product::Destroy)
-        expect(activity.source.user).to eq(user)
-        expect(activity.product).to eq(product)
-        expect(activity.title(nil)).to eq("#{product.name} removed")
-      end
-
-      it_behaves_like "a service which notifies the case owner"
+    def expected_email_body(name)
+      "Product was removed from the allegation by #{name}."
     end
+
+    it "returns success" do
+      expect(result).to be_success
+    end
+
+    it "removes the product from the case" do
+      result
+      expect(investigation.reload.products).not_to include(product)
+    end
+
+    it "creates an audit activity", :aggregate_failures do
+      result
+      activity = investigation.reload.activities.find_by!(type: AuditActivity::Product::Destroy.name)
+      expect(activity).to have_attributes(title: nil, body: nil, product_id: product.id, metadata: { "reason" => reason, "product" => JSON.parse(product.attributes.to_json) })
+      expect(activity.source.user).to eq(user)
+    end
+
+    it_behaves_like "a service which notifies the case owner"
   end
 end


### PR DESCRIPTION
## Description
the audit now stores the product's attributes in the metadata.
Also standardised the use of `have_css` over `have_content` in the feature test

