### PR TITLE
Fix error bugs on actions form

### DIFF
--- a/app/controllers/investigations/actions_controller.rb
+++ b/app/controllers/investigations/actions_controller.rb
@@ -43,8 +43,6 @@ module Investigations
     end
 
     def actions_params
-      return {} if params[:investigation_actions_form].blank?
-
       params.require(:investigation_actions_form).permit(:investigation_action)
     end
   end

--- a/app/controllers/investigations/actions_controller.rb
+++ b/app/controllers/investigations/actions_controller.rb
@@ -15,12 +15,12 @@ module Investigations
       @actions_form = InvestigationActionsForm.new(
         investigation: @investigation,
         current_user: current_user,
-        action: params[:investigation_action]
+        investigation_action: actions_params[:investigation_action]
       )
 
       return render(:index) if @actions_form.invalid?
 
-      redirect_to path_for_action(@actions_form.action)
+      redirect_to path_for_action(@actions_form.investigation_action)
     end
 
   private
@@ -40,6 +40,12 @@ module Investigations
       when "change_case_risk_level"
         investigation_risk_level_path(@investigation)
       end
+    end
+
+    def actions_params
+      return {} if params[:investigation_actions_form].blank?
+
+      params.require(:investigation_actions_form).permit(:investigation_action)
     end
   end
 end

--- a/app/controllers/investigations/actions_controller.rb
+++ b/app/controllers/investigations/actions_controller.rb
@@ -43,6 +43,8 @@ module Investigations
     end
 
     def actions_params
+      return {} if params[:investigation_actions_form].blank?
+
       params.require(:investigation_actions_form).permit(:investigation_action)
     end
   end

--- a/app/forms/investigation_actions_form.rb
+++ b/app/forms/investigation_actions_form.rb
@@ -3,11 +3,11 @@ class InvestigationActionsForm
   include ActiveModel::Attributes
   include Pundit
 
-  attribute :action
+  attribute :investigation_action
   attribute :investigation
   attribute :current_user
 
-  validates_presence_of :action
+  validates_presence_of :investigation_action
 
   def actions
     status_and_owner_actions.merge(email_alert_action)

--- a/app/views/investigations/actions/index.html.erb
+++ b/app/views/investigations/actions/index.html.erb
@@ -11,20 +11,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= error_summary @actions_form.errors %>
-    <%= form_with local: true, url: investigation_actions_path(@investigation) do |form| %>
-      <%= render "form_components/govuk_radios",
-        form: form,
-        key: :investigation_action,
-        items: radio_items_from_hash(@actions_form.actions),
-        fieldset: {
-        legend: {
-          text: page_heading,
-          classes: "govuk-fieldset__legend--l",
-          isPageHeading: true
-        }
-      } %>
-      <%= govukButton(text: "Continue") %>
+    <%= form_with model: @actions_form, local: true, url: investigation_actions_path(@investigation), builder: ApplicationFormBuilder do |form| %>
+      <%= error_summary @actions_form.errors %>
+      <%= form.govuk_radios :investigation_action, legend: page_heading, items: radio_items_from_hash(@actions_form.actions) %>
+      <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/investigations/actions/index.html.erb
+++ b/app/views/investigations/actions/index.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @actions_form, local: true, url: investigation_actions_path(@investigation), builder: ApplicationFormBuilder do |form| %>
       <%= error_summary @actions_form.errors %>
-      <%= form.govuk_radios :investigation_action, legend: page_heading, items: radio_items_from_hash(@actions_form.actions) %>
+      <%= form.govuk_radios :investigation_action, legend: page_heading, legend_classes: "govuk-fieldset__legend--l", items: radio_items_from_hash(@actions_form.actions) %>
       <%= form.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>

--- a/spec/forms/investigation_actions_form_spec.rb
+++ b/spec/forms/investigation_actions_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stubbed_mailer do
   describe "validations" do
     context "when an action has been set" do
-      let(:form) { described_class.new(action: "close_case") }
+      let(:form) { described_class.new(investigation_action: "close_case") }
 
       it "is valid" do
         expect(form).to be_valid
@@ -11,7 +11,7 @@ RSpec.describe InvestigationActionsForm, :with_stubbed_elasticsearch, :with_stub
     end
 
     context "when no action has been set" do
-      let(:form) { described_class.new(action: nil) }
+      let(:form) { described_class.new(investigation_action: nil) }
 
       it "is not valid" do
         expect(form).not_to be_valid

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -178,7 +178,7 @@ module PageExpectations
 
   def expect_to_be_on_case_actions_page(case_id:)
     expect(page).to have_current_path("/cases/#{case_id}/actions")
-    expect(page).to have_selector("h1", text: "Select an action")
+    expect(page).to have_selector(".govuk-fieldset__legend--l", text: "Select an action")
   end
 
   def expect_to_be_on_close_case_page(case_id:)


### PR DESCRIPTION
https://trello.com/c/jRw9wt3E/1019-non-js-actions-page-no-field-level-error-when-nothing-selected

## Description
Errors not correctly displaying on actions form bug. This PR fixes the issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
