### PR TITLE
Remove more excess logs from redex workflows

### DIFF
--- a/.github/workflows/publish-production-redacted-export.yml
+++ b/.github/workflows/publish-production-redacted-export.yml
@@ -117,8 +117,7 @@ jobs:
           timeout 15m bash -c 'until cf tasks $TEMP_APP_NAME > /tmp/task_result && grep -E "SUCCEEDED" /tmp/task_result; do sleep 10; echo "Waiting for task..."; done'
           echo "::endgroup::"
 
-          CF_LOGS=`cf logs $TEMP_APP_NAME --recent`
-          echo $CF_LOGS | grep "TASK SCRIPT COMPLETED"
+          cf logs $TEMP_APP_NAME --recent 2>&1 | grep --silent "TASK SCRIPT COMPLETED"
 
           sleep 5
           cf delete $TEMP_APP_NAME -f

--- a/.github/workflows/publish-staging-redacted-export.yml
+++ b/.github/workflows/publish-staging-redacted-export.yml
@@ -1,7 +1,6 @@
 name: Publish Staging redacted export to S3
 
 on:
-  push:
   schedule:
     - cron: "0 12 * * 0"
   workflow_dispatch:

--- a/.github/workflows/publish-staging-redacted-export.yml
+++ b/.github/workflows/publish-staging-redacted-export.yml
@@ -1,6 +1,7 @@
 name: Publish Staging redacted export to S3
 
 on:
+  push:
   schedule:
     - cron: "0 12 * * 0"
   workflow_dispatch:
@@ -117,8 +118,7 @@ jobs:
           timeout 15m bash -c 'until cf tasks $TEMP_APP_NAME > /tmp/task_result && grep -E "SUCCEEDED" /tmp/task_result; do sleep 10; echo "Waiting for task..."; done'
           echo "::endgroup::"
 
-          CF_LOGS=`cf logs $TEMP_APP_NAME --recent`
-          echo $CF_LOGS | grep "TASK SCRIPT COMPLETED"
+          cf logs $TEMP_APP_NAME --recent 2>&1 | grep --silent "TASK SCRIPT COMPLETED"
 
           sleep 5
           cf delete $TEMP_APP_NAME -f


### PR DESCRIPTION
## Description

Expands on #1774 to remove cluttered log lines from the export workflows which were being written to `STDERR`.