### PR TITLE
Fix bug around activity attachments

### DIFF
--- a/app/services/attachment_categorizer.rb
+++ b/app/services/attachment_categorizer.rb
@@ -12,7 +12,10 @@ class AttachmentCategorizer
   end
 
   def related_investigation
+    return if non_activity_attachment.blank?
+
     klass = Object.const_get(non_activity_attachment.record_type)
+
     instance_of_klass = klass.find(non_activity_attachment.record_id)
 
     return instance_of_klass if instance_of_klass.is_a?(Investigation)

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -275,7 +275,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
           sign_in(user)
           get asset_url
         end
-        # rubocop:disable RSpec/RepeatedExampleGroupBody
 
         context "when the user's team owns the product investigation" do
           it "returns file" do
@@ -289,7 +288,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             expect(response.status).to eq(200)
           end
         end
-        # rubocop:enable RSpec/RepeatedExampleGroupBody
       end
 
       context "when the attachment is a corrective_action" do

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -276,13 +276,13 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
           get asset_url
         end
 
-        context "when the user's team owns the product investigation" do
+        context "when the user's team owns the investigation" do
           it "returns file" do
             expect(response.status).to eq(200)
           end
         end
 
-        context "when user's team does not own the product investigation" do
+        context "when user's team does not own the investigation" do
           it "returns file" do
             sign_in(other_user)
             expect(response.status).to eq(200)

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -285,6 +285,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         context "when user's team does not own the product investigation" do
           it "returns file" do
+            sign_in(other_user)
             expect(response.status).to eq(200)
           end
         end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -272,12 +272,12 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         before do
           document.update!(record_type: "Activity", record_id: activity.id)
-          sign_in(user)
-          get asset_url
         end
 
         context "when the user's team owns the investigation" do
           it "returns file" do
+            sign_in(user)
+            get asset_url
             expect(response.status).to eq(200)
           end
         end
@@ -285,6 +285,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
         context "when user's team does not own the investigation" do
           it "returns file" do
             sign_in(other_user)
+            get asset_url
             expect(response.status).to eq(200)
           end
         end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -265,6 +265,32 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
         end
       end
 
+      context "when the attachment is on an activity" do
+        let(:asset_url) { rails_storage_proxy_path(document) }
+        let(:product) { create(:product, investigations: [investigation]) }
+        let(:activity) { create(:audit_activity_test_result, investigation: investigation, product: product) }
+
+        before do
+          document.update!(record_type: "Activity", record_id: activity.id)
+          sign_in(user)
+          get asset_url
+        end
+        # rubocop:disable RSpec/RepeatedExampleGroupBody
+
+        context "when the user's team owns the product investigation" do
+          it "returns file" do
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "when user's team does not own the product investigation" do
+          it "returns file" do
+            expect(response.status).to eq(200)
+          end
+        end
+        # rubocop:enable RSpec/RepeatedExampleGroupBody
+      end
+
       context "when the attachment is a corrective_action" do
         let(:asset_url) { rails_storage_proxy_path(document) }
         let(:corrective_action) { create(:corrective_action, investigation_id: investigation.id) }


### PR DESCRIPTION
## Description
[This bug](https://sentry.io/organizations/beis/issues/2817245290/?project=1329381&referrer=slack) occured today and seems to be due to the `attachment_categorizer` service not properly handling activity attachments.

I added a test which reproduced this error and a guard clause which stops it from occuring.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
