### PR TITLE
Allow prod and staging smoke tests to record screenshots

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,14 @@ jobs:
         SMOKE_TEST_URL: "https://staging.product-safety-database.service.gov.uk"
 
       run: |
+        mkdir -p tmp/capybara
         bundle exec rspec ./smoke_test/cases_page_spec.rb
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: capybara screenshots
+        path: tmp/capybara/
 
     - name: Create GitHub deployment for Production
       if: success()
@@ -184,6 +191,12 @@ jobs:
 
       run: |
         bundle exec rspec ./smoke_test/cases_page_spec.rb
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: capybara screenshots
+        path: tmp/capybara/
 
     - name: Alert team via Slack of deployment failure
       if: failure()

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -20,7 +20,7 @@ end
 def take_screenshot_after_failed_example(example)
   return unless example.exception
   puts "Saving screenshot to screenshot.html"
-  @session.save_page("tmp/capybara/screenshot.html")
+  @session.save_page("tmp/capybara/screenshot-#{ENV["SMOKE_TEST_URL"]}.html")
 end
 
 RSpec.feature "Search smoke test" do


### PR DESCRIPTION
Allow prod and staging smoke tests to record screenshots on failure

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
