### PR TITLE
Cases sorting bug

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,7 +3,6 @@ class SearchesController < ApplicationController
 
   def show
     @search = SearchParams.new(query_params.except(:page_name))
-
     if @search.q.blank?
       redirect_to investigations_path(query_params.except(:page_name))
     else

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -8,7 +8,7 @@
     <section class="govuk-grid-column-three-quarters" id="page-content">
       <div class="govuk-grid-row">
         <%= render 'investigations/search_bar', form: form %>
-        <%= render_sort_by form, @search.sort_by_items(with_relevant_option: true), @search.selected_sort_by %>
+        <%= render_sort_by form, @search.sort_by_items(with_relevant_option: true), @search.selected_sort_by, @search.sort_dir %>
       </div>
       <div class="govuk-grid-row">
         <%= search_result_statement(@search.q, @answer.results.total_count) %>

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -506,5 +506,42 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
         expect(page).to list_cases_in_order(cases.map(&:pretty_id))
       end
     end
+
+    context "after searching" do
+      before do
+        fill_in "Search", with: "xyz"
+        click_button "Submit search"
+      end
+
+      it "is initially sorted by relevant" do
+        expect(page).to have_content "Sort the results by Relevance"
+      end
+
+      it "allows user to sort by other options" do
+        within "form dl.govuk-list.opss-dl-select" do
+          click_on "Oldest cases"
+        end
+
+        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Oldest cases")
+
+        within "form dl.govuk-list.opss-dl-select" do
+          click_on "Newest cases"
+        end
+
+        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Newest cases")
+
+        within "form dl.govuk-list.opss-dl-select" do
+          click_on "Oldest updates"
+        end
+
+        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Oldest updates")
+
+        within "form dl.govuk-list.opss-dl-select" do
+          click_on "Recent updates"
+        end
+
+        expect(page).to have_css("form dl.opss-dl-select dd", text: "Active: Recent updates")
+      end
+    end
   end
 end

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -507,7 +507,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
       end
     end
 
-    context "after searching" do
+    context "when user has searched" do
       before do
         fill_in "Search", with: "xyz"
         click_button "Submit search"


### PR DESCRIPTION
https://trello.com/c/bGIuVXGf/1360-issue-on-prod-sort-by-defaults-to-oldest-cases-updates-on-the-cases-search-result-page

## Description
Bugfix on the cases page. Fixes an issue which caused sorting options to not persist after a user had searched for a case.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
