### PR TITLE
Move failed log in logging to trigger when authentication fails rathe…

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -40,7 +40,7 @@ module Users
           return render :new
         end
 
-        Rails.logger.info "Forgotten password email sent to user: #{user.id}"
+        Rails.logger.info "Forgotten password email sent to user: #{user.try(:id)}"
       end
     end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -39,6 +39,8 @@ module Users
           resource.errors.merge!(reset_password_form.errors)
           return render :new
         end
+
+        Rails.logger.info "Forgotten password email sent to user: #{user.id}"
       end
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -47,7 +47,7 @@ module Users
     end
 
     def handle_authentication_failure(user)
-      Rails.logger.info "Failed sign in attempt for email address: #{user.try(:email)}"
+      Rails.logger.info "Failed sign in attempt for user: #{user.try(:id)}"
 
       if user&.reload&.access_locked?
         return render "account_locked" if user.locked_reason == User.locked_reasons[:failed_attempts]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,7 +15,7 @@ module Users
       set_resource_as_new_user_from_params
 
       if sign_in_form.invalid?
-        handle_invalid_form(resource, sign_in_form.email)
+        handle_invalid_form(resource)
         return render :new
       end
 
@@ -47,7 +47,7 @@ module Users
     end
 
     def handle_authentication_failure(user)
-      Rails.logger.info "Failed sign in attempt for email address: #{email}"
+      Rails.logger.info "Failed sign in attempt for email address: #{user.try(:email)}"
 
       if user&.reload&.access_locked?
         return render "account_locked" if user.locked_reason == User.locked_reasons[:failed_attempts]
@@ -61,7 +61,7 @@ module Users
       render :new
     end
 
-    def handle_invalid_form(resource, email)
+    def handle_invalid_form(resource)
       resource.errors.merge!(sign_in_form.errors)
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -47,6 +47,8 @@ module Users
     end
 
     def handle_authentication_failure(user)
+      Rails.logger.info "Failed sign in attempt for email address: #{email}"
+
       if user&.reload&.access_locked?
         return render "account_locked" if user.locked_reason == User.locked_reasons[:failed_attempts]
 
@@ -60,7 +62,6 @@ module Users
     end
 
     def handle_invalid_form(resource, email)
-      Rails.logger.info "Failed sign in attempt for email address: #{email}"
       resource.errors.merge!(sign_in_form.errors)
     end
 

--- a/app/jobs/send_user_invitation_job.rb
+++ b/app/jobs/send_user_invitation_job.rb
@@ -19,9 +19,9 @@ class SendUserInvitationJob < ApplicationJob
     NotifyMailer.invitation_email(user, user_inviting).deliver_now
 
     if user_inviting.nil?
-      Sidekiq.logger.info "Forgotten password email sent to user: #{user.id}"
+      Rails.logger.info "Forgotten password email sent to user: #{user.id}"
     else
-      Sidekiq.logger.info "Invitation sent to user: #{user.id} by #{user_inviting_id}"
+      Rails.logger.info "Invitation sent to user: #{user.id} by #{user_inviting_id}"
     end
 
     user.update!(has_been_sent_welcome_email: true)

--- a/app/jobs/send_user_invitation_job.rb
+++ b/app/jobs/send_user_invitation_job.rb
@@ -18,12 +18,6 @@ class SendUserInvitationJob < ApplicationJob
 
     NotifyMailer.invitation_email(user, user_inviting).deliver_now
 
-    if user_inviting.nil?
-      Sidekiq.logger.info "Forgotten password email sent to user: #{user.id}"
-    else
-      Sidekiq.logger.info "Invitation sent to user: #{user.id} by #{user_inviting_id}"
-    end
-
     user.update!(has_been_sent_welcome_email: true)
   end
 end

--- a/app/jobs/send_user_invitation_job.rb
+++ b/app/jobs/send_user_invitation_job.rb
@@ -19,9 +19,9 @@ class SendUserInvitationJob < ApplicationJob
     NotifyMailer.invitation_email(user, user_inviting).deliver_now
 
     if user_inviting.nil?
-      Rails.logger.info "Forgotten password email sent to user: #{user.id}"
+      Sidekiq.logger.info "Forgotten password email sent to user: #{user.id}"
     else
-      Rails.logger.info "Invitation sent to user: #{user.id} by #{user_inviting_id}"
+      Sidekiq.logger.info "Invitation sent to user: #{user.id} by #{user_inviting_id}"
     end
 
     user.update!(has_been_sent_welcome_email: true)

--- a/app/services/invite_user_to_team.rb
+++ b/app/services/invite_user_to_team.rb
@@ -47,6 +47,8 @@ private
       user.update! invitation_token: (user.invitation_token || SecureRandom.hex(15)), invited_at: Time.zone.now
     end
 
+    Rails.logger.info "Invitation sent to user: #{user.id} by #{inviting_user&.id}"
+
     SendUserInvitationJob.perform_later(user.id, inviting_user&.id)
   end
 


### PR DESCRIPTION
…r than when form has errors

## Description

Prior to this change, the logging for failed sign in error was triggered when the sign in form had errors, however after seeing the logging go live it became clear that this logging should be triggered when authentication fails. This PR corrects this misplaced logging.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
