### PR TITLE
Update policy for adding Corrective Actions to a Case

### DIFF
--- a/app/controllers/investigations/corrective_actions_controller.rb
+++ b/app/controllers/investigations/corrective_actions_controller.rb
@@ -4,14 +4,14 @@ module Investigations
 
     def new
       investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
-      authorize investigation, :view_non_protected_details?
+      authorize investigation, :update?
       @corrective_action_form = CorrectiveActionForm.new
       @investigation = investigation.decorate
     end
 
     def create
       investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
-      authorize investigation, :view_non_protected_details?
+      authorize investigation, :update?
 
       @corrective_action_form = CorrectiveActionForm.new(corrective_action_params)
 

--- a/spec/features/add_corrective_action_spec.rb
+++ b/spec/features/add_corrective_action_spec.rb
@@ -11,6 +11,11 @@ RSpec.feature "Adding a correcting action to a case", :with_stubbed_opensearch, 
 
       expect(page).not_to have_link("Add supporting information")
     end
+
+    scenario "cannot view the new corrective action form" do
+      sign_in(read_only_user)
+      expect { visit "/cases/#{investigation.pretty_id}/corrective-actions/new" }.to raise_error(Pundit::NotAuthorizedError)
+    end
   end
 
   context "with no product added to the case" do

--- a/spec/requests/investigations/add_corrective_action_spec.rb
+++ b/spec/requests/investigations/add_corrective_action_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Adding a corrective action to a case", type: :request, with_stubbed_mailer: true, with_stubbed_opensearch: true do
+  let(:user_from_owner_team) { create(:user, :activated) }
+  let(:user_from_team_with_read_only_access) { create(:user, :activated) }
+  let(:user_from_team_with_edit_access) { create(:user, :activated) }
+  let(:other_user) { create(:user, :activated) }
+
+  let(:investigation) do
+    create(
+      :allegation,
+      is_closed: false,
+      creator: user_from_owner_team,
+      edit_access_collaborations: [
+        create(
+          :collaboration_edit_access,
+          collaborator: user_from_team_with_edit_access.team
+        )
+      ],
+      read_only_collaborations: [
+        create(
+          :read_only_collaboration,
+          collaborator: user_from_team_with_read_only_access.team
+        )
+      ]
+    )
+  end
+
+  context "when the user is from a team with read-only access", :with_errors_rendered do
+    before do
+      sign_in user_from_team_with_read_only_access
+      post investigation_corrective_actions_path(investigation.pretty_id)
+    end
+
+    it "returns a forbidden status code" do
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context "when the user is from a team not associated with the case", :with_errors_rendered do
+    before do
+      sign_in other_user
+      post investigation_corrective_actions_path(investigation.pretty_id)
+    end
+
+    it "returns a forbidden status code" do
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/fjiRMthJ/1271-nonteam-member-collaborator-on-a-case-can-add-corrective-action-via-url

## Description
Updates the policy for adding Corrective Actions to a Case, to require the user to have explicit edit access (be from a collaborating team with edit access).

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
