### PR TITLE
Fix syntax error in dangling review app delete action

### DIFF
--- a/.github/workflows/review-apps-delete-dangling.yml
+++ b/.github/workflows/review-apps-delete-dangling.yml
@@ -78,7 +78,7 @@ jobs:
           echo "Deleting ${dangling}"
           cf stop ${dangling}
           cf run-task ${dangling} --command "./env/delete-elasticsearch-indexes.sh" --name delete-elasticsearch-indexes
-          task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks ${dangling} | grep delete-elasticsearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
+          task_status=0; until [ "$task_status" = "SUCCEEDED" ]; do task_status="$(cf tasks ${dangling} | grep delete-elasticsearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
           cf delete -f -r ${dangling}
           cf delete-service -f psd-db-pr-${dangling:7} # Substring from 7th char contains the PR number
         done


### PR DESCRIPTION
The 'Delete dangling review apps' GitHub action has been failing for the last five months. We have a few review apps which are no longer needed as a result.

It reports a syntax error e.g:

`/home/runner/work/_temp/9aed070d-c2e6-4ab4-8235-fc5ab590262f.sh: line 5: [: too many arguments`

This is due to an unquoted variable in a conditional. Presumably the variable is set to a weird or empty string in some race condition where the task is not yet returned by `cf tasks`, causing it to enter an infinite loop which can never be resolved, and takes 6 hours for the task to eventually be terminated.

Once merged I will rerun the action manually to ensure it has resolved the problem.