### PR TITLE
Cases sorting options

### DIFF
--- a/app/assets/stylesheets/opss/_opss-shared.scss
+++ b/app/assets/stylesheets/opss/_opss-shared.scss
@@ -1,10 +1,10 @@
+//$opss-error-colour: #d4351c;
 @mixin down-load-link($color,$size) {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="'+ $size +'px" viewBox="0 0 24 24" width="'+ $size +'px" fill="'+ $color +'"><g><rect fill="none" height="'+ $size +'" width="'+ $size +'"/></g><g><path d="M18,15v3H6v-3H4v3c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2v-3H18z M17,11l-1.41-1.41L13,12.17V4h-2v8.17L8.41,9.59L7,11l5,5 L17,11z"/></g></svg>');
     background-position: center;
     background-repeat: no-repeat;
     display: inline-block;
 }
-
 @function calculateRem($s) {
   $remSize: $s / 16px;
   @return #{$remSize}rem;
@@ -14,11 +14,19 @@
     font-size: calculateRem($s) !important;
     line-height: $l !important;
 }
-
 @mixin word-wrap() {
   overflow-wrap: break-word; word-wrap: break-word; -ms-word-break: break-all; word-break: break-all;
   word-break: break-word; -ms-hyphens: auto; -moz-hyphens: auto; -webkit-hyphens: auto; hyphens: auto;
 }
