### PR TITLE
Refactor Activity model to remove inherited notification callbacks

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,7 @@ class CommentsController < ApplicationController
   before_action :set_investigation
 
   def create
-    @comment = Activity.new(comment_activity_params)
+    @comment = CommentActivity.new(comment_activity_params)
     @comment.investigation = @investigation
     @comment.source = UserSource.new(user: current_user)
     @investigation = @investigation.decorate
@@ -23,7 +23,7 @@ class CommentsController < ApplicationController
   end
 
   def new
-    @comment = @investigation.activities.new
+    @comment = CommentActivity.new
     @investigation = @investigation.decorate
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,8 +3,6 @@ class Activity < ApplicationRecord
 
   has_one :source, as: :sourceable, dependent: :destroy
 
-  after_save :notify_relevant_users
-
   def attached_image?
     nil
   end
@@ -26,7 +24,7 @@ class Activity < ApplicationRecord
     "#{subtitle_slug} by #{source&.show(viewer)}, #{pretty_date_stamp}"
   end
 
-  def search_index;  end
+  def search_index; end
 
   def self.sanitize_text(text)
     return text.to_s.strip.gsub(/[*_~]/) { |match| "\\#{match}" } if text
@@ -40,31 +38,10 @@ class Activity < ApplicationRecord
     # where necessary should be implemented by subclasses
   end
 
-  def email_update_text(viewer = nil); end
-
-  def email_subject_text
-    "#{investigation.case_type.upcase_first} updated"
-  end
-
   # Used to determine which view template to use for new records with metadata
   # instead of pre-generated HTML
   def template_name
     self.class.name.delete_prefix("AuditActivity::").underscore
-  end
-
-  def entities_to_notify
-    entities = users_to_notify
-
-    teams_to_notify.each do |team|
-      if team.team_recipient_email.present?
-        entities << team
-      else
-        users_from_team = team.users.active
-        entities.concat(users_from_team)
-      end
-    end
-
-    entities.uniq
   end
 
 private
@@ -74,25 +51,4 @@ private
   end
 
   def subtitle_slug; end
-
-  def notify_relevant_users
-    entities_to_notify.each do |entity|
-      email = entity.is_a?(Team) ? entity.team_recipient_email : entity.email
-      NotifyMailer.investigation_updated(investigation.pretty_id, entity.name, email, email_update_text(entity), email_subject_text).deliver_later
-    end
-  end
-
-  def users_to_notify
-    return [] unless investigation.owner.is_a? User
-    return [] if source&.user == investigation.owner
-
-    [investigation.owner]
-  end
-
-  def teams_to_notify
-    return [] unless investigation.owner.is_a? Team
-    return [] if source&.user&.team == investigation.owner
-
-    [investigation.owner]
-  end
 end

--- a/app/models/audit_activity/accident_or_incident/accident_or_incident_added.rb
+++ b/app/models/audit_activity/accident_or_incident/accident_or_incident_added.rb
@@ -1,10 +1,6 @@
 class AuditActivity::AccidentOrIncident::AccidentOrIncidentAdded < AuditActivity::Base
   belongs_to :product, class_name: "::Product"
 
-  def self.from(*)
-    raise "Deprecated - use AddAccidentOrIncidentToCase.call instead"
-  end
-
   def self.build_metadata(accident_or_incident)
     {
       accident_or_incident_id: accident_or_incident.id,
@@ -25,8 +21,4 @@ class AuditActivity::AccidentOrIncident::AccidentOrIncidentAdded < AuditActivity
   def subtitle_slug
     "Added"
   end
-
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/accident_or_incident/accident_or_incident_updated.rb
+++ b/app/models/audit_activity/accident_or_incident/accident_or_incident_updated.rb
@@ -1,8 +1,4 @@
 class AuditActivity::AccidentOrIncident::AccidentOrIncidentUpdated < AuditActivity::Base
-  def self.from(*)
-    raise "Deprecated - use UpdateAccidentOrIncident.call instead"
-  end
-
   def self.build_metadata(accident_or_incident)
     updates = accident_or_incident.previous_changes.slice(
       :date,
@@ -54,8 +50,4 @@ private
   def is_date_know_has_been_changed_from_no_to_yes?
     updates["is_date_known"]&.second
   end
-
-  # Do not send investigation_updated mail when risk assessment updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/alert/add.rb
+++ b/app/models/audit_activity/alert/add.rb
@@ -1,4 +1,5 @@
 class AuditActivity::Alert::Add < AuditActivity::Base
+  include ActivityNotification
   extend ActionView::Helpers::NumberHelper
   belongs_to :investigation
 

--- a/app/models/audit_activity/business/add.rb
+++ b/app/models/audit_activity/business/add.rb
@@ -5,10 +5,6 @@ class AuditActivity::Business::Add < AuditActivity::Base
     { business: business.attributes, investigation_business: business_investigation.attributes }
   end
 
-  def self.from(*)
-    raise "Deprecated - use AddBusinessToCase.call instead"
-  end
-
   def metadata
     migrate_metadata_structure
   end
@@ -27,8 +23,6 @@ private
       }
     }.to_json)
   end
