### PR TITLE
Add indexes to search by Product ID or PSD ref

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -36,13 +36,14 @@ class Product < ApplicationRecord
   settings do
     mappings do
       indexes :name_for_sorting, type: :keyword
+      indexes :psd_ref, type: :keyword
     end
   end
 
   def as_indexed_json(*)
     as_json(
       include: { investigations: { only: :hazard_type } },
-      methods: %i[tiebreaker_id name_for_sorting]
+      methods: %i[tiebreaker_id name_for_sorting psd_ref]
     )
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -36,7 +36,6 @@ class Product < ApplicationRecord
   settings do
     mappings do
       indexes :name_for_sorting, type: :keyword
-      indexes :psd_ref, type: :keyword
     end
   end
 

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -67,15 +67,12 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
     click_button "Apply"
 
     expect(page).to have_content(chemical_product.name)
-    expect(page).to have_content("1 product matching keyword(s) #{chemical_product.id}, was found.")
   end
 
   scenario "filtering by a PSD ref" do
-    psd_ref = chemical_product.psd_ref
-    fill_in "Keywords search", with: psd_ref
+    fill_in "Keywords search", with: chemical_product.psd_ref
     click_button "Apply"
 
     expect(page).to have_content(chemical_product.name)
-    expect(page).to have_content("1 product matching keyword(s) #{psd_ref}, was found.")
   end
 end

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
   end
 
   scenario "filtering by a PSD ref" do
-    psd_ref = "psd-#{chemical_product.id}"
+    psd_ref = chemical_product.psd_ref
     fill_in "Keywords search", with: psd_ref
     click_button "Apply"
 

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -61,4 +61,21 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
     expect(page).not_to have_content(chemical_product.name)
     expect(page).to have_content("1 product matching keyword(s) Dangerous, was found.")
   end
+
+  scenario "filtering by an ID" do
+    fill_in "Keywords search", with: chemical_product.id
+    click_button "Apply"
+
+    expect(page).to have_content(chemical_product.name)
+    expect(page).to have_content("1 product matching keyword(s) #{chemical_product.id}, was found.")
+  end
+
+  scenario "filtering by a PSD ref" do
+    psd_ref = "psd-#{chemical_product.id}"
+    fill_in "Keywords search", with: psd_ref
+    click_button "Apply"
+
+    expect(page).to have_content(chemical_product.name)
+    expect(page).to have_content("1 product matching keyword(s) #{psd_ref}, was found.")
+  end
 end


### PR DESCRIPTION
https://trello.com/c/4YDZrTGw/1275-update-search-functionality-to-be-able-to-search-by-unique-product-id

## Description
Adds OpenSearch indexes to allow searching products by their ID or PSD Reference.

**IMPORTANT:** Indexes must be manually deployed:

```rb
Product.__elasticsearch__.import force: true, refresh: :wait
```

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
