### PR TITLE
Re-invite deleted user

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -28,7 +28,7 @@ module Users
     end
 
     def create
-      user = User.find_by(email: params[:user][:email])
+      user = User.find_by(email: params[:user][:email], deleted_at: nil)
       return resend_invitation_link_for(user) if user && !user.has_completed_registration?
 
       super do |resource|

--- a/app/forms/invite_user_to_team_form.rb
+++ b/app/forms/invite_user_to_team_form.rb
@@ -6,7 +6,6 @@ class InviteUserToTeamForm
   attribute :team
 
   validates :email, email: { if: ->(form) { form.email.present? } }
-  validate :cannot_be_existing_deleted_user
   validate :cannot_be_existing_activated_user_on_same_team
   validate :cannot_be_existing_user_on_another_team
   validate :email_domain_must_be_whitelisted, if: :enforce_whitelist?
@@ -15,10 +14,6 @@ class InviteUserToTeamForm
   validates_presence_of :team
 
 private
-
-  def cannot_be_existing_deleted_user
-    errors.add(:email, :user_deleted) if existing_user&.deleted?
-  end
 
   def cannot_be_existing_activated_user_on_same_team
     if existing_user&.account_activated? && existing_user.team == team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,7 @@ class User < ApplicationRecord
     self.deleted_at = Time.zone.now
     self.deleted_by = deleted_by.id if deleted_by
     self.account_activated = false
+    self.invitation_token = nil
 
     save!
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,6 +183,19 @@ class User < ApplicationRecord
     save!
   end
 
+  def reset_to_invited_state!
+    self.deleted_at = nil
+    self.account_activated = false
+    self.mobile_number_verified = false
+    self.has_accepted_declaration = false
+    self.has_been_sent_welcome_email = false
+    self.has_viewed_introduction = false
+    self.name = nil
+    self.mobile_number = nil
+
+    save!
+  end
+
 private
 
   def lock_two_factor!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,6 +173,16 @@ class User < ApplicationRecord
     name.present? && mobile_number_verified?
   end
 
+  def mark_as_deleted!(deleted_by = nil)
+    return if deleted?
+
+    self.deleted_at = Time.zone.now
+    self.deleted_by = deleted_by.id if deleted_by
+    self.account_activated = false
+
+    save!
+  end
+
 private
 
   def lock_two_factor!

--- a/app/services/delete_user.rb
+++ b/app/services/delete_user.rb
@@ -9,8 +9,7 @@ class DeleteUser
 
     ActiveRecord::Base.transaction do
       user.mark_as_deleted!
-      user.update!(deleted_by: deleted_by.id) if deleted_by
-      user.update!(account_activated: false)
+
       change_user_investigations_ownership_to_their_team
     end
   end

--- a/app/services/delete_user.rb
+++ b/app/services/delete_user.rb
@@ -10,6 +10,7 @@ class DeleteUser
     ActiveRecord::Base.transaction do
       user.mark_as_deleted!
       user.update!(deleted_by: deleted_by.id) if deleted_by
+      user.update!(account_activated: false)
       change_user_investigations_ownership_to_their_team
     end
   end

--- a/app/services/invite_user_to_team.rb
+++ b/app/services/invite_user_to_team.rb
@@ -16,6 +16,7 @@ private
 
   def find_or_create_user
     existing_user = User.find_by email: email
+    reset_user_info(existing_user) if existing_user
     existing_user&.team == team ? existing_user : create_user
   end
 
@@ -26,6 +27,16 @@ private
       skip_password_validation: true,
       team: team
     )
+  end
+
+  def reset_user_info(user)
+    user.deleted_at = nil
+    user.account_activated = nil
+    user.mobile_number_verified = false
+    user.has_accepted_declaration = false
+    user.has_been_sent_welcome_email = false
+    user.has_viewed_introduction = false
+    user.save!
   end
 
   def send_invite

--- a/spec/features/invite_user_spec.rb
+++ b/spec/features/invite_user_spec.rb
@@ -81,8 +81,10 @@ RSpec.feature "Inviting a user", :with_stubbed_mailer, :with_stubbed_elasticsear
       context "when the user is deleted" do
         let(:existing_user_trait) { :deleted }
 
