### PR TITLE
Bump CloudFoundry Ruby buildpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -675,4 +675,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.33
+   2.3.4

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /psd
 
-RUN gem install bundler:2.2.33
+RUN gem install bundler:2.3.4
 COPY Gemfile /psd/
 COPY Gemfile.lock /psd/
 

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -3,7 +3,7 @@ applications:
 - name: ((app-name))
   buildpacks:
     - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.10
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.49
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.50
   path: .
   stack: cflinuxfs3
   routes:

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: ((app-name))
   buildpacks:
     - https://github.com/cloudfoundry/apt-buildpack.git#v0.2.10
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.49
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.50
   path: .
   stack: cflinuxfs3
   routes:


### PR DESCRIPTION
- Add rubygems 3.3.4, remove rubygems 3.2.33
- Add bundler 2.3.4, remove bundler 2.2.33

See [release notes](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.50)