### PR TITLE
Query ES for businesses in batches

### DIFF
--- a/app/controllers/business_exports_controller.rb
+++ b/app/controllers/business_exports_controller.rb
@@ -6,7 +6,7 @@ class BusinessExportsController < ApplicationController
   def generate
     authorize Business, :export?
 
-    business_ids = search_for_businesses.ids
+    business_ids = search_for_businesses_in_batches.map(&:id)
 
     business_export = BusinessExport.create!
     BusinessExportJob.perform_later(business_ids, business_export, current_user)

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -15,7 +15,7 @@ module BusinessesHelper
   end
 
   def search_for_businesses_in_batches
-    Business.search_for_businesses_in_batches(search_query)
+    Business.search_in_batches(search_query)
   end
 
   def business_export_params

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -14,6 +14,32 @@ module BusinessesHelper
       .records
   end
 
+  def search_for_businesses_in_batches(size = 1000)
+    businesses= []
+    after = 0
+
+    loop do
+      query = search_query.build_query([], [], [])
+
+      query.merge!({
+          sort: [
+            {id: "asc"}
+          ],
+          size: size,
+          search_after: [after]
+      })
+
+      results =  Business.search(query)
+      results_amount = results.size
+      businesses += results
+      after += size
+
+      break if results_amount == 0
+    end
+
+    businesses
+  end
+
   def business_export_params
     params.permit(:sort, :q)
   end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -14,22 +14,8 @@ module BusinessesHelper
       .records
   end
 
-  def search_for_businesses_in_batches(size = 1000)
-    businesses = []
-    after = 0
-
-    loop do
-      query = search_after_query(search_query.build_query([], [], []), size, after)
-
-      results = Business.search(query)
-      results_amount = results.size
-      businesses += results
-      after += size
-
-      break if results_amount.zero?
-    end
-
-    businesses
+  def search_for_businesses_in_batches
+    Business.search_for_businesses_in_batches(search_query)
   end
 
   def business_export_params
@@ -97,15 +83,5 @@ private
         }
       ]
     }
-  end
-
-  def search_after_query(_search_query, size, after)
-    query.merge!({
-      sort: [
-        { id: "asc" }
-      ],
-      size: size,
-      search_after: [after]
-    })
   end
 end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -19,15 +19,7 @@ module BusinessesHelper
     after = 0
 
     loop do
-      query = search_query.build_query([], [], [])
-
-      query.merge!({
-          sort: [
-            {id: "asc"}
-          ],
-          size: size,
-          search_after: [after]
-      })
+      query = search_after_query(search_query.build_query([], [], []), size, after)
 
       results =  Business.search(query)
       results_amount = results.size
@@ -105,5 +97,15 @@ private
         }
       ]
     }
+  end
+
+  def search_after_query(search_query, size, after)
+    query.merge!({
+        sort: [
+          {id: "asc"}
+        ],
+        size: size,
+        search_after: [after]
+    })
   end
 end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -15,18 +15,18 @@ module BusinessesHelper
   end
 
   def search_for_businesses_in_batches(size = 1000)
-    businesses= []
+    businesses = []
     after = 0
 
     loop do
       query = search_after_query(search_query.build_query([], [], []), size, after)
 
-      results =  Business.search(query)
+      results = Business.search(query)
       results_amount = results.size
       businesses += results
       after += size
 
-      break if results_amount == 0
+      break if results_amount.zero?
     end
 
     businesses
@@ -99,13 +99,13 @@ private
     }
   end
 
-  def search_after_query(search_query, size, after)
+  def search_after_query(_search_query, size, after)
     query.merge!({
-        sort: [
-          {id: "asc"}
-        ],
-        size: size,
-        search_after: [after]
+      sort: [
+        { id: "asc" }
+      ],
+      size: size,
+      search_after: [after]
     })
   end
 end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -15,7 +15,7 @@ module BusinessesHelper
   end
 
   def search_for_businesses_in_batches
-    Business.search_in_batches(search_query)
+    Business.search_in_batches(search_query, Business.first.id - 1)
   end
 
   def business_export_params

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -64,6 +64,32 @@ module Searchable
       __elasticsearch__.search(query.build_query(highlighted_fields, fuzzy_fields, exact_fields))
     end
 
+    def self.search_for_businesses_in_batches(search_query, size = 1000)
+      records = []
+      after = 0
+
+      loop do
+        query = search_query.build_query(highlighted_fields, fuzzy_fields, exact_fields)
+
+        query.merge!({
+          sort: [
+            { id: "asc" }
+          ],
+          size: size,
+          search_after: [after]
+        })
+
+        results = __elasticsearch__.search(query)
+        results_amount = results.size
+        records += results
+        after += size
+
+        break if results_amount.zero?
+      end
+
+      records
+    end
+
     # "prefix" may be changed to a more appropriate query. For alternatives see:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/term-level-queries.html
     def self.prefix_search(params, field)
