### PR TITLE
Remove excess logs from redex workflows

### DIFF
--- a/.github/workflows/publish-production-redacted-export.yml
+++ b/.github/workflows/publish-production-redacted-export.yml
@@ -117,7 +117,7 @@ jobs:
           timeout 15m bash -c 'until cf tasks $TEMP_APP_NAME > /tmp/task_result && grep -E "SUCCEEDED" /tmp/task_result; do sleep 10; echo "Waiting for task..."; done'
           echo "::endgroup::"
 
-          CF_LOGS=`cf logs $TEMP_APP_NAME --recent | tee`
+          CF_LOGS=`cf logs $TEMP_APP_NAME --recent`
           echo $CF_LOGS | grep "TASK SCRIPT COMPLETED"
 
           sleep 5

--- a/.github/workflows/publish-staging-redacted-export.yml
+++ b/.github/workflows/publish-staging-redacted-export.yml
@@ -117,7 +117,7 @@ jobs:
           timeout 15m bash -c 'until cf tasks $TEMP_APP_NAME > /tmp/task_result && grep -E "SUCCEEDED" /tmp/task_result; do sleep 10; echo "Waiting for task..."; done'
           echo "::endgroup::"
 
-          CF_LOGS=`cf logs $TEMP_APP_NAME --recent | tee`
+          CF_LOGS=`cf logs $TEMP_APP_NAME --recent`
           echo $CF_LOGS | grep "TASK SCRIPT COMPLETED"
 
           sleep 5


### PR DESCRIPTION
## Description

This change no longer `tee`s the export task's logs to the workflow output. These logs appeared as a single-line wall of text which were hard for a human to read and didn't add anything useful.