### PR TITLE
Prevent very old dates (before 1970) and standardise on `recent_date` validator

### DIFF
--- a/app/forms/accident_or_incident_form.rb
+++ b/app/forms/accident_or_incident_form.rb
@@ -18,6 +18,7 @@ class AccidentOrIncidentForm
             real_date: true,
             complete_date: true,
             not_in_future: true,
+            recent_date: { on_or_before: false },
             if: -> { is_date_known }
   validates :usage, inclusion: { in: UnexpectedEvent.usages.values, message: I18n.t(".accident_or_incident_form.usage.inclusion") }
   validates :severity_other, presence: true, if: -> { severity == "other" }

--- a/app/forms/email_correspondence_form.rb
+++ b/app/forms/email_correspondence_form.rb
@@ -35,7 +35,8 @@ class EmailCorrespondenceForm
             presence: true,
             real_date: true,
             complete_date: true,
-            not_in_future: true
+            not_in_future: true,
+            recent_date: { on_or_before: false }
 
   validate :validate_email_file_and_content
 

--- a/app/forms/phone_call_correspondence_form.rb
+++ b/app/forms/phone_call_correspondence_form.rb
@@ -6,7 +6,8 @@ class PhoneCallCorrespondenceForm
             presence: true,
             real_date: true,
             complete_date: true,
-            not_in_future: true
+            not_in_future: true,
+            recent_date: { on_or_before: false }
 
   validate :validate_transcript_and_content
 

--- a/app/forms/risk_assessment_form.rb
+++ b/app/forms/risk_assessment_form.rb
@@ -42,9 +42,8 @@ class RiskAssessmentForm
   validates :assessed_on,
             real_date: true,
             complete_date: true,
-            not_in_future: true
-
-  validate :assessed_on_cannot_be_older_than_1970
+            not_in_future: true,
+            recent_date: { on_or_before: false }
 
   def cache_file!
     return if risk_assessment_file.blank?
@@ -132,12 +131,6 @@ class RiskAssessmentForm
   end
 
 private
-
-  def assessed_on_cannot_be_older_than_1970
-    if assessed_on.is_a?(Date) && assessed_on < Date.parse("1970-01-01")
-      errors.add(:assessed_on, :too_old)
-    end
-  end
 
   def at_least_one_product_associated
     return unless product_ids.to_a.empty?

--- a/app/forms/test_result_form.rb
+++ b/app/forms/test_result_form.rb
@@ -32,7 +32,8 @@ class TestResultForm
             presence: true,
             real_date: true,
             complete_date: true,
-            not_in_future: true
+            not_in_future: true,
+            recent_date: { on_or_before: false }
   validates :failure_details, presence: true, if: -> { result == "failed" }
 
   before_validation do

--- a/app/validators/recent_date_validator.rb
+++ b/app/validators/recent_date_validator.rb
@@ -5,7 +5,9 @@ class RecentDateValidator < ActiveModel::EachValidator
     on_or_after = options[:on_or_after] || Time.zone.parse("1970-01-01").to_date
     on_or_before = options[:on_or_before] || Time.zone.today + 50.years
 
-    if value < on_or_after || value > on_or_before
+    # NOTE: You can pass `false` to turn off the check, or `nil` to take the default
+    if (!options[:on_or_after].is_a?(FalseClass) && value < on_or_after) ||
+        (!options[:on_or_before].is_a?(FalseClass) && value > on_or_before)
       record.errors.add(attribute, options[:message] || :recent_date)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,7 @@ en:
               blank: Enter date
               must_be_real: Date must be a real date
               incomplete: Date must include a %{missing_date_parts}
+              recent_date: Date must be on or after 1 January 1970
         accident_or_incident_type_form:
           attributes:
             type:
@@ -429,6 +430,7 @@ en:
               must_be_real: Date of test must be a real date
               incomplete: Date of test must include a %{missing_date_parts}
               in_future: Date of test must be today or in the past
