### PR TITLE
Remove complainant index on case search

### DIFF
--- a/app/models/concerns/investigation_elasticsearch.rb
+++ b/app/models/concerns/investigation_elasticsearch.rb
@@ -79,7 +79,6 @@ module InvestigationElasticsearch
          activities.*
          businesses.*
          products.*
-         complainant.*
          corrective_actions.*
          tests.*
          alerts.*

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -111,28 +111,6 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       end
     end
 
-    context "when searching on the complainant fields" do
-      let!(:complainant) { create(:complainant, investigation: investigation) }
-
-      context "when searching by complainant name" do
-        let(:query) { complainant.name }
-
-        it_behaves_like "finds the relevant investigation"
-      end
-
-      context "when searching by complainant phone number" do
-        let(:query) { complainant.phone_number }
-
-        it_behaves_like "finds the relevant investigation"
-      end
-
-      context "when searching by complainant email address" do
-        let(:query) { complainant.email_address }
-
-        it_behaves_like "finds the relevant investigation"
-      end
-    end
-
     context "when searcing on a business" do
       let!(:business) { create(:business, investigations: [investigation]) }
 


### PR DESCRIPTION
Remove index on complainant due to privacy concerns

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
