### PR TITLE
Change radio button on edit corrective action

### DIFF
--- a/app/decorators/audit_activity/corrective_action/update_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/update_decorator.rb
@@ -49,6 +49,10 @@ class AuditActivity::CorrectiveAction::UpdateDecorator < AuditActivity::Correcti
     geographic_scopes.map { |geographic_scope| I18n.t(geographic_scope, scope: %i[corrective_action attributes geographic_scopes]) }.to_sentence
   end
 
+  def further_details_changed?
+    metadata.dig("updates").key?("details")
+  end
+
   def new_filename
     metadata.dig("updates", "filename", 1)
   end

--- a/app/decorators/audit_activity/corrective_action/update_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/update_decorator.rb
@@ -77,6 +77,10 @@ class AuditActivity::CorrectiveAction::UpdateDecorator < AuditActivity::Correcti
     metadata.dig("updates", "business_id")
   end
 
+  def new_business
+    Business.find(metadata.dig("updates", "business_id", 1))
+  end
+
   def attachment
     @attachment ||= (signed_id = metadata.dig("updates", "existing_document_file_id", 1)) && ActiveStorage::Blob.find_signed!(signed_id)
   end

--- a/app/decorators/audit_activity/corrective_action/update_decorator.rb
+++ b/app/decorators/audit_activity/corrective_action/update_decorator.rb
@@ -70,7 +70,7 @@ class AuditActivity::CorrectiveAction::UpdateDecorator < AuditActivity::Correcti
   end
 
   def business_updated?
-    metadata.dig("updates", "business_id", 1)
+    metadata.dig("updates", "business_id")
   end
 
   def attachment

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -52,7 +52,7 @@ class CorrectiveActionForm
   validates :details, length: { maximum: 50_000 }
 
   before_validation { trim_whitespace(:other_action, :details, :file_description, :online_recall_information) }
-  before_validation { nilify_blanks(:other_action, :details, :file_description, :online_recall_information) }
+  before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }
   before_validation :clear_related_file, unless: :related_file
   before_validation :clear_other_action, unless: -> { other? }
 

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -26,7 +26,7 @@ class CorrectiveActionForm
   attribute :document
   attribute :existing_document_file_id
   attribute :filename
-  attribute :file_description, default: nil
+  attribute :file_description
   attribute :further_corrective_action, :boolean
 
   validates :product_id, presence: true, on: %i[add_corrective_action edit_corrective_action]

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -51,7 +51,7 @@ class CorrectiveActionForm
   validates :other_action, absence: true, unless: :other?
   validates :details, length: { maximum: 50_000 }
 
-  before_validation { trim_whitespace(:other_action, :details, :online_recall_information) }
+  before_validation { trim_whitespace(:other_action, :details, :online_recall_information, :file_description) }
   before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }
   before_validation :clear_related_file, unless: :related_file
   before_validation :clear_other_action, unless: -> { other? }

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -51,8 +51,8 @@ class CorrectiveActionForm
   validates :other_action, absence: true, unless: :other?
   validates :details, length: { maximum: 50_000 }
 
-  before_validation { trim_whitespace(:other_action, :details, :file_description, :online_recall_information) }
-  before_validation { nilify_blanks(:other_action, :details, :file_description, :online_recall_information) }
+  before_validation { trim_whitespace(:other_action, :details, :online_recall_information) }
+  before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }
   before_validation :clear_related_file, unless: :related_file
   before_validation :clear_other_action, unless: -> { other? }
 

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -26,7 +26,7 @@ class CorrectiveActionForm
   attribute :document
   attribute :existing_document_file_id
   attribute :filename
-  attribute :file_description
+  attribute :file_description, default: nil
   attribute :further_corrective_action, :boolean
 
   validates :product_id, presence: true, on: %i[add_corrective_action edit_corrective_action]

--- a/app/forms/corrective_action_form.rb
+++ b/app/forms/corrective_action_form.rb
@@ -51,8 +51,8 @@ class CorrectiveActionForm
   validates :other_action, absence: true, unless: :other?
   validates :details, length: { maximum: 50_000 }
 
-  before_validation { trim_whitespace(:other_action, :details, :online_recall_information, :file_description) }
-  before_validation { nilify_blanks(:other_action, :details, :online_recall_information) }
+  before_validation { trim_whitespace(:other_action, :details, :file_description, :online_recall_information) }
+  before_validation { nilify_blanks(:other_action, :details, :file_description, :online_recall_information) }
   before_validation :clear_related_file, unless: :related_file
   before_validation :clear_other_action, unless: -> { other? }
 

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -12,6 +12,7 @@ class UpdateCorrectiveAction
     corrective_action.transaction do
       corrective_action.document.detach unless related_file
       replace_attached_file             if file_changed?
+      remove_blanks_from_changes
 
       if any_changes?
         corrective_action.save!
