### PR TITLE
Remove failing migration

### DIFF
--- a/app/models/audit_activity/investigation/update_status.rb
+++ b/app/models/audit_activity/investigation/update_status.rb
@@ -1,10 +1,4 @@
 class AuditActivity::Investigation::UpdateStatus < AuditActivity::Investigation::Base
-  def migrate_to_metadata
-    is_closed = title.match?(/closed/i) ? [false, true] : [true, false]
-    self.metadata = title.match?(/closed/i) ? { updates: { is_closed: is_closed, date_closed: [nil, created_at] } } : { updates: { is_closed: is_closed } }
-    save!
-  end
-
   def self.from(_investigation)
     raise "Deprecated - use ChangeCaseStatus.call instead"
   end

--- a/db/migrate/20210426083705_migrate_invitation_update_status_audit_to_metadata.rb
+++ b/db/migrate/20210426083705_migrate_invitation_update_status_audit_to_metadata.rb
@@ -1,5 +1,0 @@
-class MigrateInvitationUpdateStatusAuditToMetadata < ActiveRecord::Migration[6.1]
-  def up
-    AuditActivity::Investigation::UpdateStatus.where(metadata: nil).find_each(&:migrate_to_metadata)
-  end
-end

--- a/spec/models/audit_activity/investigation/update_status_spec.rb
+++ b/spec/models/audit_activity/investigation/update_status_spec.rb
@@ -21,28 +21,4 @@ RSpec.describe AuditActivity::Investigation::UpdateStatus, :with_stubbed_elastic
       })
     end
   end
-
-  describe "#migrate_to_metadata" do
-    subject(:audit_activity) { create(:legacy_audit_investigation_update_status) }
-
-    context "when the case was closed" do
-      it "populates the metadata" do
-        expect { audit_activity.migrate_to_metadata }
-          .to change(audit_activity, :metadata)
-                .from(nil)
-                .to("updates" => { "is_closed" => [false, true], "date_closed" => [nil, JSON.parse(audit_activity.created_at.to_json)] })
-      end
-    end
-
-    context "when the case was re-opened" do
-      before { audit_activity.update!(title: "Allegation reopened") }
-
-      it "populates the metadata" do
-        expect { audit_activity.migrate_to_metadata }
-          .to change(audit_activity, :metadata)
-                .from(nil)
-                .to("updates" => { "is_closed" => [true, false] })
-      end
-    end
-  end
 end


### PR DESCRIPTION
Removes a migration which was taking longer than the 3 minute CloudFoundry timeout limit, causing deployments to fail.

I have run the migration manually.