+
+$std-font-family: "GDS Transport", "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+
+/* not normalised by gds library - starts */
+figure,
+figcaption {
+    margin: 0; padding: 0; display: block;
+}
+/* not normalised by gds library - ends */
 
 main.govuk-main-wrapper {
     @include govuk-media-query($from: desktop) {
@@ -43,6 +51,7 @@ main.govuk-main-wrapper {
     @include word-wrap;
 }
 
+/*tbody th  {-webkit-hyphens: auto; -moz-hyphens: auto; -ms-hyphens: auto; hyphens: auto; }*/
 .govuk-summary-list .govuk-link,
 .opss-table td a,
 .opss-table tbody tr th:first-child,
@@ -56,6 +65,12 @@ h1.govuk-fieldset__heading,
 h1.govuk-label-wrapper label.govuk-label--l {
     overflow-wrap: normal; word-wrap: normal; word-break: normal; hyphens: unset;
 }
+/*.opss-secondary-text-colour {color: $govuk-secondary-text-colour; }
+.opss-weight-normal {font-weight: normal;
+    *[class^="govuk-heading"] & {
+        font-weight: 400;
+    }
+}*/
 .opss-no-wrap {
   white-space: nowrap;
 }
@@ -70,9 +85,10 @@ h1.govuk-label-wrapper label.govuk-label--l {
 body.js-enabled .opss-nojs-hide {
     display: inline;
 }
+
 .js-enabled {
     .opss-js-enabled-hidden {
-        display: none;
+        display: none;  /* @include govuk-visually-hidden; */
     }
 }
 .opss-br-desktop {
@@ -83,13 +99,65 @@ body.js-enabled .opss-nojs-hide {
     }
 }
 
+.opss-hidden-desktop {
+    visibility: visible;
+
+    @include govuk-media-query($from: desktop) {
+        visibility: hidden;
+    }
+}
+
 .opss-float-left {
     float: left;
 }
 .opss-float-right {
     float: right;
+
+    & + .opss-float-right {
+        clear: right;
+    }
 }
 
+@include govuk-media-query($from: desktop) {
+    .opss-float-left-desktop {
+        float: left;
+    }
+    .opss-float-right-desktop {
+        float: right;
+
+        & + .opss-float-right-desktop {
+            clear: right;
+        }
+    }
+}
+
+.opss-responsive-margin-top-6 {
+    @include govuk-responsive-margin(6, "top");
+}
+.opss-responsive-margin-top-9 {
+    @include govuk-responsive-margin(9, "top");
+}
+.opss-responsive-margin-bottom-6 {
+    @include govuk-responsive-margin(6, "bottom");
+}
+.opss-responsive-margin-bottom-9 {
+    @include govuk-responsive-margin(9, "bottom");
+}
+.opss-skip-link {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+.opss-margin-bottom-1-desktop {
+    margin-bottom: govuk-spacing(4);
+
+    @include govuk-media-query($from: desktop) {
+        margin-bottom: govuk-spacing(1);
+    }
+}
 .opss-skip-link:focus {
     &.opss-skip-link--mb {
         margin-bottom: govuk-spacing(4) !important;
@@ -101,13 +169,61 @@ body.js-enabled .opss-nojs-hide {
 .opss-grey-bg {
     background-color: govuk-colour("light-grey");
 }
+.opss-rounded-corners {
+     border-radius: 5px;
+}
+.opss-document-icon-std {    /*   A CSS FOR ICON ON MOBILE - REQUIRES DESKTOP ONLY CSS TO SNAP IN FULL SIZE DIMS. And update HTML to figcaption   */
+    position: relative;
+    padding: 2px;
+    margin: 0 0 govuk-spacing(2) 0;
+    vertical-align: top;
+    background: govuk-colour("mid-grey");
+    width: 50px;
+    height: 70px;
+
+    img {
+        display: block;
+        width: 50px;
+    }
+
+    .opss-document-icon-std__filetype {
+        visibility: hidden;
+        position: absolute;
+        left: -10000px;
+
+        abbr[title]{
+            border-bottom: none;
+        }
+    }
+
+    @include govuk-media-query($from: desktop) {
+        height: 71px;
+        margin: 0;
+
+        .opss-document-icon-std__filetype {
+            visibility: visible;
+            left: 2px;
+            top: 7px;
+            width: 50px;
+            height: 30px;
+            color: govuk-colour("white");
+            font-family: inherit;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            font-weight: 700;
+            @include opss-font-size($s: 14px, $l: 1.2);
+            text-align: center;
+        }
+    }
+}
+
 @include govuk-media-query($from: desktop) {//use on
     .opss-right-box-arrow {
         position: relative;
         background-color: govuk-colour("light-grey");
         margin-right: govuk-spacing(5) !important;
         border-radius: 5px;
-        padding-left: govuk-spacing(2);
+        padding-left: govuk-spacing(3);
 
         .govuk-grid-column-one-quarter > & {
             margin-right: govuk-spacing(7) + govuk-spacing(1) !important;
@@ -149,8 +265,11 @@ kbd {
     text-align: center;
 }
 
-.opss-text-align-right {
-    @include govuk-media-query($from: tablet) {
+@include govuk-media-query($from: tablet) {
+    .opss-max-width-two-thirds {
+        max-width: 66%;
+    }
+    .opss-text-align-right {
         text-align: right; display: inline-block; width: 100%;
     }
 }
@@ -204,7 +323,7 @@ kbd {
 .opss-border-left {border-left-width: 1px; }
 .opss-border-right {border-right-width: 1px; }
 .opss-border-all {border-width: 1px; }
-.opss-border-none {border-width: 0;}
+.opss-border-none {border-width: 0; }
 
 .opss-details--sm {
     @include govuk-media-query($from: desktop) {
@@ -262,6 +381,22 @@ kbd {
 .opss-details-img {
     max-height: 300px;
     max-width: 100%;
+
+    &.opss-details-img--thumbnail {
+        max-height: 110px;
+    }
+
+    &.opss-details-img--thumbnail + .opss-img-caption {
+        max-width: 174px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+
+.opss-img-caption {
+    font-family: $std-font-family;
+    @include opss-font-size($s: 14px, $l: 1.25);
 }
 
 dl.opss-summary-list-aside {
@@ -328,6 +463,80 @@ dl.opss-summary-list-aside {
         }
         div:first-of-type dt {
             margin-top: govuk-spacing(0);
+        }
+    }
+}
+
+.opss-summary-list-mixed {
+    & > div {/* std summary list but allows for a mixture of 2 & 3 cols in 1 list */
+        display: table;
+        width: 100%;
+
+        .govuk-grid-column-three-quarters & {
+            dt {
+                width: 39%;
+            }
+            dt + dd {
+                min-width: 40%;
+                width: auto; /* 1. protects against rogue legacy psd invalid html */
+            }
+        }
+
+        dd {
+            overflow-wrap: break-word;
+            word-wrap: break-word;
+            -ms-word-break: break-all;
+            word-break: break-all;
+            word-break: break-word; /*no adding hypens*/
+        }
+        & > span.govuk-summary-list__actions {display: none !important; }/* 2. protects against rogue legacy psd invalid html */
+    }
+
+    &.opss-summary-list-mixed--narrow-dt > div {
+        dt {
+            width: 25%;
+        }
+        dt + dd {
+            min-width: 50%;
+        }
+    }
+
+    @include govuk-media-query($from: desktop) {
+        &.opss-summary-list-mixed--compact > div {
+            dt, dd {
+                margin-top: 0;
+                margin-bottom: 0;
+                padding-top: 0;
+                padding-bottom: govuk-spacing(1);
+                @include opss-font-size($s: 16px, $l: 1.2);
+                color: $govuk-secondary-text-colour;
+            }
+        }
+    }
+
+    .opss-grouping & {
+        &.opss-summary-list-mixed--narrow-dt {
+            dt {
+                width: 24%;
+            }
+        }
+    }
+
+    @-moz-document url-prefix() {/*firefox only: align 1st dd (without a 2nd) correctly */
+        .govuk-summary-list__row dd:last-child {
+            width: inherit;
+        }
+    }
+}
+
+@include govuk-media-query($from: desktop) {
+    .opss-summary-list-mixed.opss-summary-list-mixed--sm {/*a narrow and small font version */
+        dt {
+            width: 25% !important;
+        }
+        dt, dd {
+            @include opss-font-size($s: 16px, $l: 1.2);
+            padding-bottom: govuk-spacing(0);
         }
     }
 }
@@ -498,6 +707,10 @@ dl.opss-summary-list-aside {
             color: $govuk-text-colour;
         }
     }
+    /*tbody tr:last-child td a {
+        @include govuk-font($size: 16);
+    }*/
+    /*tbody tr:not(:first-child):not(:last-child) td, tbody tr:not(:first-child):not(:last-child) th, */
     tbody tr:nth-child(2) th, tbody tr:nth-child(2) td {
         padding-top: govuk-spacing(0);
         padding-bottom: govuk-spacing(2);
@@ -509,6 +722,7 @@ dl.opss-summary-list-aside {
     tbody tr:nth-child(4) th, tbody tr:nth-child(4) td {
         padding-top: govuk-spacing(0);
     }
+    /*th[colspan="3"], tfoot th {padding-top: govuk-spacing(7); }*/
     tbody tr:first-child th,
     tbody tr:not(:last-child) > *,
     tfoot tr th {

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -64,13 +64,13 @@ private
     params[:sort_by] = nil if params[:sort_by] == SortByHelper::SORT_BY_RELEVANT && params[:q].blank?
 
     @sort_by_items = sort_by_items
-    @selected_sort_by = params[:sort_by].presence || SortByHelper::SORT_BY_RECENT
+    @selected_sort_by = params[:sort_by].presence || SortByHelper::SORT_BY_UPDATED_AT
     @selected_sort_direction = params[:sort_dir]
   end
 
   def sort_by_items
     items = [
-      SortByHelper::SortByItem.new("Recently added", SortByHelper::SORT_BY_RECENT, SortByHelper::SORT_DIRECTION_DEFAULT),
+      SortByHelper::SortByItem.new("Recently added", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_DEFAULT),
       SortByHelper::SortByItem.new("Name A–Z", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_ASC),
       SortByHelper::SortByItem.new("Name Z–A", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DESC)
     ]

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -55,8 +55,7 @@ class InvestigationsController < ApplicationController
     @search = SearchParams.new({ "case_owner" => "me",
                                  "sort_by" => params["sort_by"],
                                  "sort_dir" => params["sort_dir"],
-                                 "page_name" => "team_cases"
-                               })
+                                 "page_name" => "team_cases" })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
@@ -69,8 +68,7 @@ class InvestigationsController < ApplicationController
     @search = SearchParams.new({ "case_owner" => "my_team",
                                  "sort_by" => params["sort_by"],
                                  "sort_dir" => params["sort_dir"],
-                                 "page_name" => @page_name
-                               })
+                                 "page_name" => @page_name })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -51,7 +51,9 @@ class InvestigationsController < ApplicationController
   end
 
   def your_cases
-    @search = SearchParams.new({ "case_owner" => "me" })
+    @search = SearchParams.new({ "case_owner" => "me",
+                                 "sort_by" => params["sort_by"],
+                                 "sort_dir" => params["sort_dir"] })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
@@ -61,7 +63,9 @@ class InvestigationsController < ApplicationController
   end
 
   def team_cases
-    @search = SearchParams.new({ "case_owner" => "my_team" })
+    @search = SearchParams.new({ "case_owner" => "my_team",
+                                 "sort_by" => params["sort_by"],
+                                 "sort_dir" => params["sort_dir"] })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))

--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -51,25 +51,29 @@ class InvestigationsController < ApplicationController
   end
 
   def your_cases
+    @page_name = "your_cases"
     @search = SearchParams.new({ "case_owner" => "me",
                                  "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"] })
+                                 "sort_dir" => params["sort_dir"],
+                                 "page_name" => "team_cases"
+                               })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
-    @page_name = "your_cases"
 
     render "investigations/index.html.erb"
   end
 
   def team_cases
+    @page_name = "team_cases"
     @search = SearchParams.new({ "case_owner" => "my_team",
                                  "sort_by" => params["sort_by"],
-                                 "sort_dir" => params["sort_dir"] })
+                                 "sort_dir" => params["sort_dir"],
+                                 "page_name" => @page_name
+                               })
     @answer         = search_for_investigations(20)
     @investigations = InvestigationDecorator
                         .decorate_collection(@answer.records(includes: [{ owner_user: :organisation, owner_team: :organisation }, :products]))
-    @page_name = "team_cases"
 
     render "investigations/index.html.erb"
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -91,13 +91,13 @@ private
     params[:sort_by] = nil if params[:sort_by] == SortByHelper::SORT_BY_RELEVANT && params[:q].blank?
 
     @sort_by_items = sort_by_items
-    @selected_sort_by = params[:sort_by].presence || SortByHelper::SORT_BY_NEWEST
+    @selected_sort_by = params[:sort_by].presence || SortByHelper::SORT_BY_CREATED_AT
     @selected_sort_direction = params[:sort_dir]
   end
 
   def sort_by_items
     items = [
-      SortByHelper::SortByItem.new("Newly added", SortByHelper::SORT_BY_NEWEST, SortByHelper::SORT_DIRECTION_DEFAULT),
+      SortByHelper::SortByItem.new("Newly added", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DEFAULT),
       SortByHelper::SortByItem.new("Name A–Z", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_ASC),
       SortByHelper::SortByItem.new("Name Z–A", SortByHelper::SORT_BY_NAME, SortByHelper::SORT_DIRECTION_DESC)
     ]

--- a/app/helpers/investigations_helper.rb
+++ b/app/helpers/investigations_helper.rb
@@ -14,6 +14,7 @@ module InvestigationsHelper
       :page,
       :case_owner,
       :sort_by,
+      :sort_dir,
       :priority,
       :teams_with_access,
       :case_owner_is_someone_else_id,

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -13,7 +13,7 @@ module SearchHelper
   end
 
   def query_params
-    params.permit(:q, :sort_by, :direction, :hazard_type, :page_name)
+    params.permit(:q, :sort_by, :sort_dir, :direction, :hazard_type, :page_name)
   end
 
   def sorting_params

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -21,11 +21,13 @@ class SearchParams
   attribute :teams_with_access, default: "all"
   attribute :teams_with_access_other_id
   attribute :hazard_type
+  attribute :page_name
 
   def selected_sort_by
     if sort_by.blank?
       return SortByHelper::SORT_BY_RELEVANT if q.present?
 
+      return SortByHelper::SORT_BY_CREATED_AT if (page_name == "team_cases" || page_name == "your_cases")
       return SortByHelper::SORT_BY_UPDATED_AT
     end
     sort_by
@@ -47,12 +49,22 @@ class SearchParams
   end
 
   def sort_by_items(with_relevant_option: false)
-    items = [
-      SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_DESC),
-      SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_ASC),
-      SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DESC),
-      SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_ASC)
-    ]
+    items = if (page_name == "team_cases" || page_name == "your_cases")
+              [
+                SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+                SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_ASC),
+                SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+                SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_ASC)
+              ]
+            else
+              [
+                SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+                SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_ASC),
+                SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+                SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_ASC)
+              ]
+            end
+
     items.unshift(SortByHelper::SortByItem.new("Relevance", SortByHelper::SORT_BY_RELEVANT, SortByHelper::SORT_DIRECTION_DEFAULT)) if with_relevant_option
     items
   end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -27,7 +27,8 @@ class SearchParams
     if sort_by.blank?
       return SortByHelper::SORT_BY_RELEVANT if q.present?
 
