### PR TITLE
use run task to run migration

### DIFF
--- a/deploy-review.sh
+++ b/deploy-review.sh
@@ -40,5 +40,7 @@ fi
 # Deploy the app
 cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var route=$APP_NAME.$DOMAIN --var app-name=$APP_NAME --var psd-db-name=$DB_NAME --var psd-host=$APP_NAME.$DOMAIN --var sidekiq-queue=$APP_NAME --var sentry-current-env=$APP_NAME --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS
 
+cf run-task -c "export \$(./env/get-env-from-vcap.sh) && bin/rails db:migrate db:seed" -k 2G
+
 # Remove the copied infrastructure env files to clean up
 rm -fR ${PWD-.}/env/

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -35,7 +35,7 @@ applications:
     - type: web
       env:
         RAILS_MAX_THREADS: ((web-max-threads))
-      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s ES_NAMESPACE=((app-name)) bin/rake cf:on_first_instance db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s ES_NAMESPACE=((app-name)) bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
       instances: 1
       memory: 2G
     - type: worker


### PR DESCRIPTION
This has still a major flaw which is does not fail the build when the migration fails