### PR TITLE
Display matching team name on case result highlights

### DIFF
--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -61,7 +61,7 @@ module Investigations::DisplayTextHelper
 
     highlight[1].each do |result|
       unless should_be_hidden?(source, investigation)
-        best_highlight[:content] = get_highlight_content(result)
+        best_highlight[:content] = get_highlight_content(source, result)
         return best_highlight
       end
     end
@@ -76,14 +76,23 @@ module Investigations::DisplayTextHelper
   def replace_unsightly_field_names(field_name)
     pretty_field_names = {
       pretty_id: "Case ID",
-      "activities.search_index": "Activities, comment"
+      "activities.search_index": "Activities, comment",
+      "teams_with_access.id": "Team added to the case"
     }
     pretty_field_names[field_name.to_sym] || field_name.humanize
   end
 
-  def get_highlight_content(result)
+  def get_highlight_content(source, result)
+    return get_highlighted_team_name(result) if source == "teams_with_access.id"
+
     sanitized_content = sanitize(result, tags: %w[em])
     sanitized_content.html_safe
+  end
+
+  def get_highlighted_team_name(highlighted_result)
+    team_id = sanitize(highlighted_result, tags: [])
+    team = Team.find(team_id)
+    content_tag(:em, team.name).html_safe
   end
 
   def should_be_hidden?(source, investigation)

--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -92,7 +92,7 @@ module Investigations::DisplayTextHelper
   def get_highlighted_team_name(highlighted_result)
     team_id = sanitize(highlighted_result, tags: [])
     team = Team.find(team_id)
-    content_tag(:em, team.name).html_safe
+    content_tag(:em, team.decorate.display_name).html_safe
   end
 
   def should_be_hidden?(source, investigation)

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -255,6 +255,22 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
           expect(find("details#filter-details")["open"]).to eq(nil)
         end
+
+        scenario "with keywords entered" do
+          fill_in "Keywords", with: other_user_other_team_investigation.description
+          click_on "Search"
+
+          find("#filter-details").click
+
+          within_fieldset("Teams added to cases") do
+            choose "Others"
+            select other_team.name, from: "Team name"
+          end
+          click_button "Apply"
+
+          expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
+          expect(page).to have_text("Team added to the case: #{chosen_team.name}")
+        end
       end
 
       context "when filtering case where any other team has access" do


### PR DESCRIPTION
https://trello.com/c/V9VoZQbC/1167-case-search-result-page-returning-team-ids-instead-of-names

## Description
Displays the matching team name in case search result highlights rather than their ID.

Note Opensearch is currently configured to wrap highlights in its result set in `<em>` tags. This can be changed, but would involve a much larger refactoring, so I elected to strip them out in order to resolve the team name. An exception will be thrown if the team cannot be resolved from the ID. This should be safe since we do not delete teams for various reasons which would break things elsewhere.

I nalso changed the label 'teams with access' to 'team added to the case' to be consistent with the label in the filter list.