### PR TITLE
Rename psd_admin role for clarity and to avoid confusion with team_admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,8 +84,8 @@ class User < ApplicationRecord
     super.to_s
   end
 
-  def is_psd_admin?
-    has_role? :psd_admin
+  def all_data_exporter?
+    has_role? :all_data_exporter
   end
 
   def notifying_country_editor?

--- a/app/policies/business_policy.rb
+++ b/app/policies/business_policy.rb
@@ -1,5 +1,5 @@
 class BusinessPolicy < ApplicationPolicy
   def export?
-    user.is_psd_admin?
+    user.all_data_exporter?
   end
 end

--- a/app/policies/investigation_policy.rb
+++ b/app/policies/investigation_policy.rb
@@ -48,7 +48,7 @@ class InvestigationPolicy < ApplicationPolicy
   end
 
   def export?
-    user.is_psd_admin?
+    user.all_data_exporter?
   end
 
   def risk_level_validation?

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -1,6 +1,6 @@
 class ProductPolicy < ApplicationPolicy
   def export?
-    user.is_psd_admin?
+    user.all_data_exporter?
   end
 
   def update?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -693,7 +693,7 @@ if run_seeds
 
   operational_support_unit = Team.find_by(name: "OPSS Operational support unit")
   User.where(team_id: operational_support_unit.id).each do |u|
-    u.roles.create!(name: "psd_admin")
+    u.roles.create!(name: "all_data_exporter")
     u.roles.create!(name: "risk_level_validator")
   end
 

--- a/doc/roles.md
+++ b/doc/roles.md
@@ -12,7 +12,7 @@ The available role names and their meanings are described below:
 |---------|-------|
 |`team_admin`|One or more members of each team should ordinarily have this role, which allows them to send and re-send invitations to new users to create an account on the Product Safety Database as a member of their team, or to remove users from their team.|
 |`opss`|Normally set at the team level for OPSS teams and alters certain presentation and navigation elements accordingly.|
-|`psd_admin`|Allows the user to export data from case, business and product listings in spreadsheet format. Restricted to specific OPSS teams.|
+|`all_data_exporter`|Allows the user to export data from all case, business and product listings in spreadsheet format. Includes cases which the user would not ordinarily have access to. Restricted to specific OPSS teams.|
 |`notifying_country_editor`|Allows the user to edit the notifying country of any case on the Product Safety Database.  Restricted to specific OPSS teams.|
 |`risk_level_validator`|Allows the user to mark the risk level of any case on the Product Safety Database as 'validated'. Restricted to specific OPSS teams.|
 |`email_alert_sender`|Allows the user to send an e-mail product safety alert to all users of the Product Safety Database. Restricted to specific OPSS teams.|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -69,9 +69,9 @@ FactoryBot.define do
       end
     end
 
-    trait :psd_admin do
+    trait :all_data_exporter do
       transient do
-        roles { %i[psd_admin] }
+        roles { %i[all_data_exporter] }
       end
     end
 

--- a/spec/features/export_businesses_spec.rb
+++ b/spec/features/export_businesses_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.feature "Business export", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
-  let(:user) { create :user, :psd_admin, :activated }
+  let(:user) { create :user, :all_data_exporter, :activated }
   let(:email) { delivered_emails.last }
   let(:export) { BusinessExport.find_by(user:) }
   let(:spreadsheet) do

--- a/spec/features/export_cases_spec.rb
+++ b/spec/features/export_cases_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.feature "Case export", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
-  let(:user) { create :user, :psd_admin, :activated }
+  let(:user) { create :user, :all_data_exporter, :activated }
   let(:other_user_same_team) { create :user, :activated, team: user.team, organisation: user.organisation }
   let(:other_user) { create :user, :activated }
   let(:email) { delivered_emails.last }

--- a/spec/features/export_products_spec.rb
+++ b/spec/features/export_products_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.feature "Product export", :with_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, :with_stubbed_notify, type: :feature do
-  let(:user) { create :user, :psd_admin, :activated }
+  let(:user) { create :user, :all_data_exporter, :activated }
   let(:email) { delivered_emails.last }
   let(:export) { ProductExport.find_by(user:) }
   let(:spreadsheet) do

--- a/spec/policies/business_policy_spec.rb
+++ b/spec/policies/business_policy_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe BusinessPolicy do
   let(:user) { create(:user) }
 
   describe "#export?" do
-    context "when the user has the psd_admin role" do
-      before { user.roles.create!(name: "psd_admin") }
+    context "when the user has the all_data_exporter role" do
+      before { user.roles.create!(name: "all_data_exporter") }
 
       it "returns true" do
         expect(policy).to be_export
       end
     end
 
-    context "when the user does not have the psd_admin role" do
+    context "when the user does not have the all_data_exporter role" do
       it "returns false" do
         expect(policy).not_to be_export
       end

--- a/spec/policies/product_policy_spec.rb
+++ b/spec/policies/product_policy_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe ProductPolicy do
   let(:user) { create(:user) }
 
   describe "#export?" do
-    context "when the user has the psd_admin role" do
-      before { user.roles.create!(name: "psd_admin") }
+    context "when the user has the all_data_exporter role" do
+      before { user.roles.create!(name: "all_data_exporter") }
 
       it "returns true" do
         expect(policy).to be_export
       end
     end
 
-    context "when the user does not have the psd_admin role" do
+    context "when the user does not have the all_data_exporter role" do
       it "returns false" do
         expect(policy).not_to be_export
       end

--- a/spec/requests/export_cases_spec.rb
+++ b/spec/requests/export_cases_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "Export cases as XLSX file", :with_opensearch, :with_stubbed_noti
     end
   end
 
-  context "when logged in as a user with the psd_admin role" do
-    let(:user) { create(:user, :activated, :psd_admin, :viewed_introduction) }
+  context "when logged in as a user with the all_data_exporter role" do
+    let(:user) { create(:user, :activated, :all_data_exporter, :viewed_introduction) }
 
     context "when generating a case export" do
       it "allows user to generate a case export and redirects back to cases page" do

--- a/spec/requests/export_products_spec.rb
+++ b/spec/requests/export_products_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Export products as XLSX file", :with_opensearch, :with_stubbed_n
       end
     end
 
-    context "when logged in as a user with the psd_admin role" do
-      let(:user) { create(:user, :activated, :psd_admin, :viewed_introduction) }
+    context "when logged in as a user with the all_data_exporter role" do
+      let(:user) { create(:user, :activated, :all_data_exporter, :viewed_introduction) }
 
       context "when generating a product export" do
         it "allows user to generate a product export and redirects back to products page" do


### PR DESCRIPTION
https://trello.com/c/NW3AzThS/1334-rename-psdadmin-role

## Description
Renames the `psd_admin` role in line with the established naming convention to provide more clarity as to what it does, and more distinction between it and the other `team_admin` role.
