### PR TITLE
Split attachment tab out into images and attachments

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -49,4 +49,12 @@ class Product < ApplicationRecord
   def supporting_information
     tests + corrective_actions + unexpected_events + risk_assessments
   end
+
+  def images
+    documents.includes(:blob).joins(:blob).where("left(content_type, 5) = 'image'")
+  end
+
+  def non_image_documents
+    documents.includes(:blob).joins(:blob).where("left(content_type, 5) != 'image'")
+  end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -51,7 +51,7 @@
     },
     {
       id: "images",
-      label: "Images (#{@product.documents.count})",
+      label: "Images (#{@product.images.count})",
       panel: { html: render("products/tabs/images") }
     },
     {

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -46,8 +46,13 @@
     },
     {
       id: "attachments",
-      label: "Attachments (#{@product.documents.count})",
+      label: "Attachments (#{@product.non_image_documents.count})",
       panel: { html: render("products/tabs/attachments") }
+    },
+    {
+      id: "images",
+      label: "Images (#{@product.documents.count})",
+      panel: { html: render("products/tabs/images") }
     },
     {
       id: "cases",

--- a/app/views/products/tabs/_attachments.html.erb
+++ b/app/views/products/tabs/_attachments.html.erb
@@ -15,4 +15,4 @@
   </div>
 </div>
 
-<%= render "documents_list_summary", parent: @product %>
+<%= render partial: "documents/document_card", collection: @product.non_image_documents, as: :document, locals: { parent: @product } %>

--- a/app/views/products/tabs/_images.html.erb
+++ b/app/views/products/tabs/_images.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <h2 class="govuk-heading-m">Images</h2>
+
+    <p class="govuk-body">
+      <%= link_to "Add image", new_document_flow_path(@product), class: "govuk-link" %>
+    </p>
+
+    <hr class="govuk-section-break govuk-section-break--l">
+
+    <% if @product.images.empty? %>
+      <p class="govuk-body">No attachments</p>
+    <% end %>
+  </div>
+</div>
+
+<%= render partial: "documents/document_card", collection: @product.images, as: :document, locals: { parent: @product } %>

--- a/spec/features/add_attachment_to_a_product_spec.rb
+++ b/spec/features/add_attachment_to_a_product_spec.rb
@@ -4,9 +4,48 @@ RSpec.feature "Add an attachment to a product", :with_stubbed_elasticsearch, :wi
   let(:user)    { create(:user, :activated, has_viewed_introduction: true) }
   let(:product) { create(:product) }
 
-  let(:file)        { Rails.root + "test/fixtures/files/testImage.png" }
-  let(:title)       { Faker::Lorem.sentence }
-  let(:description) { Faker::Lorem.paragraph }
+  let(:image)                 { Rails.root + "test/fixtures/files/testImage.png" }
+  let(:non_image_attachment)  { Rails.root + "test/fixtures/files/email_file.txt" }
+  let(:title)                 { Faker::Lorem.sentence }
+  let(:description)           { Faker::Lorem.paragraph }
+
+  scenario "Adding an image" do
+    sign_in user
+    visit "/products/#{product.id}"
+
+    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
+
+    click_link "Add image"
+    expect_to_be_on_add_attachment_to_a_product_upload_page(product_id: product.id)
+
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_product_upload_page(product_id: product.id)
+    expect(page).to have_error_summary("Enter file")
+
+    attach_file "document[file][file]", image
+    click_button "Upload"
+
+    expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id: product.id)
+
+    click_button "Save attachment"
+
+    expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id: product.id)
+    expect(page).to have_error_summary("Enter title")
+
+    fill_in "Document title", with: title
+    fill_in "Description",    with: description
+
+    click_button "Save attachment"
+
+    expect_to_be_on_product_page(product_id: product.id, product_name: product.name)
+    expect_confirmation_banner("File has been added to the product")
+
+    within "#images" do
+      expect(page).to have_selector("h2", text: title)
+      expect(page).to have_selector("p", text: description)
+    end
+  end
 
   scenario "Adding an attachment" do
     sign_in user
@@ -22,7 +61,7 @@ RSpec.feature "Add an attachment to a product", :with_stubbed_elasticsearch, :wi
     expect_to_be_on_add_attachment_to_a_product_upload_page(product_id: product.id)
     expect(page).to have_error_summary("Enter file")
 
-    attach_file "document[file][file]", file
+    attach_file "document[file][file]", non_image_attachment
     click_button "Upload"
 
     expect_to_be_on_add_attachment_to_a_product_metadata_page(product_id: product.id)


### PR DESCRIPTION
https://trello.com/c/60lu8SWT/586-split-product-attachments-tab-in-to-images-and-attachments-tabs

## Description
Split product attachments tab in to images and attachments tabs

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