@@ -46,6 +47,10 @@ private
 
   def any_changes?
     file_changed? || changes.except(:related_file, :existing_document_file_id, :document).any?
+  end
+
+  def remove_blanks_from_changes
+    changes.delete_if { |k,v| v.first.blank? && v.last.blank? }
   end
 
   def file_changed?

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -52,7 +52,7 @@ private
     return false if document.nil? && related_file
     return false if document == @previous_attachment
 
-    [document, @previous_attachment].compact.any?
+    document.checksum != @previous_attachment.checksum
   end
 
   def new_file_description

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -55,12 +55,6 @@ private
     document.try(:checksum) != @previous_attachment.try(:checksum)
   end
 
-  def new_file_description
-    return nil if file_description.blank?
-
-    file_description
-  end
-
   def replace_attached_file
     corrective_action.document.detach
     corrective_action.document.attach(document)
@@ -73,7 +67,7 @@ private
   def update_document_description!
     return unless document
 
-    document.metadata[:description] = new_file_description
+    document.metadata[:description] = file_description
     document.save!
   end
 

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -45,7 +45,7 @@ private
   end
 
   def any_changes?
-    file_changed? || file_description_changed? || changes.except(:related_file, :existing_document_file_id, :document, :file_description).any?
+    file_changed? || changes.except(:related_file, :existing_document_file_id, :document).any?
   end
 
   def file_changed?
@@ -53,16 +53,6 @@ private
     return false if document == @previous_attachment
 
     document.try(:checksum) != @previous_attachment.try(:checksum)
-  end
-
-  def file_description_changed?
-    return false unless changes["file_description"]
-
-    return true unless new_and_old_file_description_both_blank?
-  end
-
-  def new_and_old_file_description_both_blank?
-    changes["file_description"].select { |value| value.present? }.empty?
   end
 
   def new_file_description

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -45,7 +45,7 @@ private
   end
 
   def any_changes?
-    file_changed? || changes.except(:related_file, :existing_document_file_id, :document).any?
+    file_changed? || file_description_changed? || changes.except(:related_file, :existing_document_file_id, :document, :file_description).any?
   end
 
   def file_changed?
@@ -53,6 +53,16 @@ private
     return false if document == @previous_attachment
 
     document.try(:checksum) != @previous_attachment.try(:checksum)
+  end
+
+  def file_description_changed?
+    return false unless changes["file_description"]
+
+    return true unless new_and_old_file_description_both_blank?
+  end
+
+  def new_and_old_file_description_both_blank?
+    changes["file_description"].select { |value| value.present? }.empty?
   end
 
   def new_file_description

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -45,7 +45,7 @@ private
   end
 
   def any_changes?
-    file_changed? || changes.except(:related_file, :existing_document_file_id).any?
+    file_changed? || changes.except(:related_file, :existing_document_file_id, :document).any?
   end
 
   def file_changed?

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -12,7 +12,6 @@ class UpdateCorrectiveAction
     corrective_action.transaction do
       corrective_action.document.detach unless related_file
       replace_attached_file             if file_changed?
-      remove_blanks_from_changes
 
       if any_changes?
         corrective_action.save!
@@ -49,21 +48,11 @@ private
     file_changed? || changes.except(:related_file, :existing_document_file_id, :document).any?
   end
 
-  def remove_blanks_from_changes
-    changes.delete_if { |k,v| v.first.blank? && v.last.blank? }
-  end
-
   def file_changed?
     return false if document.nil? && related_file
     return false if document == @previous_attachment
 
     document.try(:checksum) != @previous_attachment.try(:checksum)
-  end
-
-  def new_file_description
-    return nil if file_description.blank?
-
-    file_description
   end
 
   def replace_attached_file
@@ -78,7 +67,7 @@ private
   def update_document_description!
     return unless document
 
-    document.metadata[:description] = new_file_description
+    document.metadata[:description] = file_description
     document.save!
   end
 

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -60,6 +60,12 @@ private
     document.try(:checksum) != @previous_attachment.try(:checksum)
   end
 
+  def new_file_description
+    return nil if file_description.blank?
+
+    file_description
+  end
+
   def replace_attached_file
     corrective_action.document.detach
     corrective_action.document.attach(document)
@@ -72,7 +78,7 @@ private
   def update_document_description!
     return unless document
 
-    document.metadata[:description] = file_description
+    document.metadata[:description] = new_file_description
     document.save!
   end
 

--- a/app/services/update_corrective_action.rb
+++ b/app/services/update_corrective_action.rb
@@ -52,7 +52,7 @@ private
     return false if document.nil? && related_file
     return false if document == @previous_attachment
 
-    document.checksum != @previous_attachment.checksum
+    document.try(:checksum) != @previous_attachment.try(:checksum)
   end
 
   def new_file_description

