### PR TITLE
Use find_each rather than each to stop memory issues with rake task

### DIFF
--- a/lib/tasks/migrate_comment_activity.rake
+++ b/lib/tasks/migrate_comment_activity.rake
@@ -4,7 +4,7 @@ namespace :comments do
     comment_activities = Activity.where(type: "CommentActivity")
     puts "Updating #{comment_activities.count} old comments"
 
-    comment_activities.each do |comment|
+    comment_activities.find_each(batch_size: 50) do |comment|
       comment.update!(type: AuditActivity::Investigation::AddComment, metadata: { comment_text: comment.body }, body: nil)
       puts "#{comment.id} updated"
     end


### PR DESCRIPTION
## Description
The comments:update rake task is failing due to running out of memory. This change should fix the issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