-
-  def notify_relevant_users; end
 
   def extract_relationship_from_body
     body.match(/Role: \*\*(?<relationship>.*)\*\*/)["relationship"].delete("\\")

--- a/app/models/audit_activity/business/destroy.rb
+++ b/app/models/audit_activity/business/destroy.rb
@@ -5,10 +5,6 @@ class AuditActivity::Business::Destroy < AuditActivity::Base
     { reason: reason, business: business.attributes }
   end
 
-  def self.from(_business, _investigation)
-    raise "Deprecated - use RemoveBusinessFromCase.call instead"
-  end
-
   def metadata
     migrate_metadata_structure
   end
@@ -18,8 +14,6 @@ private
   def subtitle_slug
     "Business removed"
   end
-
-  def notify_relevant_users; end
 
   def migrate_metadata_structure
     metadata = self[:metadata]

--- a/app/models/audit_activity/corrective_action/base.rb
+++ b/app/models/audit_activity/corrective_action/base.rb
@@ -5,10 +5,6 @@ class AuditActivity::CorrectiveAction::Base < AuditActivity::Base
   belongs_to :business, optional: true, class_name: "::Business"
   belongs_to :product, class_name: "::Product"
 
-  def self.from(_corrective_action)
-    raise "Deprecated - use a service class instead"
-  end
-
   def corrective_action
     if attachment.attached?
       attachment.blob.attachments.find_by(record_type: "CorrectiveAction")&.record
@@ -20,8 +16,4 @@ class AuditActivity::CorrectiveAction::Base < AuditActivity::Base
   def activity_type
     "corrective action"
   end
-
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/correspondence/add_meeting.rb
+++ b/app/models/audit_activity/correspondence/add_meeting.rb
@@ -4,6 +4,10 @@ class AuditActivity::Correspondence::AddMeeting < AuditActivity::Correspondence:
   include ActivityAttachable
   with_attachments transcript: "transcript", related_attachment: "related attachment"
 
+  def readonly?
+    true
+  end
+
   def activity_type
     "meeting"
   end

--- a/app/models/audit_activity/correspondence/add_meeting.rb
+++ b/app/models/audit_activity/correspondence/add_meeting.rb
@@ -4,20 +4,12 @@ class AuditActivity::Correspondence::AddMeeting < AuditActivity::Correspondence:
   include ActivityAttachable
   with_attachments transcript: "transcript", related_attachment: "related attachment"
 
-  def self.from(*)
-    raise "Deprecated - no longer supported"
-  end
-
   def activity_type
     "meeting"
   end
 
   def restricted_title(_user)
     "Meeting added"
-  end
-
-  def email_update_text(viewer = nil)
-    "Meeting details added to the #{investigation.case_type.upcase_first} by #{source&.show(viewer)}."
   end
 
 private

--- a/app/models/audit_activity/correspondence/add_phone_call.rb
+++ b/app/models/audit_activity/correspondence/add_phone_call.rb
@@ -3,10 +3,6 @@ class AuditActivity::Correspondence::AddPhoneCall < AuditActivity::Correspondenc
   with_attachments transcript: "transcript"
   belongs_to :correspondence, class_name: "Correspondence::PhoneCall"
 
