### PR TITLE
Disable smoke test on prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,19 +173,19 @@ jobs:
         source deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL
 
-    - name: Run Smoke Tests
-      if: success()
-      env:
-        SMOKE_USER: ${{secrets.SMOKE_USER}}
-        SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
-        SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
-        SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
-        SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
-        IS_REVIEW_APP: "false"
-        SMOKE_TEST_URL: "https://www.product-safety-database.service.gov.uk/"
-
-      run: |
-        bundle exec rspec ./smoke_test/cases_page_spec.rb
+    # - name: Run Smoke Tests
+    #   if: success()
+    #   env:
+    #     SMOKE_USER: ${{secrets.SMOKE_USER}}
+    #     SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
+    #     SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
+    #     SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
+    #     SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
+    #     IS_REVIEW_APP: "false"
+    #     SMOKE_TEST_URL: "https://www.product-safety-database.service.gov.uk/"
+    #
+    #   run: |
+    #     bundle exec rspec ./smoke_test/cases_page_spec.rb
 
     - name: Alert team via Slack of deployment failure
       if: failure()


### PR DESCRIPTION
## Description
This change disables smoke tests on production. Previously we disabled the smoke test on staging but not on prod. This issue seems to be due to some kind of change on the log in/2fa page and is causing the smoke test to not be useful at the current time until this is addressed

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
