### PR TITLE
Do not attempt deployments for dependabot PRs

### DIFF
--- a/deploy-github-functions.sh
+++ b/deploy-github-functions.sh
@@ -21,6 +21,11 @@ set -e
 gh_deploy_create() {
   environment_name=$1
 
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   deploy_url=$(curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -61,6 +66,11 @@ gh_deploy_initiate() {
   environment_name=$1
   log_url=$2
 
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -93,6 +103,11 @@ gh_deploy_success() {
   log_url=$2
   environment_url=$3
 
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -122,6 +137,12 @@ gh_deploy_success() {
 gh_deploy_failure() {
   environment_name=$1
   log_url=$2
+
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -149,6 +170,12 @@ gh_deploy_failure() {
 #
 gh_deploy_deactivate() {
   deploy_id=$1
+
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \

--- a/deploy-github-functions.sh
+++ b/deploy-github-functions.sh
@@ -31,14 +31,16 @@ gh_deploy_create() {
     "environment": "'"$environment_name"'",
     "auto_merge": false,
     "required_contexts": []
-    }' | jq -r '.url?') # Gets 'url' field from the response
+    }' | jq -r '.url') # Gets 'url' field from the response
 
-  if [ -z "$deploy_url" ]; then
+  if [[ "$deploy_url" == "null" ]]; then
     echo "Failed to create Github deployment"
+    exit 1
   else
     # Need to be shared between steps
     echo "DEPLOY_STATUSES_URL=$deploy_url/statuses" >> $GITHUB_ENV
     echo "Github deployment created: $deploy_url"
+    exit 0
   fi
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Dependabot PRs no longer have access to GitHub repo secrets, preventing the review application from deploying when Dependabot (or any other third party) opens a PR. A user with write access to the repo needs to update the branch to trigger a successful review app deploy.

It would not be desirable for secrets to be readable by anyone without write access, since these could be sent to a malicious party by modifying the GitHub actions in the PR.

See https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544 for a description of the potential two-step workflow solution. Note the `pull_request_target` alternative solution described there is not appropriate for this repo.

This PR does not attempt to solve the problem, but fixes some bugs in the actions script which allowed the action to continue executing after an error had occurred. Now the action will fail immediately.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
