### PR TITLE
Move safety and compliance section on case overview

### DIFF
--- a/app/views/investigations/tabs/_overview.html.erb
+++ b/app/views/investigations/tabs/_overview.html.erb
@@ -31,12 +31,6 @@
       rows: risks_and_issues_rows(@investigation, current_user)
     ) %>
 
-    <% if @investigation.complainant %>
-      <%= govuk_hr %>
-      <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.upcase_first %></h2>
-      <%= @investigation.source_details_summary_list(policy(@investigation).view_protected_details?) %>
-    <% end %>
-
     <%= govuk_hr %>
     <h2 class="govuk-heading-m">Safety and compliance</h2>
 
@@ -44,6 +38,13 @@
     classes: "govuk-summary-list--no-border app-summary-list--actions-on-own-line",
     rows: safety_and_compliance_rows(@investigation, current_user)
     ) %>
+    
+    <% if @investigation.complainant %>
+      <%= govuk_hr %>
+      <h2 class="govuk-heading-m"><%= @investigation.type.demodulize.upcase_first %></h2>
+      <%= @investigation.source_details_summary_list(policy(@investigation).view_protected_details?) %>
+    <% end %>
+
 
     <%= govuk_hr %>
     <h2 class="govuk-heading-m">Sharing and collaboration</h2>


### PR DESCRIPTION
https://trello.com/c/mhYKkN7W/1024-1-move-safety-and-compliance-section-opss-cases

## Description
Move safety and compliance section to below risks and issues section on overview page

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
