### PR TITLE
Fix right aligned anchors displaying as block elements

### DIFF
--- a/app/views/investigations/_heading.html.erb
+++ b/app/views/investigations/_heading.html.erb
@@ -17,10 +17,12 @@
   </div>
 
   <div class="govuk-grid-column-one-third govuk-!-margin-top-8">
-    <%= link_to "Create a case",
-      current_user.is_opss? ? new_investigation_path : new_ts_investigation_path,
-      class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset",
-      role: "button"
-    %>
+    <div class="opss-text-align-right">
+      <%= link_to "Create a case",
+        current_user.is_opss? ? new_investigation_path : new_ts_investigation_path,
+        class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset",
+        role: "button"
+      %>
+    </div>
   </div>
 </div>

--- a/app/views/investigations/tabs/images/_product_images.html.erb
+++ b/app/views/investigations/tabs/images/_product_images.html.erb
@@ -4,9 +4,11 @@
       <h2 class="govuk-heading-s"><%= product.name %></h2>
     </div>
     <div class="govuk-grid-column-one-third">
-      <a href=<%=product_path(product)%> class="govuk-link govuk-link--no-visited-state opss-text-align-right">
-        Go to the <span class="govuk-visually-hidden"><%= product.name %></span> product page
-      </a>
+      <div class="opss-text-align-right">
+        <a href=<%=product_path(product)%> class="govuk-link govuk-link--no-visited-state">
+          Go to the <span class="govuk-visually-hidden"><%= product.name %></span> product page
+        </a>
+      </div>
     </div>
   </div>
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -11,7 +11,9 @@
         </h1>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-        <%= link_to "Invite another team member", new_team_invitation_path(@team), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset" if current_user.is_team_admin? %>
+        <div class="opss-text-align-right">
+          <%= link_to "Invite another team member", new_team_invitation_path(@team), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" if current_user.is_team_admin? %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://trello.com/c/E4J3vvuV/1251-implement-solution-for-right-aligned-links-active-state

This bug has been raised a number of times internally, and now is being noticed by users.

I wasn't able to identify any such link on the businesses or products page, but I found it on the Your Team page and the case product images tab, which I've fixed as well.