-      return SortByHelper::SORT_BY_CREATED_AT if (page_name == "team_cases" || page_name == "your_cases")
+      return SortByHelper::SORT_BY_CREATED_AT if page_name == "team_cases" || page_name == "your_cases"
+
       return SortByHelper::SORT_BY_UPDATED_AT
     end
     sort_by
@@ -49,7 +50,7 @@ class SearchParams
   end
 
   def sort_by_items(with_relevant_option: false)
-    items = if (page_name == "team_cases" || page_name == "your_cases")
+    items = if page_name == "team_cases" || page_name == "your_cases"
               [
                 SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DESC),
                 SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_ASC),

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -32,6 +32,10 @@ class SearchParams
   end
 
   def selected_sort_dir
+    if sort_dir.blank?
+      return SortByHelper::SORT_DIRECTION_DESC
+    end
+    
     sort_dir
   end
 

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -26,7 +26,7 @@ class SearchParams
     if sort_by.blank?
       return SortByHelper::SORT_BY_RELEVANT if q.present?
 
-      return SortByHelper::SORT_BY_RECENT
+      return SortByHelper::SORT_BY_UPDATED_AT
     end
     sort_by
   end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -16,6 +16,7 @@ class SearchParams
   attribute :case_owner, default: "all"
   attribute :case_owner_is_someone_else_id
   attribute :sort_by
