### PR TITLE
Remove invalid closing tag from GA script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,14 +30,10 @@
     <%= yield :other_head_tags %>
 
     <% if Rails.env.production? %>
-      <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-1" />
-      <script type="text/javascript">
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-1"></script>
+      <script>
         window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-          dataLayer.push(arguments);
-        }
-
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         gtag('config', 'UA-126364208-1');
       </script>


### PR DESCRIPTION
https://trello.com/c/A4dcvuFU/1303-ensure-google-analytics-for-psd-is-picking-up-users

## Description
Fixes the invalid markup preventing Google Analytics from initialising.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
