### PR TITLE
Download webp package on PaaS environments to support WEBP image processing

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -1,0 +1,3 @@
+---
+packages:
+- webp

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -2,6 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
+    - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.6
     - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.43
   path: .
   stack: cflinuxfs3

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
+    - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.6
     - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.43
   path: .
   stack: cflinuxfs3


### PR DESCRIPTION
https://trello.com/c/G1122diI/1115-fix-webp-image-processing

Uses the CloudFoundry multi-buildpack feature and the experimental [CloudFoundry apt buildpack](https://github.com/cloudfoundry/apt-buildpack), which is similar to the Heroku apt buildpack, to automatically install the webp library on GOV.UK PaaS-hosted environments. 

This should resolve the silent failures which occur when users upload WEBP formatted images. Currently, thumbnail previews are not generated. This should ensure that thumbnails are generated correctly.