### PR TITLE
Add daera-ni.gov.uk domain to whitelist

### DIFF
--- a/config/constants/whitelisted_emails.yml
+++ b/config/constants/whitelisted_emails.yml
@@ -41,6 +41,7 @@ email_domains:
   - "coventry.gov.uk"
   - "croydon.gov.uk"
   - "cumbria.gov.uk"
+  - "daera-ni.gov.uk"
   - "darlington.gov.uk"
   - "denbighshire.gov.uk"
   - "derby.gov.uk"


### PR DESCRIPTION
https://trello.com/c/aDdqPYlh/1312-add-domain-to-whitelist