+              recent_date: Date of test must be on or after 1 January 1970
             failure_details:
               blank: Enter details about how the product failed to meet the requirements
             further_test_results:
@@ -463,9 +465,9 @@ en:
             assessed_on:
               blank: Enter the date of the assessment
               in_future: Date of assessment must be today or in the past
-              too_old: Date of assessment must be on or after 1 January 1970
               must_be_real: Date of assessment must be a real date
               incomplete: Date of assessment must include a %{missing_date_parts}
+              recent_date: Date of assessment must be on or after 1 January 1970
             risk_level:
               blank: Select the risk level
             custom_risk_level:
@@ -557,6 +559,7 @@ en:
               must_be_real: Date sent must be a real date
               incomplete: Date sent must include a %{missing_date_parts}
               in_future: Date sent must be today or in the past
+              recent_date: Date sent must be on or after 1 January 1970
             email_file:
               blank: Select a replacement file
             email_attachment:
@@ -568,6 +571,7 @@ en:
               must_be_real: Date of call must be a real date
               incomplete: Date of call must include a %{missing_date_parts}
               in_future: Date of call must be today or in the past
+              recent_date: Date of call must be on or after 1 January 1970
         corrective_action_form:
           attributes:
             product_id:

--- a/spec/forms/accident_or_incident_form_spec.rb
+++ b/spec/forms/accident_or_incident_form_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe AccidentOrIncidentForm, :with_stubbed_elasticsearch, :with_test_q
       end
     end
 
+    it_behaves_like "it does not allow far away dates", :date, nil, on_or_before: false
+
     context "with blank date" do
       context "with is_date_known == 'false'" do
         let(:date) { nil }

--- a/spec/forms/email_correspondence_form_spec.rb
+++ b/spec/forms/email_correspondence_form_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe EmailCorrespondenceForm, :with_stubbed_elasticsearch, :with_stubb
     it_behaves_like "it does not allow an incomplete", :correspondence_date
     it_behaves_like "it does not allow malformed dates", :correspondence_date
     it_behaves_like "it does not allow dates in the future", :correspondence_date
+    it_behaves_like "it does not allow far away dates", :correspondence_date, nil, on_or_before: false
 
     context "when both subject and body and email file are missing" do
       let(:email_file) { nil }

--- a/spec/forms/phone_call_correspondence_form_spec.rb
+++ b/spec/forms/phone_call_correspondence_form_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe PhoneCallCorrespondenceForm do
     it_behaves_like "it does not allow an incomplete", :correspondence_date
     it_behaves_like "it does not allow malformed dates", :correspondence_date
     it_behaves_like "it does not allow dates in the future", :correspondence_date
+    it_behaves_like "it does not allow far away dates", :correspondence_date, nil, on_or_before: false
 
     describe "#validate_transcript_and_content" do
       context "when no transcript is uploaded" do

--- a/spec/forms/risk_assessment_form_spec.rb
+++ b/spec/forms/risk_assessment_form_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe RiskAssessmentForm, :with_stubbed_elasticsearch, :with_test_queue
     it_behaves_like "it does not allow an incomplete", :assessment_date, :assessed_on
     it_behaves_like "it does not allow malformed dates", :assessment_date, :assessed_on
     it_behaves_like "it does not allow dates in the future", :assessment_date, :assessed_on
+    it_behaves_like "it does not allow far away dates", :assessment_date, :assessed_on, on_or_before: false
 
     context "with an assessment date that isn't numerical" do
       let(:assessment_date) { { day: "x", month: "12", year: "2020" } }

--- a/spec/forms/test_result_form_spec.rb
+++ b/spec/forms/test_result_form_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe TestResultForm, :with_stubbed_elasticsearch, :with_stubbed_mailer
     it_behaves_like "it does not allow dates in the future", :date_form_params, :date
     it_behaves_like "it does not allow malformed dates", :date_form_params, :date
     it_behaves_like "it does not allow an incomplete", :date_form_params, :date