@@ -99,6 +125,16 @@ module Searchable
       # To be overwritten by the model using it, defaults to all fields
       # Bear in mind that if you have a field both here and in fuzzy_fields, your result will just be fuzzy
       []
+    end
+
+    def search_after_query(query, size, after)
+      query.merge!({
+        sort: [
+          { id: "asc" }
+        ],
+        size: size,
+        search_after: [after]
+      })
     end
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -82,7 +82,7 @@ module Searchable
         results = __elasticsearch__.search(query)
         results_amount = results.size
         records += results
-        after += size
+        after = records.last.id.to_i
 
         break if results_amount.zero?
       end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -64,7 +64,7 @@ module Searchable
       __elasticsearch__.search(query.build_query(highlighted_fields, fuzzy_fields, exact_fields))
     end
 
-    def self.search_for_businesses_in_batches(search_query, size = 1000)
+    def self.search_in_batches(search_query, size = 1000)
       records = []
       after = 0
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -126,15 +126,5 @@ module Searchable
       # Bear in mind that if you have a field both here and in fuzzy_fields, your result will just be fuzzy
       []
     end
-
-    def search_after_query(query, size, after)
-      query.merge!({
-        sort: [
-          { id: "asc" }
-        ],
-        size: size,
-        search_after: [after]
-      })
-    end
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -64,9 +64,9 @@ module Searchable
       __elasticsearch__.search(query.build_query(highlighted_fields, fuzzy_fields, exact_fields))
     end
 
-    def self.search_in_batches(search_query, size = 10_000)
+    def self.search_in_batches(search_query, search_from, size = 10_000)
       records = []
-      after = 0
+      after = search_from
 
       loop do
         query = search_query.build_query(highlighted_fields, fuzzy_fields, exact_fields)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -64,7 +64,7 @@ module Searchable
       __elasticsearch__.search(query.build_query(highlighted_fields, fuzzy_fields, exact_fields))
     end
 
-    def self.search_in_batches(search_query, size = 10000)
+    def self.search_in_batches(search_query, size = 10_000)
       records = []
       after = 0
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -64,7 +64,7 @@ module Searchable
       __elasticsearch__.search(query.build_query(highlighted_fields, fuzzy_fields, exact_fields))
     end
 
-    def self.search_in_batches(search_query, size = 1000)
+    def self.search_in_batches(search_query, size = 10000)
       records = []
       after = 0
 

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -7,7 +7,6 @@ RSpec.shared_examples "finds the relevant investigation" do
 
   it "finds the relevant investigation" do
     expect(perform_search.records.to_a).to include(investigation)
-    expect(perform_search.records.to_a).not_to include(other_investigation)
   end
 end
 
@@ -28,11 +27,8 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
   # assertions that irrelevant records are *not* returned here.
   describe "#build_query" do
     let(:batch_number)            { SecureRandom.uuid }
-    let!(:other_batch_number)     { SecureRandom.uuid }
     let(:country_of_origin)       { "United Kingdom" }
-    let(:other_country_of_origin) { "France" }
     let(:product)                 { create(:product, country_of_origin: country_of_origin, batch_number: batch_number) }
-    let!(:other_product)          { create(:product, country_of_origin: country_of_origin, batch_number: other_batch_number) }
     let(:investigation)           { create(:allegation, creator: user, products: [product]) }
 
     before do

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -8,6 +8,10 @@ RSpec.shared_examples "finds the relevant investigation" do
   it "finds the relevant investigation" do
     expect(perform_search.records.to_a).to include(investigation)
   end
+
+  it "finds the relevant investigation in batches" do
+    expect(perform_batched_search.records.to_a).to include(investigation)
+  end
 end
 
 RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
@@ -18,6 +22,10 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
   let(:sorting_params) { {} }
 
   def perform_search
+    Investigation.full_search(subject)
+  end
+
+  def perform_batched_search
     Investigation.full_search(subject)
   end
 

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -159,8 +159,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       create(:business, trading_name: "Netflix")
       create(:business, trading_name: "Google")
       Business.__elasticsearch__.create_index! force: true
-      Business.import
-      sleep 2
+      Business.import refresh: :wait_for
     end
 
     context "when searching in batches of 2" do

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -11,14 +11,14 @@ RSpec.shared_examples "finds the relevant investigation" do
 end
 
 RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
-  subject { described_class.new(query, filter_params, sorting_params) }
+  subject(:query) { described_class.new(query, filter_params, sorting_params) }
 
   let(:user)           { create(:user) }
   let(:filter_params)  { {} }
   let(:sorting_params) { {} }
 
   def perform_search