-        scenario "shows an error message" do
-          expect(page).to have_summary_error("Email address belongs to a user that has been deleted. Email OPSS if you would like their account restored.")
+        scenario "reinvites the user" do
+          expect_to_be_on_team_page(team)
+          expect_confirmation_banner("Invite sent to #{email}")
+          expect_invitation_email_sent(to: email, inviting_user: user)
         end
       end
     end

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -11,6 +11,51 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
       .to receive(:secondary_authentication_enabled).and_return(true)
   end
 
+  context "when a previously deleted user is invited back" do
+    let!(:deleted_user) { create(:user, :deleted, team: team) }
+
+    it "allows deleted user to sign up again" do
+      sign_in(admin)
+
+      visit "/teams/#{team.id}/invitations/new"
+
+      # enter_secondary_authentication_code(admin.reload.direct_otp)
+
+      invite_user_to_team(deleted_user.email)
+
+      expect_user_invited_successfully(deleted_user.email)
+
+      sign_out
+
+      invitee = User.find_by!(email: deleted_user.email)
+
+      visit "/users/#{invitee.id}/complete-registration?invitation=#{invitee.invitation_token}"
+
+      fill_in_registration_form
+
+      expect_to_be_on_secondary_authentication_page
+
+      click_link "Not received a text message?"
+
+      expect_to_be_on_resend_secondary_authentication_page
+      find("details summary", text: "Change where the text message is sent").click
+      fill_in "Mobile number", with: "07012345678"
+
+      click_button "Resend security code"
+      expect_to_be_on_secondary_authentication_page
+      enter_secondary_authentication_code(invitee.reload.direct_otp)
+
+      expect_to_be_on_declaration_page
+      check "I agree"
+      click_button "Continue"
+      click_link "Skip introduction"
+      click_link("Your account", match: :first)
+
+      expect(page).to have_h1("Your account")
+      expect(page).to have_summary_item(key: "Mobile number", value: "07012345678")
+    end
+  end
+
   it "sending an invitation and registering after changing the phone number" do
     sign_in(admin)
 
@@ -58,14 +103,14 @@ RSpec.feature "Registration process", :with_stubbed_mailer, :with_stubbed_notify
     end
   end
 
-  def invite_user_to_team
-    fill_in "Email address", with: invitee_email
+  def invite_user_to_team(email = invitee_email)
+    fill_in "Email address", with: email
     click_on "Send invitation email"
   end
 
-  def expect_user_invited_successfully
+  def expect_user_invited_successfully(email = invitee_email)
     expect(page).to have_title(team.display_name)
-    expect(page).to have_link(invitee_email)
+    expect(page).to have_link(email)
   end
 
   def fill_in_registration_form

--- a/spec/forms/invite_user_to_team_form_spec.rb
+++ b/spec/forms/invite_user_to_team_form_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe InviteUserToTeamForm do
       context "when the user is deleted" do
         let(:user_trait) { :deleted }
 
-        include_examples "invalid form", [:email, "Email address belongs to a user that has been deleted. Email OPSS if you would like their account restored."]
+        include_examples "valid form", [:email, "Email address belongs to a user that has been deleted. Email OPSS if you would like their account restored."]
       end
 
       context "when the user is on a different team" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -249,6 +249,11 @@ RSpec.describe User do
       user = create(:user, :deleted)
       expect { user.mark_as_deleted! }.not_to change(user, :deleted_at)
     end
+
+    it "sets invitation_token to nil" do
+      user = create(:user, :activated, invitation_token: "xyz")
+      expect { user.mark_as_deleted! }.to change { user.invitation_token }.from("xyz").to(nil)
+    end
   end
 
   describe "#deleted?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,45 +275,45 @@ RSpec.describe User do
     end
   end
 
-  describe "#reset_to_invited_state" do
+  describe "#reset_to_invited_state!" do
     it "sets deleted_at to nil" do
       user = create(:user, :deleted)
-      expect { user.reset_to_invited_state }.to change { user.deleted_at }.from(user.deleted_at).to(nil)
+      expect { user.reset_to_invited_state! }.to change { user.deleted_at }.from(user.deleted_at).to(nil)
     end
 
     it "sets account_activated to false" do
       user = create(:user, :activated)
-      expect { user.reset_to_invited_state }.to change { user.account_activated }.from(true).to(false)
+      expect { user.reset_to_invited_state! }.to change { user.account_activated }.from(true).to(false)
     end
 
     it "sets mobile_number_verified to false" do
       user = create(:user, :activated)
