### PR TITLE
Update CloudFoundry Ruby buildpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,4 +667,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.20
+   2.2.21

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /psd
 
-RUN gem install bundler:2.2.20
+RUN gem install bundler:2.2.21
 COPY Gemfile /psd/
 COPY Gemfile.lock /psd/
 

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.41
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.42
   path: .
   stack: cflinuxfs3
   routes:

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.41
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.42
   path: .
   stack: cflinuxfs3
   routes:


### PR DESCRIPTION
Bumps to the latest version ([release notes](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.42)) as well as update RubyGems/Bundler dependencies.