### PR TITLE
Filter products

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -78,7 +78,7 @@ class ProductsController < ApplicationController
 
   def filter_params
     if params["hazard_type"].present?
-      { must: [ { term: { "investigations.hazard_type" => @search.hazard_type } } ] }
+      { must: [ { match: { "investigations.hazard_type" => @search.hazard_type } } ] }
     end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -78,7 +78,7 @@ class ProductsController < ApplicationController
 
   def filter_params
     if params["hazard_type"].present?
-      { must: [ { term: { hazard_type: @search.hazard_type } } ] }
+      { must: [ { term: { "investigations.hazard_type" => @search.hazard_type } } ] }
     end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -76,6 +76,12 @@ class ProductsController < ApplicationController
     end
   end
 
+  def filter_params
+    if params["hazard_type"].present?
+      { must: [ { term: { hazard_type: @search.hazard_type } } ] }
+    end
+  end
+
 private
 
   def build_breadcrumbs

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -78,7 +78,7 @@ class ProductsController < ApplicationController
 
   def filter_params
     if params["hazard_type"].present?
-      { must: [ { match: { "investigations.hazard_type" => @search.hazard_type } } ] }
+      { must: [{ match: { "investigations.hazard_type" => @search.hazard_type } }] }
     end
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -15,8 +15,8 @@ module ProductsHelper
   end
 
   def search_for_products(page_size = Product.count)
-    result = Product.full_search(search_query)
-    result.paginate(page: params[:page], per_page: page_size)
+    Product.full_search(search_query)
+      .page(params[:page]).per_page(page_size).records
   end
 
   def sorting_params

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -15,8 +15,8 @@ module ProductsHelper
   end
 
   def search_for_products(page_size = Product.count)
-    Product.full_search(search_query)
-      .page(params[:page]).per_page(page_size).records
+    result = Product.full_search(search_query)
+    result.paginate(page: params[:page], per_page: page_size)
   end
 
   def sorting_params

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -15,7 +15,7 @@ module SearchHelper
   end
 
   def query_params
-    params.permit(:q, :sort_by, :direction)
+    params.permit(:q, :sort_by, :direction, :hazard_type)
   end
 
   def sorting_params

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -42,6 +42,7 @@ class SearchParams
   attribute :page, :integer
   attribute :created_by, :created_by_search_params, default: CreatedBySearchFormFields.new
   attribute :teams_with_access, :teams_with_access_search_params, default: TeamsWithAccessSearchFormFields.new
+  attribute :hazard_type
 
   def owner_filter_exclusive?
     case_owner_is_someone_else? && case_owner_is_someone_else_id.blank?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -63,8 +63,4 @@ class Product < ApplicationRecord
   def non_image_documents
     documents.includes(:blob).joins(:blob).where("left(content_type, 5) != 'image'")
   end
-
-  def self.fuzzy_fields
-    %w[investigations.*]
-  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -33,6 +33,12 @@ class Product < ApplicationRecord
 
   index_name [ENV.fetch("ES_NAMESPACE", "default_namespace"), Rails.env, "products"].join("_")
 
+  def as_indexed_json(*)
+    as_json(
+      include: { investigations: { only: :hazard_type } }
+    )
+  end
+
   has_many_attached :documents
 
   has_many :investigation_products, dependent: :destroy
@@ -56,5 +62,9 @@ class Product < ApplicationRecord
 
   def non_image_documents
     documents.includes(:blob).joins(:blob).where("left(content_type, 5) != 'image'")
+  end
+
+  def self.fuzzy_fields
+    %w[investigations.*]
   end
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -32,6 +32,13 @@
             } %>
           <%= form.submit "Search", name: nil, class: "search-box--submit" %>
         </div>
+
+        <%= render "form_components/govuk_select",
+           key: "hazard_type",
+           form: form,
+           items: hazard_types.map {|type| {text: type, value: type}},
+           label: { text: "Hazard type" },
+           is_autocomplete: true %>
       <% end %>
     </div>
   </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -39,6 +39,8 @@
            items: hazard_types.map {|type| {text: type, value: type}},
            label: { text: "Hazard type" },
            is_autocomplete: true %>
+           
+        <%= form.submit "Apply filters", name: nil, class: "govuk-button" %>
       <% end %>
     </div>
   </div>

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Case filtering", :with_elasticsearch, :with_stubbed_mailer, type: :feature do
+  let(:organisation)          { create(:organisation) }
+  let(:user)                  { create(:user, :activated, organisation: organisation, has_viewed_introduction: true) }
+
+  let!(:chemical_investigation)              { create(:allegation, hazard_type: "Chemical") }
+  let!(:fire_investigation)                  { create(:allegation, hazard_type: "Fire") }
+  let!(:drowning_investigation)              { create(:allegation, hazard_type: "Drowning") }
+
+  let!(:fire_product_1)   { create(:product, name: "Hot product", investigations: [fire_investigation]) }
+  let!(:fire_product_2)   { create(:product, name: "Very hot product", investigations: [fire_investigation]) }
+  let!(:chemical_product) { create(:product, name: "Some lab stuff", investigations: [chemical_investigation]) }
+  let!(:drowning_product) { create(:product, name: "Dangerous life vest", investigations: [drowning_investigation]) }
+
+  before do
+    Investigation.import refresh: :wait_for
+    Product.import refresh: :wait_for
+    sign_in(user)
+    visit products_path
+  end
+
+  scenario "no filters applied shows all open cases" do
+    expect(page).to have_content(fire_product_1.name)
+    expect(page).to have_content(fire_product_2.name)
+    expect(page).to have_content(chemical_product.name)
+    expect(page).to have_content(drowning_product.name)
+  end
+
+  scenario "filtering by hazard type" do
+    select "Fire", from: "Hazard type"
+    click_button "Apply filters"
+
+    expect(page).to have_content(fire_product_1.name)
+    expect(page).to have_content(fire_product_2.name)
+    expect(page).not_to have_content(chemical_product.name)
+    expect(page).not_to have_content(drowning_product.name)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/OqcJY4GR/1068-add-hazard-type-filter-to-products-tab

## Description
Add 'Hazard type' filter to products page which allows user to only view products that belong to a case which has the hazard type in question

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
