### PR TITLE
Fix intermittent ActiveModel::UnknownAttributeError error when seeding review app database

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,8 @@ end
 run_seeds = (Product.count.zero? || Complainant.count.zero?)
 
 if run_seeds
-  User.reset_column_information
+  ApplicationRecord.descendants.each(&:reset_column_information)
+
   Rails.logger.info("Running seeds.rb")
 
   organisation = Organisation.create!(name: "Seed Organisation")


### PR DESCRIPTION
A fix for rare `ActiveModel::UnknownAttributeError` exceptions that occasionally occur when seeding review app databases. Examples:

https://sentry.io/organizations/beis/issues/2670001888
https://sentry.io/organizations/beis/issues/2653344496
https://sentry.io/organizations/beis/issues/2636844945

I'm not entirely sure on the cause, but I suspect there is a race condition between the migration and seed tasks which results in particular model attributes not being loaded correctly. Oddly it is always the `Product#markings` attribute affected.

**Update**: I found an instance where the `Product#subcategory` attribute failed: https://sentry.io/organizations/beis/issues/2582904790

This is a modification of a [fix for a similar error](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/1319) which affected the `User#team_id` attribute. I have just made sure all models are reloaded instead of just the `User` model.

It is difficult to test this has actually fixed the issue since it is rare and the exact cause is unknown and so not reliable reproducible; we'll need to ensure the seeds are running correctly and keep an eye on Sentry.