-      expect { user.reset_to_invited_state }.to change { user.mobile_number_verified }.from(true).to(false)
+      expect { user.reset_to_invited_state! }.to change { user.mobile_number_verified }.from(true).to(false)
     end
 
     it "sets has_accepted_declaration to false" do
       user = create(:user, :activated)
-      expect { user.reset_to_invited_state }.to change { user.has_accepted_declaration }.from(true).to(false)
+      expect { user.reset_to_invited_state! }.to change { user.has_accepted_declaration }.from(true).to(false)
     end
 
     it "sets has_been_sent_welcome_email to false" do
       user = create(:user, :activated)
-      expect { user.reset_to_invited_state }.to change { user.has_been_sent_welcome_email }.from(true).to(false)
+      expect { user.reset_to_invited_state! }.to change { user.has_been_sent_welcome_email }.from(true).to(false)
     end
 
     it "sets has_viewed_introduction to false" do
       user = create(:user, :activated)
-      expect { user.reset_to_invited_state }.to change { user.has_viewed_introduction }.from(true).to(false)
+      expect { user.reset_to_invited_state! }.to change { user.has_viewed_introduction }.from(true).to(false)
     end
 
     it "sets name to blank" do
       user = create(:user, :activated, name: "A User")
-      expect { user.reset_to_invited_state }.to change { user.name }.from("A User").to("")
+      expect { user.reset_to_invited_state! }.to change { user.name }.from("A User").to("")
     end
 
     it "sets name to nil" do
       user = create(:user, :activated, mobile_number: "07777777777")
-      expect { user.reset_to_invited_state }.to change { user.mobile_number }.from("07777777777").to(nil)
+      expect { user.reset_to_invited_state! }.to change { user.mobile_number }.from("07777777777").to(nil)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -229,6 +229,22 @@ RSpec.describe User do
       end
     end
 
+    it "sets the user 'deleted_by' to id of the user that made the deletion if supplied" do
+      user = create(:user)
+      deletor = create(:user)
+      freeze_time do
+        expect { user.mark_as_deleted!(deletor) }.to change { user.deleted_by }.from(nil).to(deletor.id)
+      end
+    end
+
+    it "sets the user 'account_activated' to false" do
+      user = create(:user, :activated)
+
+      freeze_time do
+        expect { user.mark_as_deleted! }.to change { user.account_activated }.from(true).to(false)
+      end
+    end
+
     it "does not change the flag if was already enabled" do
       user = create(:user, :deleted)
       expect { user.mark_as_deleted! }.not_to change(user, :deleted_at)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,6 +275,48 @@ RSpec.describe User do
     end
   end
 
+  describe "#reset_to_invited_state" do
+    it "sets deleted_at to nil" do
+      user = create(:user, :deleted)
+      expect { user.reset_to_invited_state }.to change { user.deleted_at }.from(user.deleted_at).to(nil)
+    end
+
+    it "sets account_activated to false" do
+      user = create(:user, :activated)
+      expect { user.reset_to_invited_state }.to change { user.account_activated }.from(true).to(false)
+    end
+
+    it "sets mobile_number_verified to false" do
+      user = create(:user, :activated)
+      expect { user.reset_to_invited_state }.to change { user.mobile_number_verified }.from(true).to(false)
+    end
+
+    it "sets has_accepted_declaration to false" do
+      user = create(:user, :activated)
+      expect { user.reset_to_invited_state }.to change { user.has_accepted_declaration }.from(true).to(false)
+    end
+
+    it "sets has_been_sent_welcome_email to false" do
+      user = create(:user, :activated)
+      expect { user.reset_to_invited_state }.to change { user.has_been_sent_welcome_email }.from(true).to(false)
+    end
+
+    it "sets has_viewed_introduction to false" do
+      user = create(:user, :activated)
+      expect { user.reset_to_invited_state }.to change { user.has_viewed_introduction }.from(true).to(false)
+    end
+
+    it "sets name to blank" do
+      user = create(:user, :activated, name: "A User")
+      expect { user.reset_to_invited_state }.to change { user.name }.from("A User").to("")
+    end
+
+    it "sets name to nil" do
+      user = create(:user, :activated, mobile_number: "07777777777")
+      expect { user.reset_to_invited_state }.to change { user.mobile_number }.from("07777777777").to(nil)
+    end
+  end
+
   describe "#has_role?" do
     subject(:user) { create(:user, team: team, organisation: team.organisation, roles: user_roles) }
 