+  attribute :sort_dir
   attribute :page, :integer
   attribute :teams_with_access, default: "all"
   attribute :teams_with_access_other_id
@@ -31,26 +32,18 @@ class SearchParams
   end
 
   def sorting_params
-    case sort_by
-    when SortByHelper::SORT_BY_NEWEST
-      { created_at: "desc" }
-    when SortByHelper::SORT_BY_OLDEST
-      { updated_at: "asc" }
-    when SortByHelper::SORT_BY_RECENT
-      { updated_at: "desc" }
-    when SortByHelper::SORT_BY_OLDEST_CREATED
-      { created_at: "asc" }
-    else
-      { updated_at: "desc" }
-    end
+    sort_by_field = sort_by.blank? ? "updated_at" : sort_by
+    sort_dir_value = sort_dir.blank? ? "desc" : sort_dir
+
+    { sort_by_field => sort_dir_value }
   end
 
   def sort_by_items(with_relevant_option: false)
     items = [
-      SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_RECENT, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_OLDEST, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_NEWEST, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_OLDEST_CREATED, SortByHelper::SORT_DIRECTION_DEFAULT)
+      SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+      SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_UPDATED_AT, SortByHelper::SORT_DIRECTION_ASC),
+      SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_DESC),
+      SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_CREATED_AT, SortByHelper::SORT_DIRECTION_ASC)
     ]
     items.unshift(SortByHelper::SortByItem.new("Relevance", SortByHelper::SORT_BY_RELEVANT, SortByHelper::SORT_DIRECTION_DEFAULT)) if with_relevant_option
     items

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -35,13 +35,13 @@ class SearchParams
     if sort_dir.blank?
       return SortByHelper::SORT_DIRECTION_DESC
     end
