### PR TITLE
Fix risk assessment file not displayed on added audit activity

### DIFF
--- a/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
+++ b/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
@@ -1,0 +1,32 @@
+class AuditActivity::RiskAssessment::RiskAssessmentAddedDecorator < ApplicationDecorator
+  delegate_all
+
+  def title(*)
+    "Risk assessment"
+  end
+
+  def assessed_on
+    object.assessed_on.to_s(:govuk)
+  end
+
+  def risk_level
+    return object.custom_risk_level if object.custom_risk_level.present?
+
+    I18n.t(".investigations.risk_level.show.levels.#{object.risk_level}")
+  end
+
+  def assessed_by_name
+    return object.assessed_by_team.name if object.assessed_by_team
+    return object.assessed_by_business.trading_name if object.assessed_by_business
+
+    object.metadata["risk_assessment"]["assessed_by_other"]
+  end
+
+  def products_assessed
+    object.products_assessed.collect(&:name).to_sentence
+  end
+
+  def risk_assessment_file
+    object.risk_assessment_file&.filename
+  end
+end

--- a/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
+++ b/app/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator.rb
@@ -25,8 +25,4 @@ class AuditActivity::RiskAssessment::RiskAssessmentAddedDecorator < ApplicationD
   def products_assessed
     object.products_assessed.collect(&:name).to_sentence
   end
-
-  def risk_assessment_file
-    object.risk_assessment_file&.filename
-  end
 end

--- a/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
@@ -86,7 +86,9 @@ private
     return metadata if metadata["risk_assessment"].present?
 
     risk_assessment = RiskAssessment.find(metadata["risk_assessment_id"])
-    risk_assessment_updated = AuditActivity::RiskAssessment::RiskAssessmentUpdated.where("metadata->'risk_assessment_id' = ?", risk_assessment.id.to_s).count.positive?
+
+    # ID must be cast to String to avoid SQL error querying JSON column
+    risk_assessment_updated = AuditActivity::RiskAssessment::RiskAssessmentUpdated.where("metadata->'risk_assessment_id' = ?", risk_assessment.id.to_s).any?
 
     if risk_assessment_updated
       # We cannot reliably find the old file since orphaned files were

--- a/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
@@ -4,46 +4,121 @@ class AuditActivity::RiskAssessment::RiskAssessmentAdded < AuditActivity::Base
   end
 
   def self.build_metadata(risk_assessment)
-    {
-      risk_assessment_id: risk_assessment.id,
-      assessed_on: risk_assessment.assessed_on,
-      risk_level: risk_assessment.risk_level,
-      custom_risk_level: risk_assessment.custom_risk_level,
-      assessed_by_team_id: risk_assessment.assessed_by_team_id,
-      assessed_by_business_id: risk_assessment.assessed_by_business_id,
-      assessed_by_other: risk_assessment.assessed_by_other,
-      details: risk_assessment.details,
-      product_ids: risk_assessment.product_ids
-    }
+    { "risk_assessment" => risk_assessment.attributes.merge(
+      "product_ids" => risk_assessment.product_ids,
+      "risk_assessment_file" => risk_assessment.risk_assessment_file.blob&.attributes
+    ) }
   end
 
-  def title(*)
-    "Risk assessment"
+  # Temporarily override getter until data is migrated
+  # TODO: Remove method once data migrated
+  def metadata
+    migrate_metadata_structure
   end
 
   def subtitle_slug
     "Added"
   end
 
+  def risk_assessment
+    RiskAssessment.find(metadata["risk_assessment"]["id"])
+  end
+
+  # Some older activities cannot refer to the file as it was not recorded on the activity and may have subsequently been deleted, or the filename recorded on the updated activity was ambiguous
+  def risk_assessment_file
+    ActiveStorage::Blob.find(metadata["risk_assessment"]["risk_assessment_file"]["id"]) if metadata["risk_assessment"]["risk_assessment_file"]
+  end
+
   def products_assessed
-    Product.find(metadata["product_ids"])
+    Product.find(metadata["risk_assessment"]["product_ids"])
   end
 
   def further_details
-    metadata["details"].presence
+    metadata["risk_assessment"]["details"]
   end
 