--- a/spec/services/invite_user_to_team_spec.rb
+++ b/spec/services/invite_user_to_team_spec.rb
@@ -108,13 +108,15 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_elasticsear
               existing_user.mark_as_deleted!
             end
 
-            it "resassigns the new team to the user and enqueues the SendUserInvitationJob with the existing user ID" do
+            # rubocop:disable RSpec/MultipleExpectations
+            it "reassigns user to new team and enqueues the SendUserInvitationJob with the existing user ID" do
               expect { result }.to have_enqueued_job(SendUserInvitationJob).at(:no_wait).on_queue("psd").with do |recipient_id, inviting_user_id|
                 expect(recipient_id).to eq existing_user.id
                 expect(inviting_user_id).to be_nil
               end
 
               expect(existing_user.reload.team).to eq team
+              # rubocop:enable RSpec/MultipleExpectations
             end
 
             it "resets user to the state that it was in when initially invited" do

--- a/spec/services/invite_user_to_team_spec.rb
+++ b/spec/services/invite_user_to_team_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_elasticsear
             end
           end
 
+          context "when the user is deleted" do
+            before do
+              existing_user.mark_as_deleted!
+            end
+
+            it "enqueues the SendUserInvitationJob with the existing user ID", :aggregate_failures do
+              expect { result }.to have_enqueued_job(SendUserInvitationJob).at(:no_wait).on_queue("psd").with do |recipient_id, inviting_user_id|
+                expect(recipient_id).to eq existing_user.id
+                expect(inviting_user_id).to be_nil
+              end
+            end
+
+            it "resets user to the state that it was in when initially invited" do
+              result
+              expect_user_to_have_been_reset_to_invited_state(existing_user)
+            end
+          end
+
           context "when the email supplied is in a different case to the existing user" do
             let(:email) { "TEst@example.com" }
 
@@ -85,8 +103,30 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_elasticsear
         context "when the existing user is on a different team" do
           let(:existing_user_team) { create(:team) }
 
-          it "raises a ActiveRecord::RecordInvalid exception" do
-            expect { result }.to raise_error(ActiveRecord::RecordInvalid)
+          context "when the user is deleted" do
+            before do
+              existing_user.mark_as_deleted!
+            end
+
+            it "resassigns the new team to the user and enqueues the SendUserInvitationJob with the existing user ID" do
+              expect { result }.to have_enqueued_job(SendUserInvitationJob).at(:no_wait).on_queue("psd").with do |recipient_id, inviting_user_id|
+                expect(recipient_id).to eq existing_user.id
+                expect(inviting_user_id).to be_nil
+              end
+
+              expect(existing_user.reload.team).to eq team
+            end
+
+            it "resets user to the state that it was in when initially invited" do
+              result
+              expect_user_to_have_been_reset_to_invited_state(existing_user)
+            end
+          end
+
+          context "when the user is not deleted" do
+            it "raises a ActiveRecord::RecordInvalid exception" do
+              expect { result }.to raise_error(ActiveRecord::RecordInvalid)
+            end
           end
         end
       end
@@ -175,6 +215,18 @@ RSpec.describe InviteUserToTeam, :with_stubbed_mailer, :with_stubbed_elasticsear
       it "returns a failure" do
         expect(result).to be_failure
       end
+    end
+
+    def expect_user_to_have_been_reset_to_invited_state(existing_user)
+      existing_user.reload
+      expect(existing_user.name).to eq ""
+      expect(existing_user.deleted_at).to eq nil
+      expect(existing_user.account_activated).to eq false
+      expect(existing_user.mobile_number_verified).to eq false
+      expect(existing_user.has_accepted_declaration).to eq false
+      expect(existing_user.has_been_sent_welcome_email).to eq false
+      expect(existing_user.has_viewed_introduction).to eq false
+      expect(existing_user.mobile_number).to eq nil
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/NdkIW2f3/1198-allow-re-adding-of-deleted-users

## Description
This change allows deleted users to be re-added by a team admin. 

Note: In order to ensure that the full user sign up flow is completed again upon re-adding I reset a lot of the user fields to the state they would be in for a fresh user upon re-adding.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