-    Investigation.full_search(subject)
+    Investigation.full_search(query)
   end
 
   # TODO: these specs are a port of the deprecated (and flaky) Minitest tests.
@@ -166,7 +166,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(subject, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map {|b| b.id.to_s})
+        expect(Business.search_in_batches(query, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -162,11 +162,25 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       Business.import refresh: :wait_for
     end
 
-    context "when searching in batches of 2" do
+    context "when searching in batches" do
       let(:query) { nil }
 
-      it "returns the expected businesses" do
-        expect(Business.search_in_batches(es_query, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
+      context "when batch size is 1" do
+        it "returns the expected businesses" do
+          expect(Business.search_in_batches(es_query, Business.first.id - 1, 1).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
+        end
+      end
+
+      context "when batch size is 2" do
+        it "returns the expected businesses" do
+          expect(Business.search_in_batches(es_query, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
+        end
+      end
+
+      context "when batch size is 100" do
+        it "returns the expected businesses" do
+          expect(Business.search_in_batches(es_query, Business.first.id - 1, 100).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
+        end
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -157,8 +157,6 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       create(:business, trading_name: "Applee")
       create(:business, trading_name: "Amazon")
       create(:business, trading_name: "Netflix")
-      create(:business, trading_name: "Netflix2")
-      create(:business, trading_name: "Netflix3")
       create(:business, trading_name: "Google")
       Business.__elasticsearch__.create_index! force: true
       Business.import

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(subject, 2).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
+        expect(Business.search_in_batches(subject, Business.first.id - 1, 2).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       create(:business, trading_name: "Google")
       Business.__elasticsearch__.create_index! force: true
       Business.import
+      sleep 2
     end
 
     context "when searching in batches of 1" do

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -11,14 +11,14 @@ RSpec.shared_examples "finds the relevant investigation" do
 end
 
 RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
-  subject(:query) { described_class.new(query, filter_params, sorting_params) }
+  subject(:es_query) { described_class.new(query, filter_params, sorting_params) }
 
   let(:user)           { create(:user) }
   let(:filter_params)  { {} }
   let(:sorting_params) { {} }
 
   def perform_search
-    Investigation.full_search(query)
+    Investigation.full_search(es_query)
   end
 
   # TODO: these specs are a port of the deprecated (and flaky) Minitest tests.
@@ -166,7 +166,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(query, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
+        expect(Business.search_in_batches(es_query, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map { |b| b.id.to_s })
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(subject, 1).map(&:ids)).to eq Business.all.map {|b| b.id.to_s}
+        expect(Business.search_in_batches(subject, 1).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(subject, Business.first.id - 1, 2).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
+        expect(Business.search_in_batches(subject, Business.first.id - 1, 2).map(&:id)).to match_array(Business.all.map {|b| b.id.to_s})
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
   end
 
   def perform_batched_search
-    Investigation.full_search(subject)
+    Investigation.search_in_batches(subject)
   end
 
   # TODO: these specs are a port of the deprecated (and flaky) Minitest tests.

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -163,11 +163,11 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
       sleep 2
     end
 
-    context "when searching in batches of 1" do
+    context "when searching in batches of 2" do
       let(:query) { nil }
 
       it "returns the expected businesses" do
-        expect(Business.search_in_batches(subject, 1).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
+        expect(Business.search_in_batches(subject, 2).map(&:id)).to eq Business.all.map {|b| b.id.to_s}
       end
     end
   end

--- a/spec/services/elasticsearch_query_spec.rb
+++ b/spec/services/elasticsearch_query_spec.rb
@@ -8,10 +8,6 @@ RSpec.shared_examples "finds the relevant investigation" do
   it "finds the relevant investigation" do
     expect(perform_search.records.to_a).to include(investigation)
   end
-
-  it "finds the relevant investigation in batches" do
-    expect(perform_batched_search.records.to_a).to include(investigation)
-  end
 end
 
 RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
@@ -23,10 +19,6 @@ RSpec.describe ElasticsearchQuery, :with_elasticsearch, :with_stubbed_mailer do
 
   def perform_search
     Investigation.full_search(subject)
-  end
-
-  def perform_batched_search
-    Investigation.search_in_batches(subject)
   end
 
   # TODO: these specs are a port of the deprecated (and flaky) Minitest tests.


### PR DESCRIPTION
https://trello.com/c/1HAsNX6G/1179-optimise-elasticsearch-query-for-business-export

## Description
This PR utilises elasticsearch's `search_after` functionality to retrieve all our businesses in 10k batches, which hopefully should reduce memory related issues now and in the future which could come from us retrieving >10k records in one query.

Note: I ordered by ID rather than created_at, as I found it much clearer to use ID as the search after point and the order will be the same regardless I believe. I don't think the ordering should matter much anyway as we are producing an excel file which the user can order as they see fit.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
