### PR TITLE
fix product not appearing in the search after removal

### DIFF
--- a/app/services/remove_product_from_case.rb
+++ b/app/services/remove_product_from_case.rb
@@ -11,7 +11,7 @@ class RemoveProductFromCase
 
     investigation.products.delete(product)
 
-    product.__elasticsearch__.delete_document
+    investigation.__elasticsearch__.update_document
 
     context.activity = create_audit_activity_for_product_removed
 

--- a/spec/services/remove_product_from_case_spec.rb
+++ b/spec/services/remove_product_from_case_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RemoveProductFromCase, :with_stubbed_elasticsearch, :with_test_queue_adapter do
+RSpec.describe RemoveProductFromCase, :with_test_queue_adapter do
   subject(:result) { described_class.call(investigation: investigation, product: product, user: user, reason: reason) }
 
   let(:investigation) { create(:allegation, products: [product], creator: creator) }
@@ -11,64 +11,78 @@ RSpec.describe RemoveProductFromCase, :with_stubbed_elasticsearch, :with_test_qu
   let(:owner)         { user }
 
   describe ".call" do
-    context "with no parameters" do
-      let(:result) { described_class.call }
+    context "with stubbed elasticsearh", :with_stubbed_elasticsearch do
+      context "with no parameters" do
+        let(:result) { described_class.call }
 
-      it "returns a failure" do
-        expect(result).to be_failure
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+
+      context "with no investigation parameter" do
+        let(:result) { described_class.call(product: product, user: user) }
+
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+
+      context "with no product parameter" do
+        let(:result) { described_class.call(investigation: investigation, user: user) }
+
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+
+      context "with no user parameter" do
+        let(:result) { described_class.call(investigation: investigation, product: product) }
+
+        it "returns a failure" do
+          expect(result).to be_failure
+        end
+      end
+
+      context "with required parameters" do
+        def expected_email_subject
+          "Allegation updated"
+        end
+
+        def expected_email_body(name)
+          "Product was removed from the allegation by #{name}."
+        end
+
+        it "returns success" do
+          expect(result).to be_success
+        end
+
+        it "removes the product from the case" do
+          result
+          expect(investigation.reload.products).not_to include(product)
+        end
+
+        it "creates an audit activity", :aggregate_failures do
+          result
+          activity = investigation.reload.activities.find_by!(type: AuditActivity::Product::Destroy.name)
+          expect(activity).to have_attributes(title: nil, body: nil, product_id: product.id, metadata: { "reason" => reason, "product" => JSON.parse(product.attributes.to_json) })
+          expect(activity.source.user).to eq(user)
+        end
+
+        it_behaves_like "a service which notifies the case owner"
       end
     end
 
-    context "with no investigation parameter" do
-      let(:result) { described_class.call(product: product, user: user) }
+    context "when searchin for product once removed from the case", :with_elasticsearch do
+      let(:records) { Product.full_search(ElasticsearchQuery.new(product.name, {}, {})).records }
 
-      it "returns a failure" do
-        expect(result).to be_failure
+      before { Product.import(refresh: :wait_for) }
+
+      it "the product should remain searchable" do
+        result
+
+        expect(records.to_a).to include(product)
       end
     end
-
-    context "with no product parameter" do
-      let(:result) { described_class.call(investigation: investigation, user: user) }
-
-      it "returns a failure" do
-        expect(result).to be_failure
-      end
-    end
-  end
-
-  context "with no user parameter" do
-    let(:result) { described_class.call(investigation: investigation, product: product) }
-
-    it "returns a failure" do
-      expect(result).to be_failure
-    end
-  end
-
-  context "with required parameters" do
-    def expected_email_subject
-      "Allegation updated"
-    end
-
-    def expected_email_body(name)
-      "Product was removed from the allegation by #{name}."
-    end
-
-    it "returns success" do
-      expect(result).to be_success
-    end
-
-    it "removes the product from the case" do
-      result
-      expect(investigation.reload.products).not_to include(product)
-    end
-
-    it "creates an audit activity", :aggregate_failures do
-      result
-      activity = investigation.reload.activities.find_by!(type: AuditActivity::Product::Destroy.name)
-      expect(activity).to have_attributes(title: nil, body: nil, product_id: product.id, metadata: { "reason" => reason, "product" => JSON.parse(product.attributes.to_json) })
-      expect(activity.source.user).to eq(user)
-    end
-
-    it_behaves_like "a service which notifies the case owner"
   end
 end

--- a/spec/services/remove_product_from_case_spec.rb
+++ b/spec/services/remove_product_from_case_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe RemoveProductFromCase, :with_test_queue_adapter do
       end
     end
 
-    context "when searchin for product once removed from the case", :with_elasticsearch do
+    context "when searching for product once removed from the case", :with_elasticsearch do
       let(:records) { Product.full_search(ElasticsearchQuery.new(product.name, {}, {})).records }
 
       before { Product.import(refresh: :wait_for) }


### PR DESCRIPTION
## Description

Address bug where instead of updating the investigation index after removing the product, the product search index was removed.
