### PR TITLE
Fix smoke test bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,21 +100,21 @@ jobs:
         bundle config path vendor/bundle
         bundle check || bundle install --without development --jobs=4 --retry=3
 
-    # Temporarily disabled due to unreliability of login flow steps
-    #
-    # - name: Run Smoke Tests
-    #   if: success()
-    #   env:
-    #     SMOKE_USER: ${{secrets.SMOKE_USER}}
-    #     SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
-    #     SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
-    #     SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
-    #     SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
-    #     IS_REVIEW_APP: "false"
-    #     SMOKE_TEST_URL: "https://staging.product-safety-database.service.gov.uk"
+    Temporarily disabled due to unreliability of login flow steps
 
-    #   run: |
-    #     bundle exec rspec ./smoke_test/cases_page_spec.rb
+    - name: Run Smoke Tests
+      if: success()
+      env:
+        SMOKE_USER: ${{secrets.SMOKE_USER}}
+        SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
+        SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
+        SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
+        SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
+        IS_REVIEW_APP: "false"
+        SMOKE_TEST_URL: "https://staging.product-safety-database.service.gov.uk"
+
+      run: |
+        bundle exec rspec ./smoke_test/cases_page_spec.rb
 
     - name: Create GitHub deployment for Production
       if: success()
@@ -173,19 +173,19 @@ jobs:
         source deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL
 
-    # - name: Run Smoke Tests
-    #   if: success()
-    #   env:
-    #     SMOKE_USER: ${{secrets.SMOKE_USER}}
-    #     SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
-    #     SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
-    #     SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
-    #     SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
-    #     IS_REVIEW_APP: "false"
-    #     SMOKE_TEST_URL: "https://www.product-safety-database.service.gov.uk/"
-    #
-    #   run: |
-    #     bundle exec rspec ./smoke_test/cases_page_spec.rb
+    - name: Run Smoke Tests
+      if: success()
+      env:
+        SMOKE_USER: ${{secrets.SMOKE_USER}}
+        SMOKE_PASSWORD: ${{secrets.SMOKE_PASSWORD}}
+        SMOKE_RELAY_CODE_URL: ${{secrets.SMOKE_RELAY_CODE_URL}}
+        SMOKE_RELAY_CODE_USER: ${{secrets.SMOKE_RELAY_CODE_USER}}
+        SMOKE_RELAY_CODE_PASS: ${{secrets.SMOKE_RELAY_CODE_PASS}}
+        IS_REVIEW_APP: "false"
+        SMOKE_TEST_URL: "https://www.product-safety-database.service.gov.uk/"
+
+      run: |
+        bundle exec rspec ./smoke_test/cases_page_spec.rb
 
     - name: Alert team via Slack of deployment failure
       if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,8 +100,6 @@ jobs:
         bundle config path vendor/bundle
         bundle check || bundle install --without development --jobs=4 --retry=3
 
-    Temporarily disabled due to unreliability of login flow steps
-
     - name: Run Smoke Tests
       if: success()
       env:

--- a/smoke_test/cases_page_spec.rb
+++ b/smoke_test/cases_page_spec.rb
@@ -40,12 +40,10 @@ RSpec.feature "Search smoke test" do
     attempts = 0
     loop do
       code = get_code
-      break unless code
+      break unless code && @session.has_current_path?(/\/two-factor/) && attempts < 4
 
       smoke_complete_secondary_authentication_with(code, @session)
       attempts += 1
-      break if @session.has_content?("Open a new case")
-      break if attempts > 3
 
       sleep attempts * 10
     end


### PR DESCRIPTION
https://trello.com/c/7J2xuOkC/1249-spike-investigate-smoke-test-failures

## Description
Smoke tests were failing due to not being able to find "Enter security code". This seemed to be because in our code we were breaking a loop based on the contents of a page which may not have loaded yet, so I have changed it to break the loop based on the path and changed the location of the break clause which fixes the issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
