### PR TITLE
Fix 404 error thrown when form submitted twice

### DIFF
--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -48,7 +48,11 @@ class CollaboratorsController < ApplicationController
   def update
     authorize @investigation, :manage_collaborators?
 
-    @collaboration = @investigation.collaboration_accesses.changeable.find(params[:id])
+    @collaboration = @investigation.collaboration_accesses.find_by(id: params[:id])
+
+    return redirect_to investigation_collaborators_path(@investigation) unless @collaboration # Usually due to double form submission
+    return render_404_page unless @collaboration.class.changeable?
+
     @collaborator = @collaboration.collaborator
 
     @edit_form = EditCaseCollaboratorForm.new(edit_params.merge(collaboration: @collaboration))

--- a/spec/requests/edit_collaborator_spec.rb
+++ b/spec/requests/edit_collaborator_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe "Editing a collaborator for a case", type: :request, with_stubbed
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "when the collaboration has already been deleted", :with_errors_rendered do
+      before do
+        edit_access_collaboration.destroy!
+      end
+
+      it "redirects back to the 'teams added to case' page" do
+        expect(do_request).to redirect_to(investigation_collaborators_path(investigation))
+      end
+    end
   end
 
   context "when the user isn't part of the team assigned", :with_errors_rendered do


### PR DESCRIPTION
https://trello.com/c/edFNkDun/673-double-click-on-remove-team-form-returns-404-error

## Description
Fixes an unhelpful 404 error page which is shown if the user submits the form twice (e.g. double click).