-  def self.from(*)
-    raise "Deprecated - use AddPhoneCallToCase.call instead"
-  end
-
   def self.build_metadata(correspondence)
     { "correspondence" => correspondence.attributes.merge(
       "transcript" => correspondence.transcript.blob&.attributes
@@ -48,7 +44,4 @@ private
   def subtitle_slug
     "Phone call"
   end
-
-  # no-op sending of email is done by the service AddPhoneCallToCase
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/correspondence/base.rb
+++ b/app/models/audit_activity/correspondence/base.rb
@@ -1,16 +1,6 @@
 class AuditActivity::Correspondence::Base < AuditActivity::Base
   belongs_to :correspondence
 
-  private_class_method def self.from(correspondence, investigation, body = nil)
-    create!(
-      body: body || sanitize_text(correspondence.details),
-      source: UserSource.new(user: User.current),
-      investigation: investigation,
-      title: correspondence.overview,
-      correspondence: correspondence
-    )
-  end
-
   def can_display_all_data?(user)
     Pundit.policy(user, investigation).view_protected_details?
   end

--- a/app/models/audit_activity/correspondence/email_updated.rb
+++ b/app/models/audit_activity/correspondence/email_updated.rb
@@ -57,10 +57,6 @@ class AuditActivity::Correspondence::EmailUpdated < AuditActivity::Correspondenc
     updated_values["attachment_description"]
   end
 
-  def self.from(*)
-    raise "Deprecated - use UpdateEmail.call instead"
-  end
-
   def self.build_metadata(email:, email_changed:, previous_email_filename:, email_attachment_changed:, previous_email_attachment_filename:, previous_attachment_description:)
     updates = email.previous_changes.slice(
       :correspondence_date,
@@ -101,7 +97,4 @@ private
   def updated_values
     @updated_values ||= metadata["updates"].transform_values(&:second)
   end
-
-  # no-op sending of email is done by the service UpdateEmail
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/correspondence/phone_call_updated.rb
+++ b/app/models/audit_activity/correspondence/phone_call_updated.rb
@@ -1,10 +1,6 @@
 class AuditActivity::Correspondence::PhoneCallUpdated < AuditActivity::Correspondence::Base
   belongs_to :correspondence, class_name: "Correspondence::PhoneCall"
 
-  def self.from(*)
-    raise "Deprecated - no longer supported"
-  end
-
   def self.build_metadata(correspondence)
     updates = correspondence.previous_changes
 
@@ -24,7 +20,4 @@ private
   def subtitle_slug
     "Phone call updated"
   end
-
-  # no-op sending of email is done by the service UpdatePhoneCall
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/document/base.rb
+++ b/app/models/audit_activity/document/base.rb
@@ -1,5 +1,6 @@
 class AuditActivity::Document::Base < AuditActivity::Base
   include ActivityAttachable
+  include ActivityNotification
   with_attachments attachment: "document"
 
   private_class_method def self.from(document, investigation, title)

--- a/app/models/audit_activity/investigation/add.rb
+++ b/app/models/audit_activity/investigation/add.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use CreateCase.call instead"
-  end
-
   def self.build_metadata(investigation)
     {
       owner_id: investigation.owner&.id,
@@ -52,10 +48,4 @@ class AuditActivity::Investigation::Add < AuditActivity::Investigation::Base
   def restricted_title(user)
     title(user)
   end
-
-private
-
-  # Do not send investigation_updated mail when case added. This overrides
-  # inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/automatically_update_owner.rb
+++ b/app/models/audit_activity/investigation/automatically_update_owner.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::AutomaticallyUpdateOwner < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use DeleteUser.call instead"
-  end
-
   def self.build_metadata(owner)
     {
       owner_id: owner.id
@@ -24,7 +20,4 @@ private
   def owner
     User.find_by(id: metadata["owner_id"]) || Team.find_by(id: metadata["owner_id"])
   end
-
-  # Do not send investigation_updated mail. This is handled by the DeleteUser service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/base.rb
+++ b/app/models/audit_activity/investigation/base.rb
@@ -2,14 +2,4 @@ class AuditActivity::Investigation::Base < AuditActivity::Base
   def self.i18n_scope
     model_name.i18n_key.to_s.split("/")
   end
-
-  private_class_method def self.from(investigation, title = nil, body = nil, metadata = nil)
-    create!(
-      source: UserSource.new(user: User.current),
-      investigation: investigation,
-      title: title,
-      body: body,
-      metadata: metadata
-    )
-  end
 end

--- a/app/models/audit_activity/investigation/change_notifying_country.rb
+++ b/app/models/audit_activity/investigation/change_notifying_country.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::ChangeNotifyingCountry < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use ChangeNotifyingCountry.call instead"
-  end
-
   def self.build_metadata(investigation)
     updated_values = investigation.previous_changes.slice(:notifying_country)
 
@@ -26,9 +22,4 @@ class AuditActivity::Investigation::ChangeNotifyingCountry < AuditActivity::Inve
   def new_country
     metadata["updates"]["notifying_country"].second
   end
-
-private
-
-  # Do not send investigation_updated mail. This is handled by the ChangeNotifyingCountry service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/change_safety_and_compliance_data.rb
+++ b/app/models/audit_activity/investigation/change_safety_and_compliance_data.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::ChangeSafetyAndComplianceData < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use ChangeSafetyAndComplianceData.call instead"
-  end
-
   def self.build_metadata(investigation)
     updated_values = investigation.previous_changes.slice(:hazard_type, :hazard_description, :non_compliant_reason, :reported_reason)
 
@@ -14,9 +10,4 @@ class AuditActivity::Investigation::ChangeSafetyAndComplianceData < AuditActivit
   def title(*)
     "Safety and compliance status changed"
   end
-
-private
-
-  # Do not send investigation_updated mail. This is handled by the ChangeSafetyAndComplianceData service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/risk_level_updated.rb
+++ b/app/models/audit_activity/investigation/risk_level_updated.rb
@@ -2,10 +2,6 @@ class AuditActivity::Investigation::RiskLevelUpdated < AuditActivity::Investigat
   I18N_SCOPE = "audit_activity.investigation.risk_level_updated".freeze
   SUBTITLE_SLUG = "Risk level changed".freeze
 
-  def self.from(*)
-    raise "Deprecated - use ChangeCaseRiskLevel.call instead"
-  end
-
   def self.build_metadata(investigation, update_verb)
     updated_values = investigation.previous_changes.slice(:risk_level, :custom_risk_level)
     {
@@ -33,7 +29,4 @@ private
       metadata["updates"]["custom_risk_level"]&.second
     end
   end
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseRiskLevel service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/team_added.rb
+++ b/app/models/audit_activity/investigation/team_added.rb
@@ -14,11 +14,4 @@ class AuditActivity::Investigation::TeamAdded < AuditActivity::Investigation::Ba
   def team
     Team.find(metadata["team"]["id"])
   end
-
-private
-
-  # This is handled by the AddTeamToCase service, but this override is required
-  # to prevent a duplicate investigation_updated email being enqueued, which
-  # will fail
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/team_deleted.rb
+++ b/app/models/audit_activity/investigation/team_deleted.rb
@@ -12,11 +12,4 @@ class AuditActivity::Investigation::TeamDeleted < AuditActivity::Investigation::
   def team
     Team.find(metadata["team"]["id"])
   end
-
-private
-
-  # This is handled by RemoveTeamFromCase, but this override is required to
-  # prevent a duplicate investigation_updated email being enqueued, which will
-  # fail
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/team_permission_changed.rb
+++ b/app/models/audit_activity/investigation/team_permission_changed.rb
@@ -12,11 +12,4 @@ class AuditActivity::Investigation::TeamPermissionChanged < AuditActivity::Inves
       message: message
     }
   end
-
-private
-
-  # This is handled by ChangeCasePermissionLevelForTeam, but this override is
-  # required to prevent a duplicate investigation_updated email being enqueued,
-  # which will fail
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_coronavirus_status.rb
+++ b/app/models/audit_activity/investigation/update_coronavirus_status.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateCoronavirusStatus < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use ChangeCaseCoronavirusStatus.call instead"
-  end
-
   def self.build_metadata(investigation)
     updated_values = investigation.previous_changes.slice(:coronavirus_related)
 
@@ -22,9 +18,4 @@ class AuditActivity::Investigation::UpdateCoronavirusStatus < AuditActivity::Inv
   def new_status
     metadata["updates"]["coronavirus_related"].second
   end
-
-private
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseCoronavirusStatus service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_owner.rb
+++ b/app/models/audit_activity/investigation/update_owner.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateOwner < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use ChangeCaseOwner.call instead"
-  end
-
   def self.build_metadata(owner, rationale)
     {
       owner_id: owner.id,
@@ -27,7 +23,4 @@ private
   def subtitle_slug
     "Changed"
   end
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseOwner service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_risk_level_validation.rb
+++ b/app/models/audit_activity/investigation/update_risk_level_validation.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateRiskLevelValidation < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use UpdateRiskLevelValidation.call instead"
-  end
-
   def self.build_metadata(investigation, rationale)
     updated_values = investigation.previous_changes.slice(:risk_validated_at).merge(investigation.previous_changes.slice(:risk_validated_by))
 
@@ -23,7 +19,4 @@ class AuditActivity::Investigation::UpdateRiskLevelValidation < AuditActivity::I
   def body
     metadata["rationale"]
   end
-
-  # Do not send investigation_updated mail. This is handled by the ChangeRiskValidation service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_status.rb
+++ b/app/models/audit_activity/investigation/update_status.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateStatus < AuditActivity::Investigation::Base
-  def self.from(_investigation)
-    raise "Deprecated - use ChangeCaseStatus.call instead"
-  end
-
   def self.build_metadata(investigation, rationale)
     updated_values = investigation.previous_changes.slice(:is_closed, :date_closed)
 
@@ -11,9 +7,4 @@ class AuditActivity::Investigation::UpdateStatus < AuditActivity::Investigation:
       rationale: rationale
     }
   end
-
-private
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseStatus service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_summary.rb
+++ b/app/models/audit_activity/investigation/update_summary.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateSummary < AuditActivity::Investigation::Base
-  def self.from(*)
-    raise "Deprecated - use ChangeCaseSummary.call instead"
-  end
-
   def self.build_metadata(investigation)
     updated_values = investigation.previous_changes.slice(:description)
 
@@ -24,7 +20,4 @@ private
   def subtitle_slug
     "Changed"
   end
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseSummary service
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/investigation/update_visibility.rb
+++ b/app/models/audit_activity/investigation/update_visibility.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Investigation::UpdateVisibility < AuditActivity::Investigation::Base
-  def self.from(_investigation)
-    raise "Deprecated - use ChangeCaseVisibility.call instead"
-  end
-
   def self.build_metadata(investigation, rationale)
     updated_values = investigation.previous_changes.slice(:is_private)
 
@@ -25,9 +21,6 @@ private
 
     { "updates" => { "is_private" => [nil, title.match?(/\s+restricted$/im)] } }
   end
-
-  # Do not send investigation_updated mail. This is handled by the ChangeCaseVisibility service
-  def notify_relevant_users; end
 
   def already_in_new_format?
     self[:metadata]&.key?("updates")

--- a/app/models/audit_activity/product/add.rb
+++ b/app/models/audit_activity/product/add.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Product::Add < AuditActivity::Product::Base
-  def self.from(*)
-    raise "Deprecated - use AddProductToCase.call instead"
-  end
-
 private
 
   def subtitle_slug

--- a/app/models/audit_activity/product/base.rb
+++ b/app/models/audit_activity/product/base.rb
@@ -1,7 +1,3 @@
 class AuditActivity::Product::Base < AuditActivity::Base
   validates :product, presence: true
-
-  # Do not send investigation_updated mail when product added/removed. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/product/destroy.rb
+++ b/app/models/audit_activity/product/destroy.rb
@@ -3,10 +3,6 @@ class AuditActivity::Product::Destroy < AuditActivity::Product::Base
     { reason: reason, product: product.attributes }
   end
 
-  def self.from(*)
-    raise "Deprecated - use RemoveProductFromCase.call instead"
-  end
-
 private
 
   def subtitle_slug

--- a/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_added.rb
@@ -1,8 +1,4 @@
 class AuditActivity::RiskAssessment::RiskAssessmentAdded < AuditActivity::Base
-  def self.from(*)
-    raise "Deprecated - use AddRiskAssessmentToCase.call instead"
-  end
-
   def self.build_metadata(risk_assessment)
     { "risk_assessment" => risk_assessment.attributes.merge(
       "product_ids" => risk_assessment.product_ids,
@@ -58,10 +54,6 @@ class AuditActivity::RiskAssessment::RiskAssessmentAdded < AuditActivity::Base
   end
 
 private
-
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 
   # Migrates metadata from old structure to current. This method can be deleted once data is migrated.
   # TODO: Remove method once data migrated

--- a/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
+++ b/app/models/audit_activity/risk_assessment/risk_assessment_updated.rb
@@ -1,8 +1,4 @@
 class AuditActivity::RiskAssessment::RiskAssessmentUpdated < AuditActivity::Base
-  def self.from(*)
-    raise "Deprecated - use UpdateRiskAssessment.call instead"
-  end
-
   def self.build_metadata(risk_assessment:, previous_product_ids:, attachment_changed:, previous_attachment_filename:)
     updates = risk_assessment.previous_changes.slice(
       :assessed_on,
@@ -121,8 +117,4 @@ private
   def updates
     metadata["updates"]
   end
-
-  # Do not send investigation_updated mail when risk assessment updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/test/base.rb
+++ b/app/models/audit_activity/test/base.rb
@@ -4,28 +4,6 @@ class AuditActivity::Test::Base < AuditActivity::Base
 
   validates :product, presence: true
 
-  private_class_method def self.from(test, title)
-    activity = create!(
-      body: build_body(test),
-      title: title,
-      source: UserSource.new(user: User.current),
-      investigation: test.investigation,
-      product: test.product
-    )
-    activity.attach_blob test.document.blob if test.document.attached?
-  end
-
-  def self.build_body(test)
-    body = ""
-    body += "Legislation: **#{sanitize_text(test.legislation)}**<br>" if test.legislation.present?
-    body += "#{date_label}: **#{test.date.strftime('%d/%m/%Y')}**<br>" if test.date.present?
-    body += "Attached: **#{sanitize_text test.document.filename}**<br>" if test.document.attached?
-    body += "<br>#{sanitize_text(test.details)}" if test.details.present?
-    body
-  end
-
-  def self.date_label; end
-
   def activity_type
     "test"
   end

--- a/app/models/audit_activity/test/request.rb
+++ b/app/models/audit_activity/test/request.rb
@@ -1,5 +1,9 @@
 # Recording of test requests is deprecated - existing data is still supported
 class AuditActivity::Test::Request < AuditActivity::Test::Base
+  def readonly?
+    true
+  end
+
 private
 
   def subtitle_slug

--- a/app/models/audit_activity/test/request.rb
+++ b/app/models/audit_activity/test/request.rb
@@ -1,17 +1,5 @@
+# Recording of test requests is deprecated - existing data is still supported
 class AuditActivity::Test::Request < AuditActivity::Test::Base
-  def self.from(test)
-    title = "Test requested: #{test.product.name}"
-    super(test, title)
-  end
-
-  def self.date_label
-    "Date requested"
-  end
-
-  def email_update_text(viewer = nil)
-    "Test request was added to the #{investigation.case_type} by #{source&.show(viewer)}."
-  end
-
 private
 
   def subtitle_slug

--- a/app/models/audit_activity/test/result.rb
+++ b/app/models/audit_activity/test/result.rb
@@ -5,10 +5,6 @@ class AuditActivity::Test::Result < AuditActivity::Test::Base
     ) }
   end
 
-  def self.from(_test_result)
-    raise "Deprecated - use AddTestResultToInvestigation.call instead"
-  end
-
   def test_result
     return if metadata.nil?
 
@@ -54,8 +50,4 @@ private
   def subtitle_slug
     "Test result recorded"
   end
-
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/audit_activity/test/test_result_updated.rb
+++ b/app/models/audit_activity/test/test_result_updated.rb
@@ -1,8 +1,4 @@
 class AuditActivity::Test::TestResultUpdated < AuditActivity::Test::Base
-  def self.from(*)
-    raise "Deprecated - use UpdateTestResult.call instead"
-  end
-
   def self.build_metadata(test_result, changes)
     updated_values = changes.except("document", "existing_document_file_id")
 
@@ -75,8 +71,4 @@ private
   def updates
     metadata["updates"]
   end
-
-  # Do not send investigation_updated mail when test result updated. This
-  # overrides inherited functionality in the Activity model :(
-  def notify_relevant_users; end
 end

--- a/app/models/comment_activity.rb
+++ b/app/models/comment_activity.rb
@@ -1,4 +1,5 @@
 class CommentActivity < Activity
+  include ActivityNotification
   include SanitizationHelper
   before_validation { trim_line_endings(:body) }
   validates :body, presence: true

--- a/app/models/concerns/activity_notification.rb
+++ b/app/models/concerns/activity_notification.rb
@@ -1,0 +1,53 @@
+# Legacy behaviour for those Activity subclasses which have not yet been
+# refactored to use service classes. This should not be used anymore.
+module ActivityNotification
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :notify_relevant_users
+  end
+
+  def email_update_text(viewer = nil); end
+
+  def email_subject_text
+    "#{investigation.case_type.upcase_first} updated"
+  end
+
+  def entities_to_notify
+    entities = users_to_notify
+
+    teams_to_notify.each do |team|
+      if team.team_recipient_email.present?
+        entities << team
+      else
+        users_from_team = team.users.active
+        entities.concat(users_from_team)
+      end
+    end
+
+    entities.uniq
+  end
+
+private
+
+  def notify_relevant_users
+    entities_to_notify.each do |entity|
+      email = entity.is_a?(Team) ? entity.team_recipient_email : entity.email
+      NotifyMailer.investigation_updated(investigation.pretty_id, entity.name, email, email_update_text(entity), email_subject_text).deliver_later
+    end
+  end
+
+  def users_to_notify
+    return [] unless investigation.owner.is_a? User
+    return [] if source&.user == investigation.owner
+
+    [investigation.owner]
+  end
+
+  def teams_to_notify
+    return [] unless investigation.owner.is_a? Team
+    return [] if source&.user&.team == investigation.owner
+
+    [investigation.owner]
+  end
+end

--- a/app/models/correspondence/meeting.rb
+++ b/app/models/correspondence/meeting.rb
@@ -5,8 +5,4 @@ class Correspondence::Meeting < Correspondence
   has_one_attached :related_attachment
 
   date_attribute :correspondence_date
-
-  def readonly?
-    true
-  end
 end

--- a/app/models/correspondence/meeting.rb
+++ b/app/models/correspondence/meeting.rb
@@ -5,4 +5,8 @@ class Correspondence::Meeting < Correspondence
   has_one_attached :related_attachment
 
   date_attribute :correspondence_date
+
+  def readonly?
+    true
+  end
 end

--- a/app/models/test/request.rb
+++ b/app/models/test/request.rb
@@ -1,5 +1,9 @@
 # Recording of test requests is deprecated - existing data is still supported
 class Test::Request < Test
+  def readonly?
+    true
+  end
+
   def pretty_name
     "testing request"
   end

--- a/app/models/test/request.rb
+++ b/app/models/test/request.rb
@@ -1,10 +1,5 @@
+# Recording of test requests is deprecated - existing data is still supported
 class Test::Request < Test
-  after_create :create_audit_activity
-
-  def create_audit_activity
-    AuditActivity::Test::Request.from(self)
-  end
-
   def pretty_name
     "testing request"
   end

--- a/app/models/test/request.rb
+++ b/app/models/test/request.rb
@@ -1,9 +1,5 @@
 # Recording of test requests is deprecated - existing data is still supported
 class Test::Request < Test
-  def readonly?
-    true
-  end
-
   def pretty_name
     "testing request"
   end

--- a/app/services/add_phone_call_to_case.rb
+++ b/app/services/add_phone_call_to_case.rb
@@ -38,12 +38,20 @@ private
         entity.name,
         entity.email,
         email_update_text,
-        activity.email_subject_text
+        email_subject
       ).deliver_later
     end
   end
 
+  def email_subject
+    I18n.t("add_phone_call_to_case.email_subject_text", case_type: email_case_type)
+  end
+
+  def email_case_type
+    investigation.case_type.upcase_first
+  end
+
   def email_update_text
-    "Phone call details added to the #{investigation.case_type.upcase_first} by #{activity.source.show}."
+    "Phone call details added to the #{email_case_type} by #{activity.source.show}."
   end
 end

--- a/app/services/update_phone_call.rb
+++ b/app/services/update_phone_call.rb
@@ -42,7 +42,7 @@ private
         entity.name,
         entity.email,
         email_update_text,
-        activity.email_subject_text
+        email_subject
       ).deliver_later
     end
   end
@@ -56,8 +56,16 @@ private
     )
   end
 
+  def email_subject
+    I18n.t("update_phone_call.email_subject_text", case_type: email_case_type)
+  end
+
+  def email_case_type
+    investigation.case_type.upcase_first
+  end
+
   def email_update_text
-    "Phone call details updated on the #{investigation.case_type.upcase_first} by #{activity.source.show}."
+    "Phone call details updated on the #{email_case_type} by #{activity.source.show}."
   end
 
   def any_changes?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,10 @@ en:
   change_risk_validation:
     validated: "has been validated"
     validation_removed: "has had validation removed"
+  add_phone_call_to_case:
+    email_subject_text: "%{case_type} updated"
+  update_phone_call:
+    email_subject_text: "%{case_type} updated"
 
   case:
     badges:

--- a/db/migrate/20210520120140_change_activity_type_column.rb
+++ b/db/migrate/20210520120140_change_activity_type_column.rb
@@ -1,0 +1,9 @@
+class ChangeActivityTypeColumn < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_column_default :activities, :type, from: "CommentActivity", to: nil
+      change_column_null :activities, :type, false
+      add_index :activities, :type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 2021_05_20_120140) do
     t.index ["business_id"], name: "index_activities_on_business_id"
     t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
     t.index ["investigation_id"], name: "index_activities_on_investigation_id"
-    t.index ["metadata"], name: "index_activities_on_metadata"
     t.index ["product_id"], name: "index_activities_on_product_id"
     t.index ["type"], name: "index_activities_on_type"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_083705) do
+ActiveRecord::Schema.define(version: 2021_05_20_120140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -64,12 +64,13 @@ ActiveRecord::Schema.define(version: 2021_04_26_083705) do
     t.jsonb "metadata"
     t.bigint "product_id"
     t.string "title"
-    t.string "type", default: "CommentActivity"
+    t.string "type", null: false
     t.datetime "updated_at", null: false
     t.index ["business_id"], name: "index_activities_on_business_id"
     t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
     t.index ["investigation_id"], name: "index_activities_on_investigation_id"
     t.index ["product_id"], name: "index_activities_on_product_id"
+    t.index ["type"], name: "index_activities_on_type"
   end
 
   create_table "alerts", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_05_20_120140) do
     t.index ["business_id"], name: "index_activities_on_business_id"
     t.index ["correspondence_id"], name: "index_activities_on_correspondence_id"
     t.index ["investigation_id"], name: "index_activities_on_investigation_id"
+    t.index ["metadata"], name: "index_activities_on_metadata"
     t.index ["product_id"], name: "index_activities_on_product_id"
     t.index ["type"], name: "index_activities_on_type"
   end


### PR DESCRIPTION
This change removes the notification callback functionality in the `Activity` model, which is inherited by all subclasses in the `AuditActivity` namespace.

Since all but 6 of these classes have now been refactored to use service class interfaces for their creation and the notification logic moved to those, it is no longer appropriate for all of the subclasses to inherit this functionality, which can cause undesirable and unexpected behaviour.

Moving the logic to a concern which is included only in those classes which have not yet been refactored makes it easier to identify the outstanding work, removing some overhead in the refactoring and is a long-awaited improvement.

For reference, the remaining classes that depend on this are:

`CommentActivity`
`AuditActivity::Alert::Add`
`AuditActivity::Correspondence::AddEmail`
`AuditActivity::Document::Add`
`AuditActivity::Document::Destroy`
`AuditActivity::Document::Update`

I'm working on removing this dependency from the last three in a separate branch.

Also improves one curious design choice where by case comments inherit from `Activity` and are in fact the default type in the database schema. The comments controller now instantiates the correct `CommentActivity` class explicitly which improves understanding and mitigates potential unexpected behaviour.