### PR TITLE
Fix missing metadata for legacy audit activities

### DIFF
--- a/app/models/audit_activity/product/destroy.rb
+++ b/app/models/audit_activity/product/destroy.rb
@@ -3,9 +3,28 @@ class AuditActivity::Product::Destroy < AuditActivity::Product::Base
     { reason: reason, product: product.attributes }
   end
 
+  def metadata
+    migrate_metadata_structure
+  end
+
 private
 
   def subtitle_slug
     "Product removed"
+  end
+
+  def migrate_metadata_structure
+    metadata = self[:metadata]
+
+    return metadata if already_in_new_format?
+
+    JSON.parse({
+      "reason" => self[:title],
+      "product" => product.attributes
+    }.to_json)
+  end
+
+  def already_in_new_format?
+    self[:metadata]&.key?("product")
   end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -39,6 +39,12 @@ FactoryBot.define do
     body { "Role: **fulfillment\\_house**" }
   end
 
+  factory :legacy_audit_product_destroyed, class: "AuditActivity::Product::Destroy" do
+    investigation { create :allegation }
+    product { create(:product) }
+    title { "Product removed from case" }
+  end
+
   factory :legacy_audit_investigation_visibility_status, class: "AuditActivity::Investigation::UpdateVisibility" do
     investigation { create :allegation }
     title { "Allegation visibility\n            restricted" }

--- a/spec/models/audit_activity/product/destroy_spec.rb
+++ b/spec/models/audit_activity/product/destroy_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe AuditActivity::Product::Destroy, :with_stubbed_elasticsearch, :with_stubbed_mailer do
+  subject(:audit_activity) { create :legacy_audit_product_destroyed }
+
+  describe "#metadata" do
+    context "when not migrated to new structure" do
+      it "builds the new structure" do
+        expect(audit_activity.metadata).to eq(
+          "product" => JSON.parse(audit_activity.product.attributes.to_json),
+          "reason" => "Product removed from case"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/RWjoWopE/1058-bug-in-product-auditactivity-when-product-is-destroyed

## Description
Addresses a bug resulting in 500 errors surfaced to users when viewing an activity timeline containing a `AuditActivity::Product::Destroy` entity.

This was caused by existing data not being migrated in #1330.

On deployment the `activities:update_metadata` task should be run to persist the new data.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
