### PR TITLE
Fix incorrect count on products and businesses pages

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -15,8 +15,8 @@ class BusinessesController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        results = search_for_businesses(20)
-        @businesses = BusinessDecorator.decorate_collection(results)
+        @results = search_for_businesses(20)
+        @businesses = BusinessDecorator.decorate_collection(@results)
       end
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,8 +14,8 @@ class ProductsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        results = search_for_products(20)
-        @products = ProductDecorator.decorate_collection(results)
+        @results = search_for_products(20)
+        @products = ProductDecorator.decorate_collection(@results)
       end
       format.csv do
         authorize Product, :export?

--- a/app/views/businesses/index.html.erb
+++ b/app/views/businesses/index.html.erb
@@ -47,7 +47,7 @@
 
     <section class="govuk-grid-column-three-quarters">
       <%= render "controls",
-        count: @businesses.size,
+        count: @results.total_count,
         keywords: params[:q],
         filter: params[:hazard_type],
         form: form,

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -67,7 +67,7 @@
 
     <section class="govuk-grid-column-three-quarters">
       <%= render "controls",
-        count: @products.size,
+        count: @results.total_count,
         keywords: params[:q],
         filter: params[:hazard_type],
         form: form,

--- a/spec/features/businesses_spec.rb
+++ b/spec/features/businesses_spec.rb
@@ -9,12 +9,17 @@ RSpec.feature "Business listing", :with_opensearch, :with_stubbed_mailer, type: 
   before do
     create_list :business, 18, created_at: 4.days.ago
     sign_in(user)
+    Business.import refresh: :wait_for
+    visit businesses_path
+  end
+
+  context "when no keywords are entered" do
+    it "shows total number of businesses" do
+      expect(page).to have_content "There are currently #{Business.count} businesses."
+    end
   end
 
   scenario "lists business according to search relevance" do
-    Business.import refresh: :wait_for
-    visit businesses_path
-
     within "table#results tbody.govuk-table__body > tr:nth-child(1) > th:nth-child(1)" do
       expect(page).to have_link(business_one.trading_name, href: business_path(business_one))
     end
@@ -39,9 +44,6 @@ RSpec.feature "Business listing", :with_opensearch, :with_stubbed_mailer, type: 
   end
 
   scenario "strips leading and trailing whitespace from search queries" do
-    Business.import refresh: :wait_for
-    visit businesses_path
-
     fill_in "Keywords", with: "  #{business_three.trading_name} "
     click_on "Search"
 

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
 
   context "when there are multiple pages of products" do
     before do
-      17.times {Product.create(name: "QQQQQQ")}
+      17.times { Product.create(name: "TestProduct") }
       Product.import refresh: :wait_for
       visit products_path
     end

--- a/spec/features/filter_products_spec.rb
+++ b/spec/features/filter_products_spec.rb
@@ -28,6 +28,18 @@ RSpec.feature "Product filtering", :with_opensearch, :with_stubbed_mailer, type:
     expect(page).to have_content("There are currently 4 products.")
   end
 
+  context "when there are multiple pages of products" do
+    before do
+      17.times {Product.create(name: "QQQQQQ")}
+      Product.import refresh: :wait_for
+      visit products_path
+    end
+
+    it "shows total number of products regardless of how many are on the current page" do
+      expect(page).to have_content("There are currently #{Product.count} products.")
+    end
+  end
+
   scenario "filtering by hazard type" do
     select "Fire", from: "Hazard type"
     click_button "Apply"


### PR DESCRIPTION
https://trello.com/c/xLxeynfs/1288-wrong-count-on-products-and-businesses-pages

## Description
Prior to this change the search statement on the product and business page had a bug that caused it to show a maximum of 20 in the statement which describes total number of businesses/products. This PR fixes that issue.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