--- a/app/views/investigations/activities/corrective_action/_update.erb
+++ b/app/views/investigations/activities/corrective_action/_update.erb
@@ -29,7 +29,11 @@
   <% end %>
 
   <% if activity.business_updated? %>
-    Business: <%= link_to activity.business.trading_name, activity.business %><br>
+    <% if activity.business %>
+      Business: <%= link_to activity.business.trading_name, activity.business %><br>
+    <% else %>
+      Business: Removed
+    <% end %>
   <% end %>
 
   <% if activity.new_measure_type %>

--- a/app/views/investigations/activities/corrective_action/_update.erb
+++ b/app/views/investigations/activities/corrective_action/_update.erb
@@ -48,7 +48,7 @@
     Geographic scopes: <b><%= activity.new_geographic_scopes %></b><br>
   <% end %>
 
-  <% if activity.new_details %>
+  <% if activity.further_details_changed? %>
     Details: <%= updated_field activity.new_details %><br>
   <% end %>
 

--- a/app/views/investigations/activities/corrective_action/_update.erb
+++ b/app/views/investigations/activities/corrective_action/_update.erb
@@ -30,7 +30,7 @@
 
   <% if activity.business_updated? %>
     <% if activity.business %>
-      Business: <%= link_to activity.business.trading_name, activity.business %><br>
+      Business: <%= link_to activity.new_business.trading_name, activity.new_business %><br>
     <% else %>
       Business: Removed
     <% end %>

--- a/app/views/investigations/corrective_actions/edit.html.erb
+++ b/app/views/investigations/corrective_actions/edit.html.erb
@@ -32,11 +32,13 @@
       <% end %>
       <%= form.hidden_field :related_file, value: nil %>
 
+      <% remove_file_text = @corrective_action_form.related_file? ? "Remove attached file" : "No" %>
+
       <%= form.govuk_radios :related_file,
          legend: "Are there any files related to the action?",
          items: [
            { text: "Yes", value: "true", conditional: { html: file_field }, checked: @corrective_action_form.document.present? },
-           { text: "No", value: "off" }
+           { text: remove_file_text, value: "off" }
          ]
       %>
 

--- a/spec/features/edit_corrective_action_spec.rb
+++ b/spec/features/edit_corrective_action_spec.rb
@@ -121,6 +121,16 @@ RSpec.feature "Edit corrective action", :with_stubbed_elasticsearch, :with_stubb
         fill_in "Other action", with: ""
       end
 
+      within_fieldset("What action is being taken?") do
+        choose new_action
+        fill_in "Other action", with: ""
+      end
+
+      select "", from: "Business"
+      within_fieldset "Are there any files related to the action?" do
+        choose "Remove attached file"
+      end
+
       click_on "Update corrective action"
 
       expect_to_be_on_corrective_action_summary_page
@@ -134,9 +144,19 @@ RSpec.feature "Edit corrective action", :with_stubbed_elasticsearch, :with_stubb
       click_link "Back to #{investigation.decorate.pretty_description.downcase}"
       click_link "Activity"
 
+      expect(page).to have_content "Business: Removed"
+
       page.first("a", text: "View corrective action").click
 
       expect_to_be_on_corrective_action_summary_page
+
+      click_link "Edit corrective action"
+
+      within_fieldset("Are there any files related to the action?") do
+        expect(page).to have_unchecked_field("Yes")
+        expect(page).to have_checked_field("No")
+        expect(page).not_to have_checked_field("Remove attached file")
+      end
     end
   end
 end

--- a/spec/features/edit_corrective_action_spec.rb
+++ b/spec/features/edit_corrective_action_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "Edit corrective action", :with_stubbed_elasticsearch, :with_stubb
 
       within_fieldset("Are there any files related to the action?") do
         expect(page).to have_checked_field("Yes")
+        expect(page).to have_unchecked_field("Remove attached file")
         expect(page).to have_link(corrective_action.document_blob.filename.to_s)
       end
 
@@ -64,6 +65,7 @@ RSpec.feature "Edit corrective action", :with_stubbed_elasticsearch, :with_stubb
 
       within_fieldset("Are there any files related to the action?") do
         expect(page).to have_checked_field("Yes")
+        expect(page).to have_unchecked_field("Remove attached file")
         expect(page).to have_link(corrective_action.document_blob.filename.to_s)
         expect(page).to have_field("Attachment description", with: /#{Regexp.escape(corrective_action.document_blob.metadata["description"])}/)
       end


### PR DESCRIPTION
https://trello.com/c/qk5MQogL/688-update-edit-corrective-action-behaviour-and-activity-log-file-upload-removal

## Description
It seems the only remaining work that needed to be done on the ticket above was to dynamically render the text for the no option on the question "Are there any files related to the action?" to say "Remove attached file" if there is an existing file attached to the corrective action being edited.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
