### PR TITLE
Screenshot smoke test fails

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -135,4 +135,4 @@ jobs:
       if: failure()
       with:
         name: capybara screenshots
-        path: tmp/capybara
+        path: tmp/capybara/screenshot

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -128,7 +128,7 @@ jobs:
         SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD: ${{secrets.SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD}}
 
       run: |
-        mkdir -p temp/capybara
+        mkdir -p tmp/capybara
         bundle exec rspec ./smoke_test/cases_page_spec.rb
 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -135,4 +135,4 @@ jobs:
       if: failure()
       with:
         name: capybara screenshots
-        path: tmp/capybara/screenshot
+        path: tmp/capybara/

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -128,6 +128,7 @@ jobs:
         SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD: ${{secrets.SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD}}
 
       run: |
+        mkdir -p temp/capybara
         bundle exec rspec ./smoke_test/cases_page_spec.rb
 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -129,3 +129,9 @@ jobs:
 
       run: |
         bundle exec rspec ./smoke_test/cases_page_spec.rb
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: capybara screenshots
+        path: tmp/capybara

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -50,10 +50,7 @@ RSpec.feature "Search smoke test" do
       sleep attempts * 10
     end
 
-    @session.click_link "Cases123"
-
-    @session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
-    @session.find(".govuk-grid-row.psd-case-card:nth-child(10)")
+    @session.click_link "Cases"
 
     expect(@session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
     expect(@session).to have_css(".govuk-grid-row.psd-case-card:nth-child(10)")

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -1,11 +1,14 @@
 require 'capybara/rspec'
 require 'capybara/mechanize'
 require "webmock"
-require "capybara-screenshot/rspec"
 
 # we need to use machanize in order to make remote requests
 Capybara.register_driver :mechanize do |app|
   Capybara::Mechanize::Driver.new(proc {})
+end
+
+Rspec.configure do |config|
+  config.after { |example_group| save_page if example_group.exception }
 end
 
 RSpec.feature "Search smoke test" do
@@ -28,7 +31,7 @@ RSpec.feature "Search smoke test" do
     loop do
       code = get_code
       break unless code
-      
+
       smoke_complete_secondary_authentication_with(code, session)
       attempts += 1
       break if session.has_content?("Open a new case")

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -12,12 +12,12 @@ RSpec.feature "Search smoke test" do
 
   scenario "sign-in and visit case page" do
     WebMock.allow_net_connect!
-    session.driver.browser.agent.add_auth("https://psd-pr-1599.london.cloudapps.digital/", "psd", "reviewAPP")
-    session.visit("https://psd-pr-1599.london.cloudapps.digital/")
+    session.driver.browser.agent.add_auth(ENV["SMOKE_TEST_URL"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_USER"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD"]) if ENV["IS_REVIEW_APP"] == "true"
+    session.visit(ENV["SMOKE_TEST_URL"])
     expect(session).to have_css("h1", text: "Product Safety Database")
-    session.visit("#{"https://staging.product-safety-database.service.gov.uk/"}/sign-in")
-    session.fill_in "Email address", with: "smoketest@example.com"
-    session.fill_in "Password", with: "JHxztd534MeFw4Q"
+    session.visit("#{ENV["SMOKE_TEST_URL"]}/sign-in")
+    session.fill_in "Email address", with: ENV["SMOKE_USER"]
+    session.fill_in "Password", with: ENV["SMOKE_PASSWORD"]
     session.click_button "Continue"
 
     expect(session).to have_current_path(/\/two-factor/)
@@ -37,12 +37,14 @@ RSpec.feature "Search smoke test" do
     end
 
     session.click_link "Cases"
+
   begin
     session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
     session.find(".govuk-grid-row.psd-case-card:nth-child(1000)")
   rescue
     session.save_page("tmp/capybara/screenshot.html")
   end
+
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1000)")
   end
@@ -54,10 +56,10 @@ def smoke_complete_secondary_authentication_with(code, session)
 end
 
 def get_code
-  uri = URI("https://beis-opss-text-relay.london.cloudapps.digital/text")
+  uri = URI(ENV["SMOKE_RELAY_CODE_URL"])
 
   req = Net::HTTP::Get.new(uri)
-  req.basic_auth "sendatext", "itsforsmoketest"
+  req.basic_auth ENV["SMOKE_RELAY_CODE_USER"], ENV["SMOKE_RELAY_CODE_PASS"]
 
   http = Net::HTTP.new(uri.hostname, uri.port)
   http.use_ssl = true

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Search smoke test" do
 
     session.click_link "Cases"
 
-    number_of_cases = session.all(".govuk-grid-row.psd-case-card:nth-child").count
+    number_of_cases = session.all(".govuk-grid-row.psd-case-card").count
     session.save_page("tmp/capybara/screenshot.html") if number_of_cases < 10
     expect(number_of_cases).to be > 9
   end

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -1,6 +1,7 @@
 require 'capybara/rspec'
 require 'capybara/mechanize'
 require "webmock"
+require "capybara-screenshot/rspec"
 
 # we need to use machanize in order to make remote requests
 Capybara.register_driver :mechanize do |app|

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -7,46 +7,56 @@ Capybara.register_driver :mechanize do |app|
   Capybara::Mechanize::Driver.new(proc {})
 end
 
-RSpec.feature "Search smoke test" do
-  let(:session) { Capybara::Session.new :mechanize }
+RSpec.configure do |config|
+  config.before do
+    @session = Capybara::Session.new :mechanize
+  end
 
+  config.after do |example|
+    take_screenshot_after_failed_example(example)
+  end
+end
+
+def take_screenshot_after_failed_example(example)
+  return unless example.exception
+  puts "Saving screenshot to screenshot.html"
+  @session.save_page("tmp/capybara/screenshot.html")
+end
+
+RSpec.feature "Search smoke test" do
   scenario "sign-in and visit case page" do
     WebMock.allow_net_connect!
-    session.driver.browser.agent.add_auth(ENV["SMOKE_TEST_URL"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_USER"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD"]) if ENV["IS_REVIEW_APP"] == "true"
-    session.visit(ENV["SMOKE_TEST_URL"])
-    expect(session).to have_css("h1", text: "Product Safety Database")
-    session.visit("#{ENV["SMOKE_TEST_URL"]}/sign-in")
-    session.fill_in "Email address", with: ENV["SMOKE_USER"]
-    session.fill_in "Password", with: ENV["SMOKE_PASSWORD"]
-    session.click_button "Continue"
+    @session.driver.browser.agent.add_auth(ENV["SMOKE_TEST_URL"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_USER"], ENV["SMOKE_TEST_REVIEW_APP_BASIC_AUTH_PASSWORD"]) if ENV["IS_REVIEW_APP"] == "true"
+    @session.visit(ENV["SMOKE_TEST_URL"])
+    expect(@session).to have_css("h1", text: "Product Safety Database")
+    @session.visit("#{ENV["SMOKE_TEST_URL"]}/sign-in")
+    @session.fill_in "Email address", with: ENV["SMOKE_USER"]
+    @session.fill_in "Password", with: ENV["SMOKE_PASSWORD"]
+    @session.click_button "Continue"
 
-    expect(session).to have_current_path(/\/two-factor/)
-    expect(session).to have_content("Check your phone")
+    expect(@session).to have_current_path(/\/two-factor/)
+    expect(@session).to have_content("Check your phone")
 
     attempts = 0
     loop do
       code = get_code
       break unless code
 
-      smoke_complete_secondary_authentication_with(code, session)
+      smoke_complete_secondary_authentication_with(code, @session)
       attempts += 1
-      break if session.has_content?("Open a new case")
+      break if @session.has_content?("Open a new case")
       break if attempts > 3
 
       sleep attempts * 10
     end
 
-    session.click_link "Cases"
+    @session.click_link "Cases123"
 
-    begin
-      session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
-      session.find(".govuk-grid-row.psd-case-card:nth-child(10)")
-    rescue
-      session.save_page("tmp/capybara/screenshot.html")
-    end
+    @session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
+    @session.find(".govuk-grid-row.psd-case-card:nth-child(10)")
 
-    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
-    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(10)")
+    expect(@session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
+    expect(@session).to have_css(".govuk-grid-row.psd-case-card:nth-child(10)")
   end
 end
 

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Search smoke test" do
     session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
     session.find(".govuk-grid-row.psd-case-card:nth-child(1000)")
   rescue
-    session.save_page("tmp/capybara/screenshot")
+    session.save_page("tmp/capybara/screenshot.html")
   end
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1000)")

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Search smoke test" do
     session.click_link "Cases"
   begin
     session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
-    session.find(".govuk-grid-row.psd-case-card:nth-child(1000)")
+    session.find(".govuk-grid-row.psd-case-card:nth-child(11)")
   rescue
     session.save_page
   end

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -7,7 +7,7 @@ Capybara.register_driver :mechanize do |app|
   Capybara::Mechanize::Driver.new(proc {})
 end
 
-Rspec.configure do |config|
+RSpec.configure do |config|
   config.after { |example_group| save_page if example_group.exception }
 end
 

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -38,15 +38,9 @@ RSpec.feature "Search smoke test" do
 
     session.click_link "Cases"
 
-  begin
-    session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
-    session.find(".govuk-grid-row.psd-case-card:nth-child(1000)")
-  rescue
-    session.save_page("tmp/capybara/screenshot.html")
-  end
-
-    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
-    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1000)")
+    number_of_cases = session.all(".govuk-grid-row.psd-case-card:nth-child").count
+    session.save_page("tmp/capybara/screenshot.html") if number_of_cases < 10
+    expect(number_of_cases).to be > 9
   end
 end
 

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -38,9 +38,15 @@ RSpec.feature "Search smoke test" do
 
     session.click_link "Cases"
 
-    number_of_cases = session.all(".govuk-grid-row.psd-case-card").count
-    session.save_page("tmp/capybara/screenshot.html") if number_of_cases < 10
-    expect(number_of_cases).to be > 9
+    begin
+      session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
+      session.find(".govuk-grid-row.psd-case-card:nth-child(10)")
+    rescue
+      session.save_page("tmp/capybara/screenshot.html")
+    end
+
+    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
+    expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(10)")
   end
 end
 

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Search smoke test" do
     session.click_link "Cases"
   begin
     session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
-    session.find(".govuk-grid-row.psd-case-card:nth-child(11)")
+    session.find(".govuk-grid-row.psd-case-card:nth-child(1000)")
   rescue
     session.save_page("tmp/capybara/screenshot")
   end

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Search smoke test" do
     session.find(".govuk-grid-row.psd-case-card:nth-child(1)")
     session.find(".govuk-grid-row.psd-case-card:nth-child(11)")
   rescue
-    session.save_page
+    session.save_page("tmp/capybara/screenshot")
   end
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1)")
     expect(session).to have_css(".govuk-grid-row.psd-case-card:nth-child(1000)")


### PR DESCRIPTION
Allow smoke tests to record page data if test fails on prod and staging

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