-    
+
     sort_dir
   end
 
   def sorting_params
-    sort_by_field = sort_by.blank? ? "updated_at" : sort_by
-    sort_dir_value = sort_dir.blank? ? "desc" : sort_dir
+    sort_by_field = sort_by.presence || "updated_at"
+    sort_dir_value = sort_dir.presence || "desc"
 
     { sort_by_field => sort_dir_value }
   end

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -38,6 +38,8 @@ class SearchParams
       { updated_at: "asc" }
     when SortByHelper::SORT_BY_RECENT
       { updated_at: "desc" }
+    when SortByHelper::SORT_BY_OLDEST_CREATED
+      { created_at: "asc" }
     else
       { updated_at: "desc" }
     end
@@ -47,7 +49,8 @@ class SearchParams
     items = [
       SortByHelper::SortByItem.new("Recent updates", SortByHelper::SORT_BY_RECENT, SortByHelper::SORT_DIRECTION_DEFAULT),
       SortByHelper::SortByItem.new("Oldest updates", SortByHelper::SORT_BY_OLDEST, SortByHelper::SORT_DIRECTION_DEFAULT),
-      SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_NEWEST, SortByHelper::SORT_DIRECTION_DEFAULT)
+      SortByHelper::SortByItem.new("Newest cases", SortByHelper::SORT_BY_NEWEST, SortByHelper::SORT_DIRECTION_DEFAULT),
+      SortByHelper::SortByItem.new("Oldest cases", SortByHelper::SORT_BY_OLDEST_CREATED, SortByHelper::SORT_DIRECTION_DEFAULT)
     ]
     items.unshift(SortByHelper::SortByItem.new("Relevance", SortByHelper::SORT_BY_RELEVANT, SortByHelper::SORT_DIRECTION_DEFAULT)) if with_relevant_option
     items

--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -31,6 +31,10 @@ class SearchParams
     sort_by
   end
 
+  def selected_sort_dir
+    sort_dir
+  end
+
   def sorting_params
     sort_by_field = sort_by.blank? ? "updated_at" : sort_by
     sort_dir_value = sort_dir.blank? ? "desc" : sort_dir

--- a/app/helpers/sort_by_helper.rb
+++ b/app/helpers/sort_by_helper.rb
@@ -4,6 +4,7 @@ module SortByHelper
     SORT_BY_OLDEST   = "oldest".freeze,
     SORT_BY_RECENT   = "recent".freeze,
     SORT_BY_RELEVANT = "relevant".freeze,
+    SORT_BY_OLDEST_CREATED = "oldest_created".freeze,
     SORT_BY_NAME     = "name".freeze
   ].freeze
 

