### PR TITLE
Fix sentry audit visibility

### DIFF
--- a/app/models/audit_activity/investigation/update_visibility.rb
+++ b/app/models/audit_activity/investigation/update_visibility.rb
@@ -12,8 +12,24 @@ class AuditActivity::Investigation::UpdateVisibility < AuditActivity::Investigat
     }
   end
 
+  def metadata
+    migrate_metadata_structure
+  end
+
 private
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if already_in_new_format?
+
+    { "updates" => { "is_private" => title.match?(/\s+restricted$/im) } }
+  end
 
   # Do not send investigation_updated mail. This is handled by the ChangeCaseVisibility service
   def notify_relevant_users; end
+
+  def already_in_new_format?
+    self[:metadata]&.key?("updates")
+  end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -25,4 +25,9 @@ FactoryBot.define do
     investigation { create :allegation }
     title { "Allegation closed" }
   end
+
+  factory :legacy_audit_investigation_visibility_status, class: "AuditActivity::Investigation::UpdateVisibility" do
+    investigation { create :allegation }
+    title { "Allegation visibility\n            restricted" }
+  end
 end

--- a/spec/models/audit_activity/investigation/update_visibility_spec.rb
+++ b/spec/models/audit_activity/investigation/update_visibility_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe AuditActivity::Investigation::UpdateVisibility, :with_stubbed_ela
   describe ".build_metadata" do
     it "returns a Hash of the arguments" do
       expect(metadata).to eq({
-                               updates: {
-                                 "is_private" => [false, true]
-                               },
-                               rationale: rationale
-                             })
+        updates: {
+          "is_private" => [false, true]
+        },
+        rationale: rationale
+      })
     end
   end
 

--- a/spec/models/audit_activity/investigation/update_visibility_spec.rb
+++ b/spec/models/audit_activity/investigation/update_visibility_spec.rb
@@ -24,10 +24,22 @@ RSpec.describe AuditActivity::Investigation::UpdateVisibility, :with_stubbed_ela
 
   describe "#metadata" do
     context "with legacy audit" do
-      subject(:audit_activity) { migrates the aud }
+      subject(:audit_activity) { create(:legacy_audit_investigation_visibility_status, title: title) }
 
-      it "populates the audit" do
+      context "with restricted status" do
+        let(:title) { "Allegation visibility\n            Restricted" }
 
+        it "populates the audit" do
+          expect(audit_activity.metadata).to eq("updates" => { "is_private" => true })
+        end
+      end
+
+      context "with unrestricted status" do
+        let(:title) { "Allegation visibility\n            Unrestricted" }
+
+        it "populates the audit" do
+          expect(audit_activity.metadata).to eq("updates" => { "is_private" => false })
+        end
       end
     end
   end

--- a/spec/models/audit_activity/investigation/update_visibility_spec.rb
+++ b/spec/models/audit_activity/investigation/update_visibility_spec.rb
@@ -14,11 +14,21 @@ RSpec.describe AuditActivity::Investigation::UpdateVisibility, :with_stubbed_ela
   describe ".build_metadata" do
     it "returns a Hash of the arguments" do
       expect(metadata).to eq({
-        updates: {
-          "is_private" => [false, true]
-        },
-        rationale: rationale
-      })
+                               updates: {
+                                 "is_private" => [false, true]
+                               },
+                               rationale: rationale
+                             })
+    end
+  end
+
+  describe "#metadata" do
+    context "with legacy audit" do
+      subject(:audit_activity) { migrates the aud }
+
+      it "populates the audit" do
+
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

This fix legacy investigation visibility update audit logs throwing an error on the activity page