### PR TITLE
Attachments authorised by team

### DIFF
--- a/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -45,19 +45,23 @@ private
     attachment_categorizer.related_investigation
   end
 
-  def non_activity_attachment
-    attachment_categorizer.non_activity_attachment
+  def attachment
+    attachment_categorizer.attachment
   end
 
   def is_an_image?
     attachment_categorizer.is_an_image?
   end
 
-  def is_an_investigation_image?
-    non_activity_attachment.record_type == "Investigation" && is_an_image?
+  def is_a_correspondence_or_correspondence_activity_document?
+    attachment.record_type == "Correspondence" || attachment_categorizer.is_a_correspondence_activity?
+  end
+
+  def is_a_non_image_investigation_document?
+    attachment.record_type == "Investigation" && !is_an_image? || attachment_categorizer.is_an_investigation_document? && !is_an_image?
   end
 
   def attachment_is_protected_type?
-    non_activity_attachment.record_type == "Correspondence" || non_activity_attachment.record_type == "Investigation" && !is_an_image?
+    is_a_correspondence_or_correspondence_activity_document? || is_a_non_image_investigation_document?
   end
 end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -272,16 +272,27 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         before do
           document.update!(record_type: "Activity", record_id: activity.id)
+<<<<<<< cede1af901558bafd16ef5fe00a431d532021c1f
         end
 
         context "when the user's team owns the investigation" do
           it "returns file" do
             sign_in(user)
             get asset_url
+=======
+          sign_in(user)
+          get asset_url
+        end
+        # rubocop:disable RSpec/RepeatedExampleGroupBody
+
+        context "when the user's team owns the product investigation" do
+          it "returns file" do
+>>>>>>> Fix bug around activity attachments
             expect(response.status).to eq(200)
           end
         end
 
+<<<<<<< cede1af901558bafd16ef5fe00a431d532021c1f
         context "when user's team does not own the investigation" do
           it "returns file" do
             sign_in(other_user)
@@ -289,6 +300,14 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             expect(response.status).to eq(200)
           end
         end
+=======
+        context "when user's team does not own the product investigation" do
+          it "returns file" do
+            expect(response.status).to eq(200)
+          end
+        end
+        # rubocop:enable RSpec/RepeatedExampleGroupBody
+>>>>>>> Fix bug around activity attachments
       end
 
       context "when the attachment is a corrective_action" do

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -273,27 +273,16 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         before do
           document.update!(record_type: "Activity", record_id: activity.id)
-<<<<<<< cede1af901558bafd16ef5fe00a431d532021c1f
-        end
-
-        context "when the user's team owns the investigation" do
-          it "returns file" do
-            sign_in(user)
-            get asset_url
-=======
           sign_in(user)
           get asset_url
         end
-        # rubocop:disable RSpec/RepeatedExampleGroupBody
 
-        context "when the user's team owns the product investigation" do
+        context "when the user's team owns the  investigation" do
           it "returns file" do
->>>>>>> Fix bug around activity attachments
             expect(response.status).to eq(200)
           end
         end
 
-<<<<<<< cede1af901558bafd16ef5fe00a431d532021c1f
         context "when user's team does not own the investigation" do
           it "returns file" do
             sign_in(other_user)
@@ -301,14 +290,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             expect(response.status).to eq(200)
           end
         end
-=======
-        context "when user's team does not own the product investigation" do
-          it "returns file" do
-            expect(response.status).to eq(200)
-          end
-        end
-        # rubocop:enable RSpec/RepeatedExampleGroupBody
->>>>>>> Fix bug around activity attachments
       end
 
       context "when the attachment is a corrective_action" do

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         context "when user's team does not own the product investigation" do
           it "returns file" do
+            sign_in(other_user)
             expect(response.status).to eq(200)
           end
         end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             document.update!(record_type: "Activity", record_id: activity.id)
           end
 
-          context "when the documents is an image" do
+          context "when the document is an image" do
             context "when the user's team owns the investigation" do
               it "returns file" do
                 sign_in(user)
@@ -341,7 +341,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             end
           end
 
-          context "when the documents is not an image" do
+          context "when the document is not an image" do
             before do
               document.blob.update!(content_type: "pdf")
             end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -273,12 +273,12 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
         before do
           document.update!(record_type: "Activity", record_id: activity.id)
-          sign_in(user)
-          get asset_url
         end
 
         context "when the user's team owns the investigation" do
           it "returns file" do
+            sign_in(user)
+            get asset_url
             expect(response.status).to eq(200)
           end
         end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
   end
   let(:other_user) { create(:user, :activated, has_viewed_introduction: true, team: other_team) }
 
+  # rubocop:disable RSpec/NestedGroups
   context "when using generic active storage urls" do
     context "when using blobs redirect controller" do
       # /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)                                 active_storage/blobs/redirect#show
@@ -93,7 +94,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             before do
               sign_in(other_user)
             end
-            # rubocop:disable RSpec/NestedGroups
 
             context "when the user does not have the can_view_restricted_cases role" do
               it "does not return the file" do
@@ -113,7 +113,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
                 expect(response.status).to eq(200)
               end
             end
-            # rubocop:enable RSpec/NestedGroups
           end
         end
 
@@ -140,7 +139,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
 
               expect(response.status).to eq(200)
             end
-            # rubocop:disable RSpec/NestedGroups
 
             context "when the investigation is restricted" do
               before do
@@ -153,7 +151,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
                 expect(response.status).to eq(302)
               end
             end
-            # rubocop:enable RSpec/NestedGroups
           end
         end
       end
@@ -270,7 +267,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
         let(:asset_url) { rails_storage_proxy_path(document) }
         let(:product) { create(:product, investigations: [investigation]) }
 
-
         context "when the activity is not a correspondence or investigation document related" do
           let(:activity) { create(:audit_activity_test_result, investigation: investigation, product: product) }
 
@@ -353,7 +349,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             end
 
             context "when the user's team owns the investigation" do
-
               it "returns file" do
                 sign_in(user)
                 get asset_url
@@ -428,5 +423,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
   # rubocop:enable RSpec/MultipleExpectations
 end

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -164,7 +164,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
           sign_in(user)
           get asset_url
         end
-        # rubocop:disable RSpec/RepeatedExampleGroupBody
 
         context "when the user's team owns the product investigation" do
           it "returns file" do
@@ -178,7 +177,6 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
             expect(response.status).to eq(200)
           end
         end
-        # rubocop:enable RSpec/RepeatedExampleGroupBody
       end
 
       context "when the attachment is an correspondence" do

--- a/spec/requests/assets_security_spec.rb
+++ b/spec/requests/assets_security_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "Asset security", type: :request, with_stubbed_elasticsearch: tru
           get asset_url
         end
 
-        context "when the user's team owns the  investigation" do
+        context "when the user's team owns the investigation" do
           it "returns file" do
             expect(response.status).to eq(200)
           end


### PR DESCRIPTION
https://trello.com/c/A8X5Zs05/1225-correctly-authorize-attachments-on-activity

## Description
Prior to this PR, attachments on activities did not share the same level of authorization as the same attachments on other models. This PR corrects this issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