+    it_behaves_like "it does not allow far away dates", :date_form_params, :date, on_or_before: false
   end
 
   describe "#product_form=" do

--- a/spec/support/shared_examples/date_validations.rb
+++ b/spec/support/shared_examples/date_validations.rb
@@ -25,22 +25,26 @@ RSpec.shared_examples "it does not allow an incomplete" do |form_attribute, attr
   end
 end
 
-RSpec.shared_examples "it does not allow far away dates" do |form_attribute, attribute|
-  context "with a date 60 years from now" do
-    let(form_attribute) { { day: "1", month: "1", year: 60.years.from_now.to_date.year.to_s } }
+RSpec.shared_examples "it does not allow far away dates" do |form_attribute, attribute, on_or_after: true, on_or_before: true|
+  if on_or_before
+    context "with a date 60 years from now" do
+      let(form_attribute) { { day: "1", month: "1", year: 60.years.from_now.year.to_s } }
 
-    it "is not valid and contains an error message", :aggregate_failures do
-      expect(form).not_to be_valid
-      expect(form.errors.details[attribute || form_attribute]).to eq([{ error: :recent_date }])
+      it "is not valid and contains an error message", :aggregate_failures do
+        expect(form).not_to be_valid
+        expect(form.errors.details[attribute || form_attribute]).to eq([{ error: :recent_date }])
+      end
     end
   end
 
-  context "with a date before 1970" do
-    let(form_attribute) { { day: "1", month: "1", year: "1960" } }
+  if on_or_after
+    context "with a date before 1970" do
+      let(form_attribute) { { day: "31", month: "12", year: "1969" } }
 
-    it "is not valid and contains an error message", :aggregate_failures do
-      expect(form).not_to be_valid
-      expect(form.errors.details[attribute || form_attribute]).to eq([{ error: :recent_date }])
+      it "is not valid and contains an error message", :aggregate_failures do
+        expect(form).not_to be_valid
+        expect(form.errors.details[attribute || form_attribute]).to eq([{ error: :recent_date }])
+      end
     end
   end
 end

--- a/spec/validators/recent_date_validator_spec.rb
+++ b/spec/validators/recent_date_validator_spec.rb
@@ -129,4 +129,54 @@ RSpec.describe RecentDateValidator do
       end
     end
   end
+
+  context "with on_or_after set to false" do
+    subject(:validator) do
+      Class.new {
+        include ActiveModel::Validations
+        attr_accessor :date
+
+        validates :date,
+                  recent_date: {
+                    message: "Date not recent",
+                    on_or_after: false
+                  }
+
+        def self.name
+          "RecentDateValidatorSpec"
+        end
+      }.new
+    end
+
+    it "does not check dates before 1970" do
+      validator.date = Date.new(1969, 12, 31)
+      validator.validate
+      expect(validator).to be_valid
+    end
+  end
+
+  context "with on_or_before set to false" do
+    subject(:validator) do
+      Class.new {
+        include ActiveModel::Validations
+        attr_accessor :date
+
+        validates :date,
+                  recent_date: {
+                    message: "Date not recent",
+                    on_or_before: false
+                  }
+
+        def self.name
+          "RecentDateValidatorSpec"
+        end
+      }.new
+    end
+
+    it "does not check dates over 50 years in the future" do
+      validator.date = Time.zone.today + 50.years + 1.day
+      validator.validate
+      expect(validator).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/6aBbE5o9/1108-make-1970-50y-date-handling-consistent

## Description
This PR adds validations to prevent users entering very old dates in fields where the date should be recent. It also standardises any existing validations to use the same validator.

 - Accident/incident date
 - Correspondence date (email/phone)
 - Risk assessment (assessed on) — standardised to use the `recent_date` validator
 - Test result

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
