### PR TITLE
Fix error when user navigates back to the change ownership form after submission

### DIFF
--- a/app/controllers/investigations/ownership_controller.rb
+++ b/app/controllers/investigations/ownership_controller.rb
@@ -6,6 +6,8 @@ class Investigations::OwnershipController < ApplicationController
   steps :"select-owner", :confirm
 
   def show
+    return redirect_to wizard_path(:"select-owner") if form_params[:owner_id].blank? && (step != :"select-owner")
+
     @potential_owner = form.owner&.decorate
 
     get_potential_assignees if step == :"select-owner"

--- a/app/views/investigations/ownership/confirm.html.erb
+++ b/app/views/investigations/ownership/confirm.html.erb
@@ -23,7 +23,7 @@
       <%= render "minimal_investigation_heading", investigation: @investigation, title: page_heading %>
       <p>
         You are changing the case owner to:
-        <strong><%= @potential_owner.decorate.display_name(viewer: current_user) %></strong>
+        <strong><%= @potential_owner.display_name(viewer: current_user) %></strong>
       </p>
       <div class="govuk-form-group">
         <%= render "form_components/govuk_textarea",

--- a/spec/requests/investigations/changing_owner_spec.rb
+++ b/spec/requests/investigations/changing_owner_spec.rb
@@ -69,4 +69,15 @@ RSpec.describe "Changing the owner of a case", :with_stubbed_elasticsearch, :wit
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  context "when no form params are supplied on confirm step" do
+    before do
+      sign_in user_from_owner_team
+      get investigation_ownership_path(investigation, "confirm")
+    end
+
+    it "redirects to the first step" do
+      expect(response).to redirect_to(investigation_ownership_path(investigation, "select-owner"))
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/IQznMlyf/1060-fix-error-when-navigating-back-to-change-owner-form-after-form-submission

## Description
According to examples of this exception on Sentry, an error occurs when a GET request is made to the `confirm` step. This probably happens when the user clicks the back button after submitting the form, since this should have corresponding form params.

This PR introduces a check and redirect to the first step page to avoid the error.