-  def assessed_by_name
-    if metadata["assessed_by_team_id"]
-      Team.find(metadata["assessed_by_team_id"])&.name
-    elsif metadata["assessed_by_business_id"]
-      Business.find(metadata["assessed_by_business_id"])&.trading_name
-    else
-      metadata["assessed_by_other"]
-    end
+  def risk_level
+    metadata["risk_assessment"]["risk_level"]
   end
+
+  def custom_risk_level
+    metadata["risk_assessment"]["custom_risk_level"]
+  end
+
+  def assessed_on
+    Date.parse(metadata["risk_assessment"]["assessed_on"])
+  end
+
+  def assessed_by_team
+    Team.find_by(id: metadata["risk_assessment"]["assessed_by_team_id"])
+  end
+
+  def assessed_by_business
+    Business.find_by(id: metadata["risk_assessment"]["assessed_by_business_id"])
+  end
+
+private
 
   # Do not send investigation_updated mail when test result updated. This
   # overrides inherited functionality in the Activity model :(
   def notify_relevant_users; end
+
+  # Migrates metadata from old structure to current. This method can be deleted once data is migrated.
+  # TODO: Remove method once data migrated
+  #
+  # Old structure:
+  #
+  # {
+  #   risk_assessment_id: risk_assessment.id,
+  #   assessed_on: risk_assessment.assessed_on,
+  #   risk_level: risk_assessment.risk_level,
+  #   custom_risk_level: risk_assessment.custom_risk_level,
+  #   assessed_by_team_id: risk_assessment.assessed_by_team_id,
+  #   assessed_by_business_id: risk_assessment.assessed_by_business_id,
+  #   assessed_by_other: risk_assessment.assessed_by_other,
+  #   details: risk_assessment.details,
+  #   product_ids: risk_assessment.product_ids
+  # }
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    # Already in new format
+    return metadata if metadata["risk_assessment"].present?
+
+    risk_assessment = RiskAssessment.find(metadata["risk_assessment_id"])
+    risk_assessment_updated = AuditActivity::RiskAssessment::RiskAssessmentUpdated.where("metadata->'risk_assessment_id' = ?", risk_assessment.id.to_s).count.positive?
+
+    if risk_assessment_updated
+      # We cannot reliably find the old file since orphaned files were
+      # previously deleted and there are a large proportion of records with
+      # ambiguous filenames.
+      new_risk_assessment_file = nil
+      new_updated_at = updated_at
+    else
+      # If the risk assessment has not been updated we can safely assume the
+      # file has not changed since it was added
+      new_risk_assessment_file = risk_assessment.risk_assessment_file.blob&.attributes
+      new_updated_at = risk_assessment.updated_at
+    end
+
+    {
+      "risk_assessment" => {
+        "id" => metadata["risk_assessment_id"],
+        "investigation_id" => risk_assessment.investigation_id,
+        "assessed_on" => metadata["assessed_on"],
+        "assessed_by_team_id" => metadata["assessed_by_team_id"],
+        "assessed_by_business_id" => metadata["assessed_by_business_id"],
+        "assessed_by_other" => metadata["assessed_by_other"],
+        "details" => metadata["details"],
+        "custom_risk_level" => metadata["custom_risk_level"],
+        "added_by_user_id" => risk_assessment.added_by_user_id,
+        "added_by_team_id" => risk_assessment.added_by_team_id,
+        "created_at" => risk_assessment.created_at,
+        "updated_at" => new_updated_at,
+        "risk_level" => metadata["risk_level"],
+        "product_ids" => metadata["product_ids"],
+        "risk_assessment_file" => new_risk_assessment_file
+      }
+    }
+  end
 end

--- a/app/views/investigations/activities/risk_assessment/_risk_assessment_added.html.erb
+++ b/app/views/investigations/activities/risk_assessment/_risk_assessment_added.html.erb
@@ -1,17 +1,22 @@
 <div class="govuk-body">
-  Date of assessment: <%= Date.parse(activity.metadata["assessed_on"]).to_s(:govuk) %>
+  Date of assessment: <strong><%= activity.assessed_on %></strong>
   <br>
-  Risk level: <%= activity.metadata["custom_risk_level"].presence || I18n.t(".investigations.risk_level.show.levels.#{activity.metadata["risk_level"]}")  %>
+  Risk level: <strong><%= activity.risk_level %></strong>
   <br>
