### PR TITLE
Further logging metrics

### DIFF
--- a/app/forms/secondary_authentication_form.rb
+++ b/app/forms/secondary_authentication_form.rb
@@ -34,6 +34,7 @@ class SecondaryAuthenticationForm
     return if errors.present?
 
     unless secondary_authentication.valid_otp? otp_code
+      Rails.logger.info "Failed 2FA attempt for user: #{user_id}"
       errors.add(:otp_code, I18n.t(".otp_code.incorrect"))
     end
   end

--- a/app/jobs/log_db_metrics_job.rb
+++ b/app/jobs/log_db_metrics_job.rb
@@ -4,7 +4,9 @@ class LogDbMetricsJob < ApplicationJob
       total_number_of_cases: Investigation.count,
       total_number_of_users: User.count,
       total_number_of_products: Product.count,
-      total_number_of_businesses: Business.count
+      total_number_of_businesses: Business.count,
+      total_number_of_locked_users: User.where.not(locked_at: nil).count,
+      total_number_of_failed_sign_ins: User.sum(:failed_attempts)
     }
 
     Sidekiq.logger.info "PsdStatistics #{stats.to_a.map { |x| x.join('=') }.join(' ')}"

--- a/app/jobs/send_user_invitation_job.rb
+++ b/app/jobs/send_user_invitation_job.rb
@@ -17,6 +17,9 @@ class SendUserInvitationJob < ApplicationJob
     user_inviting = user_inviting_id ? User.find(user_inviting_id) : nil
 
     NotifyMailer.invitation_email(user, user_inviting).deliver_now
+
+    Sidekiq.logger.info "Forgotten password email sent to user: #{user.id}" if user_inviting.nil?
+
     user.update!(has_been_sent_welcome_email: true)
   end
 end


### PR DESCRIPTION
https://trello.com/c/49rWAeuX/1161-kibana-dashboard-for-psd

## Description
This PR adds the additional logging and metrics as described in the ticket.
It adds:
- `total_number_of_locked_users` to the log metrics db job
- `total_number_of_failed_sign_ins` to the log metrics db job
- Logging for a user requested password reset email and for a failed 2FA attempt, as well as recording the ID of the user in question.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
