### PR TITLE
Change the name sorting options on Products to match Businesses

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -91,12 +91,14 @@ private
 
     @sort_by_items = sort_by_items
     @selected_sort_by = params[:sort_by].presence || SortByHelper::SORT_BY_NEWEST
+    @selected_sort_direction = params[:sort_dir]
   end
 
   def sort_by_items
     items = [
       SortByHelper::SortByItem.new("Newly added", SortByHelper::SORT_BY_NEWEST, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Name", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DEFAULT)
+      SortByHelper::SortByItem.new("Name A–Z", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_ASC),
+      SortByHelper::SortByItem.new("Name Z–A", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DESC)
     ]
     items.unshift(SortByHelper::SortByItem.new("Relevance", SortByHelper::SORT_BY_RELEVANT, SortByHelper::SORT_DIRECTION_DEFAULT)) if params[:q].present?
     items

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -21,9 +21,14 @@ module ProductsHelper
 
   def sorting_params
     return {} if params[:sort_by] == SortByHelper::SORT_BY_RELEVANT
+    return { name_for_sorting: :desc } if params[:sort_by] == SortByHelper::SORT_BY_NAME && params[:sort_dir] == SortByHelper::SORT_DIRECTION_DESC
     return { name_for_sorting: :asc } if params[:sort_by] == SortByHelper::SORT_BY_NAME
 
     { created_at: :desc }
+  end
+
+  def sort_direction
+    SortByHelper::SORT_DIRECTIONS.include?(params[:sort_dir]) ? params[:sort_dir] : :desc
   end
 
   def search_for_product_code(product_code, excluded_ids)

--- a/app/views/products/_controls.html.erb
+++ b/app/views/products/_controls.html.erb
@@ -2,5 +2,5 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "search_statement", count: count, keywords: keywords, filter: filter %>
   </div>
-  <%= render_sort_by form, sort_by_items, selected_sort_by %>
+  <%= render_sort_by form, sort_by_items, selected_sort_by, selected_sort_direction %>
 </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -26,6 +26,7 @@
         <%= form.label :q, "Keywords search", class: "govuk-label" %>
         <div class="govuk-input__wrapper opss-search__wrapper">
           <%= form.hidden_field :sort_by, value: params[:sort_by] %>
+          <%= form.hidden_field :sort_dir, value: params[:sort_dir] %>
           <%= form.search_field :q, class: "govuk-input govuk-!-width-one-half", data: { "opss-clear-on-reset" => "element" }, spellcheck: false, "aria-describedby" => "search-hint" %>
           <button class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
             <span class="govuk-visually-hidden">Search</span>
@@ -71,7 +72,8 @@
         filter: params[:hazard_type],
         form: form,
         sort_by_items: @sort_by_items,
-        selected_sort_by: @selected_sort_by
+        selected_sort_by: @selected_sort_by,
+        selected_sort_direction: @selected_sort_direction
       %>
       <% unless @products.empty? %>
         <div class="govuk-grid-row">

--- a/spec/features/sort_products_spec.rb
+++ b/spec/features/sort_products_spec.rb
@@ -29,12 +29,13 @@ RSpec.feature "Product sorting", :with_elasticsearch, :with_stubbed_mailer, type
     expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(4) > th:nth-child(1)", text: fire_product_1.name)
   end
 
-  scenario "selecting Name sorts by name" do
+  scenario "selecting Name A–Z sorts ascending by name" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name"
+      click_on "Name A–Z"
     end
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
-    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name")
+    expect(page).to have_current_path(/sort_dir=asc/, ignore_query: false)
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name A–Z")
 
     expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(1) > th:nth-child(1)", text: drowning_product.name)
     expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(2) > th:nth-child(1)", text: fire_product_1.name)
@@ -42,16 +43,30 @@ RSpec.feature "Product sorting", :with_elasticsearch, :with_stubbed_mailer, type
     expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(4) > th:nth-child(1)", text: fire_product_2.name)
   end
 
+  scenario "selecting Name Z–A sorts descending by name" do
+    within "form dl.govuk-list.opss-dl-select" do
+      click_on "Name Z–A"
+    end
+    expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
+    expect(page).to have_current_path(/sort_dir=desc/, ignore_query: false)
+    expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Name Z–A")
+
+    expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(1) > th:nth-child(1)", text: fire_product_2.name)
+    expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(2) > th:nth-child(1)", text: chemical_product.name)
+    expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(3) > th:nth-child(1)", text: fire_product_1.name)
+    expect(page).to have_css("table#results tbody.govuk-table__body > tr:nth-child(4) > th:nth-child(1)", text: drowning_product.name)
+  end
+
   scenario "selected sort order is persisted when filtering by hazard type" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name"
+      click_on "Name A–Z"
     end
 
     select "Fire", from: "Hazard type"
     click_button "Apply"
 
     expect(page).to have_current_path(/sort_by=name/, ignore_query: false)
-    expect(page).to have_css("form dl.govuk-list.opss-dl-select dd", text: "Active: Name")
+    expect(page).to have_css("form dl.govuk-list.opss-dl-select dd", text: "Active: Name A–Z")
   end
 
   scenario "filtering by keyword sorts by Relevance by default" do
@@ -69,7 +84,7 @@ RSpec.feature "Product sorting", :with_elasticsearch, :with_stubbed_mailer, type
 
   scenario "filtering by keyword persists a selected sort order" do
     within "form dl.govuk-list.opss-dl-select" do
-      click_on "Name"
+      click_on "Name A–Z"
     end
 
     fill_in "Keywords search", with: "Dangerous"


### PR DESCRIPTION
https://trello.com/c/ze5RRvfT/1265-additional-sorting-on-products-page

## Description
- Make the Products sort-by-name options consistent with the Businesses page
  - Rename the "Name" sort option to "Name A–Z"
  - Introduce a "Name Z-A" sort option

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [x] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