-  Assessed by: <%= activity.assessed_by_name  %>
+  Assessed by: <strong><%= activity.assessed_by_name %></strong>
   <br>
-  Product assessed: <%= activity.products_assessed.collect(&:name).to_sentence  %>
+  Product assessed: <strong><%= activity.products_assessed %></strong>
+
+  <% if activity.risk_assessment_file %>
+    <br>
+    Attached: <strong><%= activity.risk_assessment_file %></strong>
+  <% end %>
 
   <% if activity.further_details %>
     <br>
-    Further details: <%= activity.further_details %>
+    Further details: <strong><%= activity.further_details %></strong>
   <% end %>
 </div>
 
-<%= link_to "View risk assessment", investigation_risk_assessment_path(activity.investigation, activity.metadata["risk_assessment_id"]) %>
+<%= link_to "View risk assessment", investigation_risk_assessment_path(activity.investigation, activity.risk_assessment) %>
 

--- a/app/views/investigations/activities/risk_assessment/_risk_assessment_added.html.erb
+++ b/app/views/investigations/activities/risk_assessment/_risk_assessment_added.html.erb
@@ -9,7 +9,7 @@
 
   <% if activity.risk_assessment_file %>
     <br>
-    Attached: <strong><%= activity.risk_assessment_file %></strong>
+    Attached: <strong><%= link_to activity.risk_assessment_file.filename, url_for(activity.risk_assessment_file) %></strong>
   <% end %>
 
   <% if activity.further_details %>

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -35,3 +35,13 @@ cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && ID=<id> 
 ```
 
 Case collaborations and users which belong to the team identified by `ID` will be migrated to another team identified by `NEW_TEAM_ID`. The user identified by `EMAIL` will be attributed to the change on all relevant audit activity.
+
+## Migrating audit activity metadata
+
+Sometimes we need to update the structure of metadata stored against an activity type. We provide a task which can be used instead of ActiveRecord migrations to more safely migrate the data asynchronously to avoid problems with deployment timeouts and multiple versions of the code resulting in errors.
+
+```bash
+cf run-task psd-web --command "export \$(./env/get-env-from-vcap.sh) && CLASS_NAME=<activity class name> rake activities:update_metadata" --name <task name> -k 2G
+```
+
+To implement a conversion, override the `metadata` getter method on the class being changed to return legacy activity metadata in the new format. This task will invoke the overridden getter method and update each instance with the new structure.

--- a/lib/tasks/update_activity_metadata.rake
+++ b/lib/tasks/update_activity_metadata.rake
@@ -1,0 +1,27 @@
+namespace :activities do
+  desc "Updates the metadata for activities where the structure of these has changed"
+  task update_metadata: :environment do
+    class_to_update = ENV.fetch("CLASS_NAME").constantize
+
+    raise "Error: #{class_to_update} is not a subclass of Activity" unless class_to_update.new.is_a?(Activity)
+
+    succeeded = 0
+    failed = 0
+
+    puts "Migrating #{class_to_update.count} records of #{class_to_update}"
+
+    activities = class_to_update.all
+
+    activities.each do |activity|
+      begin
+        activity.update!(metadata: activity.metadata)
+        succeeded += 1
+      rescue
+        puts "Updating activity with ID #{activity.id} failed."
+        failed += 1
+      end
+    end
+
+    puts "Finished: #{succeeded} activities updated successfully. #{failed} activities failed to update; see previous log."
+  end
+end

--- a/lib/tasks/update_activity_metadata.rake
+++ b/lib/tasks/update_activity_metadata.rake
@@ -13,13 +13,11 @@ namespace :activities do
     activities = class_to_update.all
 
     activities.each do |activity|
-      begin
-        activity.update!(metadata: activity.metadata)
-        succeeded += 1
-      rescue
-        puts "Updating activity with ID #{activity.id} failed."
-        failed += 1
-      end
+      activity.update!(metadata: activity.metadata)
+      succeeded += 1
+    rescue StandardError
+      puts "Updating activity with ID #{activity.id} failed."
+      failed += 1
     end
 
     puts "Finished: #{succeeded} activities updated successfully. #{failed} activities failed to update; see previous log."

--- a/lib/tasks/update_activity_metadata.rake
+++ b/lib/tasks/update_activity_metadata.rake
@@ -10,9 +10,7 @@ namespace :activities do
 
     puts "Migrating #{class_to_update.count} records of #{class_to_update}"
 
-    activities = class_to_update.all
-
-    activities.each do |activity|
+    class_to_update.find_each do |activity|
       activity.update!(metadata: activity.metadata)
       succeeded += 1
     rescue StandardError

--- a/spec/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator_spec.rb
+++ b/spec/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAddedDecorator, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_antivirus do
+  subject(:activity) do
+    AuditActivity::RiskAssessment::RiskAssessmentAdded.create!(
+      source: UserSource.new(user: risk_assessment.added_by_user),
+      investigation: risk_assessment.investigation,
+      metadata: described_class.build_metadata(risk_assessment)
+    ).decorate
+  end
+
+  let(:risk_assessment) { create(:risk_assessment, trait, risk_level: risk_level, custom_risk_level: custom_risk_level, assessed_by_team: assessed_by_team, assessed_by_business: assessed_by_business, assessed_by_other: assessed_by_other, products: products) }
+  let(:trait) { :without_file }
+  let(:risk_level) { "serious" }
+  let(:custom_risk_level) { nil }
+  let(:assessed_by_team) { nil }
+  let(:assessed_by_business) { nil }
+  let(:assessed_by_other) { "test" }
+  let(:products) { [build(:product)] }
+
+  describe "#assessed_on" do
+    it "returns a generated String" do
+      expect(activity.assessed_on).to eq("20 July 2020")
+    end
+  end
+
+  describe "#risk_level" do
+    context "when custom_risk_level is nil" do
+      it "returns a generated String based on risk_level" do
+        expect(activity.risk_level).to eq("Serious risk")
+      end
+    end
+
+    context "when custom_risk_level is set" do
+      let(:risk_level) { "other" }
+      let(:custom_risk_level) { "test" }
+
+      it "returns custom_risk_level" do
+        expect(activity.risk_level).to eq(custom_risk_level)
+      end
+    end
+  end
+
+  describe "#assessed_by_name" do
+    context "when assessed_by_team is set" do
+      let(:assessed_by_team) { build(:team) }
+      let(:assessed_by_other) { nil }
+
+      it "returns the team name" do
+        expect(activity.assessed_by_name).to eq(assessed_by_team.name)
+      end
+    end
+
+    context "when assessed_by_business is set" do
+      let(:assessed_by_business) { build(:business, trading_name: "test") }
+      let(:assessed_by_other) { nil }
+
+      it "returns the business trading name" do
+        expect(activity.assessed_by_name).to eq(assessed_by_business.trading_name)
+      end
+    end
+
+    context "when neither assessed_by_team nor assessed_by_business is set" do
+      it "returns assessed_by_other" do
+        expect(activity.assessed_by_name).to eq(assessed_by_other)
+      end
+    end
+  end
+
+  describe "#products_assessed" do
+    context "with one product" do
+      let(:product) { build(:product) }
+      let(:products) { [product] }
+
+      it "returns the product name" do
+        expect(activity.products_assessed).to eq(product.name)
+      end
+    end
+
+    context "with multiple products" do
+      let(:product_1) { build(:product) }
+      let(:product_2) { build(:product) }
+      let(:product_3) { build(:product) }
+      let(:products) { [product_1, product_2, product_3] }
+
+      it "returns the product names in a single String" do
+        expect(activity.products_assessed).to eq("#{product_1.name}, #{product_2.name} and #{product_3.name}")
+      end
+    end
+  end
+
+  describe "#risk_assessment_file" do
+    context "with no file attached" do
+      it "returns nil" do
+        expect(activity.risk_assessment_file).to be_nil
+      end
+    end
+
+    context "with a file attached" do
+      let(:trait) { :with_file }
+
+      it "returns the filename" do
+        expect(activity.risk_assessment_file).to eq("new_risk_assessment.txt")
+      end
+    end
+  end
+end

--- a/spec/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator_spec.rb
+++ b/spec/decorators/audit_activity/risk_assessment/risk_assessment_added_decorator_spec.rb
@@ -88,20 +88,4 @@ RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAddedDecorator, :wit
       end
     end
   end
-
-  describe "#risk_assessment_file" do
-    context "with no file attached" do
-      it "returns nil" do
-        expect(activity.risk_assessment_file).to be_nil
-      end
-    end
-
-    context "with a file attached" do
-      let(:trait) { :with_file }
-
-      it "returns the filename" do
-        expect(activity.risk_assessment_file).to eq("new_risk_assessment.txt")
-      end
-    end
-  end
 end

--- a/spec/factories/risk_assessments.rb
+++ b/spec/factories/risk_assessments.rb
@@ -10,5 +10,22 @@ FactoryBot.define do
     products { [build(:product)] }
     added_by_user { association :user }
     added_by_team { association :team }
+
+    transient do
+      file_description { Faker::Hipster.sentence }
+    end
+
+    trait :without_file do
+      risk_assessment_file { nil }
+    end
+
+    trait :with_file do
+      risk_assessment_file { Rack::Test::UploadedFile.new("test/fixtures/files/new_risk_assessment.txt") }
+
+      after(:create) do |risk_assessment, evaluator|
+        risk_assessment.risk_assessment_file_blob.metadata["description"] = evaluator.file_description
+        risk_assessment.risk_assessment_file_blob.save!
+      end
+    end
   end
 end

--- a/spec/features/add_a_risk_assessment_to_a_case_spec.rb
+++ b/spec/features/add_a_risk_assessment_to_a_case_spec.rb
@@ -138,6 +138,7 @@ RSpec.feature "Adding a risk assessment to a case", :with_stubbed_elasticsearch,
     expect(page).to have_text("Risk level: Serious risk")
     expect(page).to have_text("Assessed by: MyCouncil Trading Standards")
     expect(page).to have_text("Product assessed: MyBrand washing machine model X")
+    expect(page).to have_text("Attached: new_risk_assessment.txt")
     expect(page).to have_text("Further details: Products risk-assessed in response to incident.")
 
     expect(page).to have_link("View risk assessment")

--- a/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
+++ b/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAdded, :with_stubbed
 
       context "when the risk assessment has not been subsequently updated" do
         it "returns the file blob metadata" do
-          expect(activity.metadata["risk_assessment"]["risk_assessment_file"]).to match(hash_including(risk_assessment.risk_assessment_file.blob.attributes.except("created_at", "updated_at")))
+          expect(JSON.parse(activity.metadata["risk_assessment"]["risk_assessment_file"].to_json)).to eq(JSON.parse(risk_assessment.risk_assessment_file.blob.attributes.to_json))
         end
 
         it "returns the updated_at of the risk assessment" do

--- a/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
+++ b/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAdded, :with_stubbed
             "custom_risk_level" => risk_assessment.custom_risk_level,
             "added_by_user_id" => risk_assessment.added_by_user_id,
             "added_by_team_id" => risk_assessment.added_by_team_id,
-            "created_at" => risk_assessment.created_at,
             "risk_level" => risk_assessment.risk_level,
             "product_ids" => risk_assessment.product_ids
           })
@@ -64,11 +63,11 @@ RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAdded, :with_stubbed
 
       context "when the risk assessment has not been subsequently updated" do
         it "returns the file blob metadata" do
-          expect(activity.metadata["risk_assessment"]["risk_assessment_file"]).to eq(risk_assessment.risk_assessment_file.blob.attributes)
+          expect(activity.metadata["risk_assessment"]["risk_assessment_file"]).to match(hash_including(risk_assessment.risk_assessment_file.blob.attributes.except("created_at", "updated_at")))
         end
 
         it "returns the updated_at of the risk assessment" do
-          expect(activity.metadata["risk_assessment"]["updated_at"]).to eq(risk_assessment.updated_at)
+          expect(activity.metadata["risk_assessment"]["updated_at"].to_i).to eq(risk_assessment.updated_at.to_i)
         end
       end
 

--- a/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
+++ b/spec/models/audit_activity/risk_assessment/risk_assessment_added_spec.rb
@@ -1,0 +1,199 @@
+require "rails_helper"
+
+RSpec.describe AuditActivity::RiskAssessment::RiskAssessmentAdded, :with_stubbed_elasticsearch, :with_stubbed_mailer, :with_stubbed_antivirus do
+  subject(:activity) do
+    described_class.create!(
+      source: UserSource.new(user: risk_assessment.added_by_user),
+      investigation: risk_assessment.investigation,
+      metadata: metadata
+    )
+  end
+
+  let(:risk_assessment) { create(:risk_assessment, trait, assessed_by_team: assessed_by_team, assessed_by_business: assessed_by_business, assessed_by_other: assessed_by_other, products: products) }
+  let(:trait) { :without_file }
+  let(:assessed_by_team) { nil }
+  let(:assessed_by_business) { nil }
+  let(:assessed_by_other) { "test" }
+  let(:products) { [build(:product)] }
+  let(:metadata) { described_class.build_metadata(risk_assessment) }
+
+  describe "#metadata" do
+    context "when the metadata is in the current format" do
+      it "returns the metadata" do
+        expect(activity.metadata).to eq(activity.read_attribute(:metadata))
+      end
+    end
+
+    context "when the activity was generated prior to the metadata structure revision" do
+      let(:trait) { :with_file }
+      let(:metadata) do
+        {
+          risk_assessment_id: risk_assessment.id,
+          assessed_on: risk_assessment.assessed_on,
+          risk_level: risk_assessment.risk_level,
+          custom_risk_level: risk_assessment.custom_risk_level,
+          assessed_by_team_id: risk_assessment.assessed_by_team_id,
+          assessed_by_business_id: risk_assessment.assessed_by_business_id,
+          assessed_by_other: risk_assessment.assessed_by_other,
+          details: risk_assessment.details,
+          product_ids: risk_assessment.product_ids
+        }
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "returns a Hash in the new format" do
+        expect(activity.metadata).to match({
+          "risk_assessment" => hash_including({
+            "id" => risk_assessment.id,
+            "investigation_id" => risk_assessment.investigation_id,
+            "assessed_on" => "2020-07-20",
+            "assessed_by_team_id" => risk_assessment.assessed_by_team_id,
+            "assessed_by_business_id" => risk_assessment.assessed_by_business_id,
+            "assessed_by_other" => risk_assessment.assessed_by_other,
+            "details" => risk_assessment.details,
+            "custom_risk_level" => risk_assessment.custom_risk_level,
+            "added_by_user_id" => risk_assessment.added_by_user_id,
+            "added_by_team_id" => risk_assessment.added_by_team_id,
+            "created_at" => risk_assessment.created_at,
+            "risk_level" => risk_assessment.risk_level,
+            "product_ids" => risk_assessment.product_ids
+          })
+        })
+      end
+      # rubocop:enable RSpec/ExampleLength
+
+      context "when the risk assessment has not been subsequently updated" do
+        it "returns the file blob metadata" do
+          expect(activity.metadata["risk_assessment"]["risk_assessment_file"]).to eq(risk_assessment.risk_assessment_file.blob.attributes)
+        end
+
+        it "returns the updated_at of the risk assessment" do
+          expect(activity.metadata["risk_assessment"]["updated_at"]).to eq(risk_assessment.updated_at)
+        end
+      end
+
+      context "when the risk assessment has been subsequently updated" do
+        before do
+          UpdateRiskAssessment.call!(
+            user: risk_assessment.added_by_user,
+            risk_assessment: risk_assessment,
+            details: "test update",
+            assessed_on: risk_assessment.assessed_on,
+            risk_level: risk_assessment.risk_level,
+            product_ids: risk_assessment.product_ids,
+            assessed_by_other: risk_assessment.assessed_by_other
+          )
+        end
+
+        it "does not return the file blob metadata" do
+          expect(activity.metadata["risk_assessment"]["risk_assessment_file"]).to be_nil
+        end
+
+        it "returns the updated_at of the activity" do
+          expect(activity.metadata["risk_assessment"]["updated_at"]).to eq(activity.updated_at)
+        end
+      end
+    end
+  end
+
+  describe "#risk_assessment" do
+    it "returns the risk assessment" do
+      expect(activity.risk_assessment).to eq(risk_assessment)
+    end
+  end
+
+  describe "#risk_assessment_file" do
+    context "with no file attached to the risk assessment" do
+      it "returns nil" do
+        expect(activity.risk_assessment_file).to be_nil
+      end
+    end
+
+    context "with a file attached to the risk assessment" do
+      let(:trait) { :with_file }
+
+      it "returns the blob" do
+        expect(activity.risk_assessment_file.filename).to eq("new_risk_assessment.txt")
+      end
+    end
+  end
+
+  describe "#products_assessed" do
+    context "with one product on the risk assessment" do
+      let(:product) { create(:product) }
+      let(:products) { [product] }
+
+      it "returns the product" do
+        expect(activity.products_assessed).to eq(products)
+      end
+    end
+
+    context "with multiple products on the risk assessment" do
+      let(:product_1) { create(:product) }
+      let(:product_2) { create(:product) }
+      let(:products) { [product_1, product_2] }
+
+      it "returns an Array of products" do
+        expect(activity.products_assessed).to eq(products)
+      end
+    end
+  end
+
+  describe "#further_details" do
+    it "returns the risk assessment details" do
+      expect(activity.further_details).to eq(risk_assessment.details)
+    end
+  end
+
+  describe "#risk_level" do
+    it "returns the risk assessment risk_level" do
+      expect(activity.risk_level).to eq(risk_assessment.risk_level)
+    end
+  end
+
+  describe "#custom_risk_level" do
+    it "returns the risk assessment custom_risk_level" do
+      expect(activity.custom_risk_level).to eq(risk_assessment.custom_risk_level)
+    end
+  end
+
+  describe "#assessed_on" do
+    it "returns the risk assessment assessed_on" do
+      expect(activity.assessed_on).to eq(risk_assessment.assessed_on)
+    end
+  end
+
+  describe "#assessed_by_team" do
+    context "when assessed_by_team on the risk assessment is nil" do
+      it "returns nil" do
+        expect(activity.assessed_by_team).to be_nil
+      end
+    end
+
+    context "when assessed_by_team on the risk assessment is set" do
+      let(:assessed_by_team) { create(:team) }
+      let(:assessed_by_other) { nil }
+
+      it "returns the Team" do
+        expect(activity.assessed_by_team).to eq(assessed_by_team)
+      end
+    end
+  end
+
+  describe "#assessed_by_business" do
+    context "when assessed_by_business on the risk assessment is nil" do
+      it "returns nil" do
+        expect(activity.assessed_by_business).to be_nil
+      end
+    end
+
+    context "when assessed_by_business on the risk assessment is set" do
+      let(:assessed_by_business) { create(:business) }
+      let(:assessed_by_other) { nil }
+
+      it "returns the Business" do
+        expect(activity.assessed_by_business).to eq(assessed_by_business)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/2DTwhgRB/731-add-risk-assessment-file-attached-doesnt-get-record-in-activity-log

## Description
Fixes the attached file not being displayed on the activity log. Also tidies up the view template and moves logic which should not be in the view to a decorator, and backfills missing tests.

We now store the complete file metadata in the activity so can trace the history of a risk assessment more completely.

**Importantly, this introduces a proposed design for how to handle migrations of activity metadata without the use of ActiveRecord migrations.**

Migrations have previously caused issues during deployments due to deployment timeout thresholds being reached, and the zero-downtime deploys resulting in two versions of the code being active during the deployment - sometimes resulting in errors shown to users for a short time.

This design is summarised below:

* Override the `metadata` getter method to convert the Hash structure on the fly. This is useful during deployments when there are still instances with the old code active, and provides a neat way to implement the conversion logic without introducing extra methods
* Provide a generic rake task which can be used to migrate the metadata for a given class name.

Using the `metadata` override means the migration task is non-destructive if run repeatedly, and we don't need to keep creating single use rake tasks every time we want to change the structure.

Example usage:

```
CLASS_NAME=AuditActivity::RiskAssessment::RiskAssessmentAdded bin/rake activities:update_metadata
```

This task can be run at any time post-deployment, and in the meantime users should not suffer any errors.

### Limitations
On investigation of production data, I concluded it is not possible to reconcile the original risk assessment file if it has been subsequently updated. As of this writing, this affects 105 records out of a total of 560.

This is due to some of the files having been deleted (our codebase previously automatically deleted orphaned files), and the updated activity metadata only stores the filename which in most cases provides an ambiguous match. It may be possible to reconcile a subset of these 105 records via more intricate detective work, but that can be tackled as a separate task.