--- a/app/helpers/sort_by_helper.rb
+++ b/app/helpers/sort_by_helper.rb
@@ -1,10 +1,6 @@
 module SortByHelper
   SORT_BY_VALUES = [
-    SORT_BY_NEWEST   = "newest".freeze,
-    SORT_BY_OLDEST   = "oldest".freeze,
-    SORT_BY_RECENT   = "recent".freeze,
     SORT_BY_RELEVANT = "relevant".freeze,
-    SORT_BY_OLDEST_CREATED = "oldest_created".freeze,
     SORT_BY_NAME     = "name".freeze,
     SORT_BY_CREATED_AT = "created_at".freeze,
     SORT_BY_UPDATED_AT = "updated_at".freeze

--- a/app/helpers/sort_by_helper.rb
+++ b/app/helpers/sort_by_helper.rb
@@ -5,7 +5,9 @@ module SortByHelper
     SORT_BY_RECENT   = "recent".freeze,
     SORT_BY_RELEVANT = "relevant".freeze,
     SORT_BY_OLDEST_CREATED = "oldest_created".freeze,
-    SORT_BY_NAME     = "name".freeze
+    SORT_BY_NAME     = "name".freeze,
+    SORT_BY_CREATED_AT = "created_at".freeze,
+    SORT_BY_UPDATED_AT = "updated_at".freeze
   ].freeze
 
   SORT_DIRECTIONS = [

--- a/app/helpers/sort_by_helper.rb
+++ b/app/helpers/sort_by_helper.rb
@@ -27,12 +27,13 @@ module SortByHelper
     end
   end
 
-  def render_sort_by(form, sort_by_items, selected_value, sort_direction = SORT_DIRECTION_DEFAULT)
+  def render_sort_by(form, sort_by_items, selected_value, sort_direction = SORT_DIRECTION_DEFAULT, custom_classes = nil)
     render "application/sort_dropdown",
            form: form,
            sort_by_items: sort_by_items,
            selected_value: selected_value,
-           sort_direction: sort_direction
+           sort_direction: sort_direction,
+           custom_classes: custom_classes
   end
 
   def url_for_sort_by(sort_by_item)

--- a/app/views/application/_sort_dropdown.html.erb
+++ b/app/views/application/_sort_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-column-one-third">
+<div class="<%= custom_classes ? custom_classes : "govuk-grid-column-one-third" %>">
   <div class="govuk-form-group opss-text-align-right">
     <fieldset id="sort-by-fieldset" class="opss-border-none govuk-!-padding-0 opss-nojs-hide">
       <label class="govuk-label govuk-body-s" for="sort_by">

--- a/app/views/investigations/_case_card.html.erb
+++ b/app/views/investigations/_case_card.html.erb
@@ -21,7 +21,7 @@
       <%= investigation.owner_display_name_for(viewer: current_user) %>
     </span>
   </div>
-  <% if sorted_by == SortByHelper::SORT_BY_NEWEST %>
+  <% if sorted_by == SortByHelper::SORT_BY_CREATED_AT %>
     <div class="govuk-grid-column-one-quarter">
       <span class="govuk-caption-m govuk-!-font-size-16">
         Date created

--- a/app/views/investigations/_full_table_body.html.erb
+++ b/app/views/investigations/_full_table_body.html.erb
@@ -23,7 +23,7 @@
         <%= investigation.owner_display_name_for(viewer: current_user) %>
       </td>
     <% end %>
-    <% if sorted_by == SortByHelper::SORT_BY_NEWEST %>
+    <% if sorted_by == SortByHelper::SORT_BY_CREATED_AT %>
       <td headers="created <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
         <%= "#{time_ago_in_words(investigation.created_at)} ago" %>
       </td>

--- a/app/views/investigations/_highlight_table_body.html.erb
+++ b/app/views/investigations/_highlight_table_body.html.erb
@@ -19,7 +19,7 @@
     <td headers="caseowner <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
       <%= investigation.owner_display_name_for(viewer: current_user) %>
     </td>
-    <% if sorted_by == SortByHelper::SORT_BY_NEWEST %>
+    <% if sorted_by == SortByHelper::SORT_BY_CREATED_AT %>
       <td headers="created <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
         <%= "#{time_ago_in_words(investigation.created_at)} ago" %>
       </td>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -4,12 +4,14 @@
 
 <%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
+    <%= form.hidden_field :sort_by, value: params[:sort_by] %>
+    <%= form.hidden_field :sort_dir, value: params[:sort_dir] %>
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">
       <% if ["team_cases", "your_cases"].exclude? @page_name  ||  @investigations.size > 11 %>
         <div class="govuk-grid-row">
           <%= render 'investigations/search_bar', form: form if ["team_cases", "your_cases"].exclude? @page_name %>
-          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by if @investigations.size > 11 %>
+          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @investigations.size > 11 %>
         </div>
         <div class="govuk-grid-row">
           <%= search_result_statement(@search.q, @count) %>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -6,17 +6,15 @@
   <div class="govuk-grid-row opss-full-height">
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">
-      <% if ["team_cases", "your_cases"].exclude?(@page_name)  &&  @investigations.size > 11 %>
+      <% if ["team_cases", "your_cases"].exclude?(@page_name) %>
         <div class="govuk-grid-row">
-          <%= render 'investigations/search_bar', form: form if ["team_cases", "your_cases"].exclude? @page_name %>
+          <%= render 'investigations/search_bar', form: form %>
           <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @answer.total_count > 11 %>
         </div>
         <div class="govuk-grid-row">
           <%= search_result_statement(@search.q, @count) %>
         </div>
-      <% end %>
-
-      <% if ["team_cases", "your_cases"].include?(@page_name ) &&  @investigations.size > 11 %>
+      <% else %>
         <div class="govuk-grid-row">
           <%= render_sort_by(form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir, "govuk-grid-column-one-third opss-float-right-desktop") if @answer.total_count > 11 %>
         </div>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -9,7 +9,7 @@
       <% if ["team_cases", "your_cases"].exclude? @page_name  ||  @investigations.size > 11 %>
         <div class="govuk-grid-row">
           <%= render 'investigations/search_bar', form: form if ["team_cases", "your_cases"].exclude? @page_name %>
-          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @investigations.size > 11 %>
+          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @answer.total_count > 11 %>
         </div>
         <div class="govuk-grid-row">
           <%= search_result_statement(@search.q, @count) %>
@@ -32,7 +32,7 @@
                   <% else %>
                     <th id="caseowner" scope="col" class="govuk-table__header">Case owner</th>
                   <% end %>
-                  <% if query_params[:sort_by] == SortByHelper::SORT_BY_NEWEST %>
+                  <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
                     <th id="updated" scope="col" class="govuk-table__header">Updated</th>
@@ -52,7 +52,7 @@
                     <th class="govuk-visually-hidden">&nbsp;</th>
                     <th scope="col" class="govuk-table__header">Case number</th>
                     <th scope="col" class="govuk-table__header">Case owner</th>
-                    <% if query_params[:sort_by] == SortByHelper::SORT_BY_NEWEST %>
+                    <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT %>
                       <th scope="col" class="govuk-table__header">Created</th>
                     <% else %>
                       <th scope="col" class="govuk-table__header">Updated</th>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -9,14 +9,14 @@
       <% if ["team_cases", "your_cases"].exclude?(@page_name) %>
         <div class="govuk-grid-row">
           <%= render 'investigations/search_bar', form: form %>
-          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @answer.total_count > 11 %>
+          <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if (@answer.total_count && @answer.total_count > 11) %>
         </div>
         <div class="govuk-grid-row">
           <%= search_result_statement(@search.q, @count) %>
         </div>
       <% else %>
         <div class="govuk-grid-row">
-          <%= render_sort_by(form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir, "govuk-grid-column-one-third opss-float-right-desktop") if @answer.total_count > 11 %>
+          <%= render_sort_by(form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir, "govuk-grid-column-one-third opss-float-right-desktop") if (@answer.total_count && @answer.total_count > 11) %>
         </div>
       <% end %>
 

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -4,8 +4,6 @@
 
 <%= form_with(model: @search, scope: "", url: investigations_search_path, method: :get, local: true, id: "cases-search-form", html: { novalidate: true, role: "search" }) do |form| %>
   <div class="govuk-grid-row opss-full-height">
-    <%= form.hidden_field :sort_by, value: params[:sort_by] %>
-    <%= form.hidden_field :sort_dir, value: params[:sort_dir] %>
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">
       <% if ["team_cases", "your_cases"].exclude? @page_name  ||  @investigations.size > 11 %>

--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -6,13 +6,19 @@
   <div class="govuk-grid-row opss-full-height">
     <%= render 'investigations/filters', search: @search, form: form %>
     <section class="govuk-grid-column-three-quarters" id="page-content">
-      <% if ["team_cases", "your_cases"].exclude? @page_name  ||  @investigations.size > 11 %>
+      <% if ["team_cases", "your_cases"].exclude?(@page_name)  &&  @investigations.size > 11 %>
         <div class="govuk-grid-row">
           <%= render 'investigations/search_bar', form: form if ["team_cases", "your_cases"].exclude? @page_name %>
           <%= render_sort_by form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir if @answer.total_count > 11 %>
         </div>
         <div class="govuk-grid-row">
           <%= search_result_statement(@search.q, @count) %>
+        </div>
+      <% end %>
+
+      <% if ["team_cases", "your_cases"].include?(@page_name ) &&  @investigations.size > 11 %>
+        <div class="govuk-grid-row">
+          <%= render_sort_by(form, @search.sort_by_items(with_relevant_option: false), @search.selected_sort_by, @search.selected_sort_dir, "govuk-grid-column-one-third opss-float-right-desktop") if @answer.total_count > 11 %>
         </div>
       <% end %>
 

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -25,7 +25,7 @@
                   <th class="govuk-visually-hidden">&nbsp;</th>
                   <th id="case" scope="col" class="govuk-table__header">Case number</th>
                   <th id="caseowner" scope="col" class="govuk-table__header">Case owner</th>
-                  <% if @search.sort_by == SortByHelper::SORT_BY_NEWEST %>
+                  <% if @search.sort_by == SortByHelper::SORT_BY_CREATED_AT %>
                     <th id="created" scope="col" class="govuk-table__header">Created</th>
                   <% else %>
                     <th id="updated" scope="col" class="govuk-table__header">Updated</th>
@@ -50,7 +50,7 @@
                     <th class="govuk-visually-hidden">&nbsp;</th>
                     <th scope="col" class="govuk-table__header">Case number</th>
                     <th scope="col" class="govuk-table__header">Case owner</th>
-                    <% if @search.sort_by == SortByHelper::SORT_BY_NEWEST %>
+                    <% if @search.sort_by == SortByHelper::SORT_BY_CREATED_AT %>
                       <th scope="col" class="govuk-table__header">Created</th>
                     <% else %>
                       <th scope="col" class="govuk-table__header">Updated</th>

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       context "when more than 11 cases" do
         before do
-          11.times { create(:allegation, creator: user) }
+          create_list(:allegation, 11, creator: user)
           Investigation.import refresh: true, force: true
         end
 
@@ -98,7 +98,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       context "when more than 11 cases" do
         before do
-          11.times { create(:allegation, creator: other_user_same_team) }
+          create_list(:allegation, 11, creator: other_user_same_team)
           Investigation.import refresh: true, force: true
         end
 
@@ -132,7 +132,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       context "when more than 11 cases" do
         before do
-          11.times { create(:allegation) }
+          create_list(:allegation, 11)
           Investigation.import refresh: true, force: true
         end
 

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -52,11 +52,32 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
     end
 
     context "when the user is on the your cases page" do
-      it "shows cases that are owned by the user" do
+      before do
         click_on "Your cases"
+      end
+
+      it "shows cases that are owned by the user" do
         expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
+      end
+
+      context "when less than 12 cases" do
+        it "does not show the sort filter drop down" do
+          expect(page).not_to have_css("form dl.opss-dl-select dd")
+        end
+      end
+
+      context "when more than 11 cases" do
+        before do
+          11.times { create(:allegation, creator: user) }
+          Investigation.import refresh: true, force: true
+        end
+
+        it "does show the sort filter drop down" do
+          visit "/cases/your-cases"
+          expect(page).to have_css("form dl.opss-dl-select dd")
+        end
       end
     end
 
@@ -67,6 +88,24 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         expect(page).to have_selector("td.govuk-table__cell", text: user_case.pretty_id)
         expect(page).to have_selector("td.govuk-table__cell", text: team_case.pretty_id)
         expect(page).not_to have_selector("td.govuk-table__cell", text: other_case.pretty_id)
+      end
+
+      context "when less than 12 cases" do
+        it "does not show the sort filter drop down" do
+          expect(page).not_to have_css("form dl.opss-dl-select dd")
+        end
+      end
+
+      context "when more than 11 cases" do
+        before do
+          11.times { create(:allegation, creator: other_user_same_team) }
+          Investigation.import refresh: true, force: true
+        end
+
+        it "does show the sort filter drop down" do
+          visit "/cases/team-cases"
+          expect(page).to have_css("form dl.opss-dl-select dd")
+        end
       end
     end
 
@@ -83,6 +122,24 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
       it "highlights the all cases tab" do
         expect(highlighted_tab).to eq "All cases - Search"
+      end
+
+      context "when less than 12 cases" do
+        it "does not show the sort filter drop down" do
+          expect(page).not_to have_css("form dl.opss-dl-select dd")
+        end
+      end
+
+      context "when more than 11 cases" do
+        before do
+          11.times { create(:allegation) }
+          Investigation.import refresh: true, force: true
+        end
+
+        it "does show the sort filter drop down" do
+          visit "/cases/all-cases"
+          expect(page).to have_css("form dl.opss-dl-select dd")
+        end
       end
     end
   end

--- a/spec/features/cases_navigation_spec.rb
+++ b/spec/features/cases_navigation_spec.rb
@@ -74,9 +74,9 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
           Investigation.import refresh: true, force: true
         end
 
-        it "does show the sort filter drop down" do
+        it "does show the sort filter drop down with 'newest cases' sorting option selected" do
           visit "/cases/your-cases"
-          expect(page).to have_css("form dl.opss-dl-select dd")
+          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases")
         end
       end
     end
@@ -102,9 +102,9 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
           Investigation.import refresh: true, force: true
         end
 
-        it "does show the sort filter drop down" do
+        it "does show the sort filter drop down with 'newest cases' sorting option selected" do
           visit "/cases/team-cases"
-          expect(page).to have_css("form dl.opss-dl-select dd")
+          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases")
         end
       end
     end
@@ -136,9 +136,9 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
           Investigation.import refresh: true, force: true
         end
 
-        it "does show the sort filter drop down" do
+        it "does show the sort filter drop down with 'recent cases' sorting option selected" do
           visit "/cases/all-cases"
-          expect(page).to have_css("form dl.opss-dl-select dd")
+          expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Recent updates")
         end
       end
     end

--- a/spec/features/investigations_spec.rb
+++ b/spec/features/investigations_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Investigation listing", :with_opensearch, :with_stubbed_mailer, t
     within("form#cases-search-form dl.opss-dl-select") do
       click_on "Oldest updates"
     end
-    expect(page).to have_current_path(/sort_by=oldest/, ignore_query: false)
+    expect(page).to have_current_path(/sort_by=updated_at&sort_dir=asc/, ignore_query: false)
 
     expect(page.find("select#sort_by option", text: "Oldest updates")).to be_selected
     expect(page).to have_css("form#cases-search-form dl.opss-dl-select dd", text: "Active: Oldest updates")

--- a/spec/models/search_params_spec.rb
+++ b/spec/models/search_params_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SearchParams do
     context "when there is no search query present" do
       describe "selected_sort_by" do
         it "returns recent" do
-          expect(model_instance.selected_sort_by).to eq(SortByHelper::SORT_BY_RECENT)
+          expect(model_instance.selected_sort_by).to eq(SortByHelper::SORT_BY_UPDATED_AT)
         end
       end
 

--- a/spec/models/search_params_spec.rb
+++ b/spec/models/search_params_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SearchParams do
 
       describe "sorting_params" do
         it "returns updated_at descending" do
-          expect(model_instance.sorting_params).to eq({ updated_at: "desc" })
+          expect(model_instance.sorting_params).to eq({ "updated_at" => "desc" })
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/hxKa7Fov/1309-separate-out-sorting-option

## Description
- Add new sorting option "Oldest cases" as an option on investigation pages.
- Show sorting drop down on "Your cases" and "Team cases" when there is more than 11 cases.
- Refactor sorting logic

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
