### PR TITLE
Move case export query into background job and find in batches

### DIFF
--- a/app/controllers/case_exports_controller.rb
+++ b/app/controllers/case_exports_controller.rb
@@ -6,12 +6,11 @@ class CaseExportsController < ApplicationController
   def generate
     authorize Investigation, :export?
 
-    # TODO: move this query to the job once we are satisfied that this is working well.
-    answer = search_for_investigations
-    investigations = answer.records(includes: [:complainant, :products, :owner_team, :owner_user, { creator_user: :team }]).to_a
+    investigation_ids = search_for_investigations.records.ids
 
     case_export = CaseExport.create!
-    CaseExportJob.perform_later(investigations, case_export.id, current_user)
+    CaseExportJob.perform_later(investigation_ids, case_export.id, current_user)
+
     redirect_to investigations_path(q: params[:q]), flash: { success: "Your case export is being prepared. You will receive an email when your export is ready to download." }
   end
 

--- a/app/controllers/case_exports_controller.rb
+++ b/app/controllers/case_exports_controller.rb
@@ -9,7 +9,7 @@ class CaseExportsController < ApplicationController
     investigation_ids = search_for_investigations.records.ids
 
     case_export = CaseExport.create!
-    CaseExportJob.perform_later(investigation_ids, case_export.id, current_user)
+    CaseExportJob.perform_later(investigation_ids, case_export, current_user)
 
     redirect_to investigations_path(q: params[:q]), flash: { success: "Your case export is being prepared. You will receive an email when your export is ready to download." }
   end

--- a/app/jobs/case_export_job.rb
+++ b/app/jobs/case_export_job.rb
@@ -1,8 +1,5 @@
 class CaseExportJob < ApplicationJob
-  def perform(case_ids, case_export_id, user)
-    case_export = CaseExport.find(case_export_id)
-    return unless case_export
-
+  def perform(case_ids, case_export, user)
     case_export.export case_ids
 
     NotifyMailer.case_export(

--- a/app/jobs/case_export_job.rb
+++ b/app/jobs/case_export_job.rb
@@ -1,9 +1,9 @@
 class CaseExportJob < ApplicationJob
-  def perform(cases, case_export_id, user)
+  def perform(case_ids, case_export_id, user)
     case_export = CaseExport.find(case_export_id)
     return unless case_export
 
-    case_export.export(cases)
+    case_export.export case_ids
 
     NotifyMailer.case_export(
       email: user.email,

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -1,6 +1,7 @@
 class CaseExport < ApplicationRecord
   include CountriesHelper
 
+  # Helps to manage the database query execution time within the PaaS imposed limits
   FIND_IN_BATCH_SIZE = 1000
 
   has_one_attached :export_file

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Case export", :with_elasticsearch, :with_stubbed_antivirus, :with
     user.roles.create!(name: "psd_admin")
     sign_in(user)
     allow(CaseExportJob).to receive(:perform_later) do
-      CaseExportJob.new.perform(Investigation.all, CaseExport.last.id, user)
+      CaseExportJob.new.perform(Investigation.pluck(:id), CaseExport.last.id, user)
     end
   end
 

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Case export", :with_elasticsearch, :with_stubbed_antivirus, :with
     user.roles.create!(name: "psd_admin")
     sign_in(user)
     allow(CaseExportJob).to receive(:perform_later) do
-      CaseExportJob.new.perform(Investigation.pluck(:id), CaseExport.last.id, user)
+      CaseExportJob.new.perform(Investigation.pluck(:id), CaseExport.last, user)
     end
   end
 

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CaseExport, :with_elasticsearch, :with_stubbed_notify, :with_stub
 
   describe "#export" do
     before do
-      case_export.export(cases)
+      case_export.export(cases.pluck(:id))
     end
 
     let!(:exported_data) { case_export.export_file.open { |file| Roo::Excelx.new(file) } }


### PR DESCRIPTION
https://trello.com/c/M37lIPUp/1112-full-case-export-timing-out

## Description

This PR moves a large database query from a synchronous controller request to the background job for case export. This was an existing TODO item which needed to be cleared up since during very large exports, users were still seeing a timeout error, caused by a SQL timeout.

Rather than passing the records around, this PR passes `case_ids` as an array to the background job, and then allows the exporter to find cases in batches. This has the same effect in the backend as pagination would on the frontend.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
