### PR TITLE
Update sort_businesses_spec.rb

### DIFF
--- a/spec/features/sort_businesses_spec.rb
+++ b/spec/features/sort_businesses_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Business sorting", :with_elasticsearch, :with_stubbed_mailer, typ
 
   before do
     Investigation.import refresh: :wait_for
-    Product.import refresh: :wait_for
+    Business.import refresh: :wait_for
     sign_in(user)
     visit businesses_path
   end


### PR DESCRIPTION
Fix a typo which was making the business sort spec flaky by not correctly indexing the businesses the test was creating.