### PR TITLE
Redact data on restricted cases export unless user has access to it

### DIFF
--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -126,7 +126,7 @@ private
   end
 
   def serialize_case(investigation, team)
-    restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_private?
+    restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_private
 
     restrict_info ? restricted_data(investigation) : non_restricted_data(investigation)
   end

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -126,7 +126,7 @@ private
   end
 
   def serialize_case(investigation, team)
-    restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_closed?
+    restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_private?
 
     restrict_info ? restricted_data(investigation) : non_restricted_data(investigation)
   end

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -114,7 +114,7 @@ private
   end
 
   def serialize_case(investigation, team)
-    restrict_info?(team, investigation) ? restricted_data(investigation) : non_restricted_data(investigation)
+    Pundit.policy!(user, investigation).view_protected_details?(user: user) ? non_restricted_data(investigation) : restricted_data(investigation)
   end
 
   def non_restricted_data(investigation)

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -113,18 +113,6 @@ private
         .find(ids)
   end
 
-  def title(investigation, current_user_is_on_creator_team)
-    current_user_is_on_creator_team ? investigation.title : "Restricted"
-  end
-
-  def decription(investigation, current_users_team_id)
-    current_user_is_on_creator_team ? investigation.description : "Restricted"
-  end
-
-  def case_owner_user(investigation, current_users_team_id)
-    current_user_is_on_creator_team ? investigation.owner_user&.name : "Restricted"
-  end
-
   def serialize_case(investigation, team)
     restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_private
 

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -33,7 +33,7 @@ class CaseExport < ApplicationRecord
 
     case_ids.each_slice(FIND_IN_BATCH_SIZE) do |batch_case_ids|
       find_cases(batch_case_ids).each do |investigation|
-        sheet.add_row(serialize_case(investigation.decorate, user.team), types: :text)
+        sheet.add_row(serialize_case(investigation.decorate), types: :text)
       end
     end
 

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -113,8 +113,8 @@ private
         .find(ids)
   end
 
-  def serialize_case(investigation, team)
-    Pundit.policy!(user, investigation).view_protected_details?(user: user) ? non_restricted_data(investigation) : restricted_data(investigation)
+  def serialize_case(investigation)
+    Pundit.policy!(user, investigation).view_protected_details?(user:) ? non_restricted_data(investigation) : restricted_data(investigation)
   end
 
   def non_restricted_data(investigation)

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -178,12 +178,4 @@ private
       investigation.reported_reason
     ]
   end
-
-  def restrict_info?(team, investigation)
-    !current_user_is_on_owner_team?(team, investigation) && investigation.is_private
-  end
-
-  def current_user_is_on_owner_team?(team, investigation)
-    investigation.owner_team == team
-  end
 end

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -114,9 +114,7 @@ private
   end
 
   def serialize_case(investigation, team)
-    restrict_info = !current_user_is_on_owner_team?(team, investigation) && investigation.is_private
-
-    restrict_info ? restricted_data(investigation) : non_restricted_data(investigation)
+    restrict_info?(team, investigation) ? restricted_data(investigation) : non_restricted_data(investigation)
   end
 
   def non_restricted_data(investigation)
@@ -179,6 +177,10 @@ private
       country_from_code(investigation.notifying_country, Country.notifying_countries),
       investigation.reported_reason
     ]
+  end
+
+  def restrict_info?(team, investigation)
+    !current_user_is_on_owner_team?(team, investigation) && investigation.is_private
   end
 
   def current_user_is_on_owner_team?(team, investigation)

--- a/app/models/case_export.rb
+++ b/app/models/case_export.rb
@@ -114,7 +114,7 @@ private
   end
 
   def serialize_case(investigation)
-    Pundit.policy!(user, investigation).view_protected_details?(user:) ? non_restricted_data(investigation) : restricted_data(investigation)
+    Pundit.policy!(user, investigation).view_protected_details?(user:) || !investigation.is_private? ? non_restricted_data(investigation) : restricted_data(investigation)
   end
 
   def non_restricted_data(investigation)

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
   let!(:user) { create(:user, :activated, organisation:, team:, has_viewed_introduction: true) }
   let!(:other_user_other_team) { create(:user, :activated, name: "other user same team", organisation:, team: other_team) }
   let!(:investigation) { create(:allegation, creator: user).decorate }
-  let!(:other_team_investigation) { create(:allegation, creator: other_user_other_team).decorate }
+  let!(:other_team_investigation) { create(:allegation, creator: other_user_other_team, is_private: true).decorate }
   let(:params) { { case_type: "all", sort_by: "recent", created_by: "all", case_status: "open", teams_with_access: "all" } }
   let(:case_export) { described_class.create!(user:, params:) }
 
@@ -50,7 +50,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 5)).to eq "Description"
       expect(sheet.cell(2, 5)).to eq investigation.object.description
-      expect(sheet.cell(3, 5)).to eq other_team_investigation.object.description
+      expect(sheet.cell(3, 5)).to eq "Restricted"
 
       expect(sheet.cell(1, 6)).to eq "Product_Category"
       expect(sheet.cell(2, 6)).to eq investigation.categories.presence&.join(", ")
@@ -74,7 +74,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 11)).to eq "Case_Owner_User"
       expect(sheet.cell(2, 11)).to eq investigation.owner_user&.name
-      expect(sheet.cell(3, 11)).to eq other_team_investigation.owner_user&.name
+      expect(sheet.cell(3, 11)).to eq "Restricted"
 
       expect(sheet.cell(1, 12)).to eq "Source_Type"
       expect(sheet.cell(2, 12)).to eq investigation.complainant&.complainant_type

--- a/spec/models/case_export_spec.rb
+++ b/spec/models/case_export_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed_mailer, :with_stubbed_antivirus do
   let!(:organisation) { create(:organisation) }
   let!(:team) { create(:team, organisation:) }
+  let!(:other_team) { create(:team, organisation:) }
   let!(:user) { create(:user, :activated, organisation:, team:, has_viewed_introduction: true) }
-  let!(:other_user_same_team) { create(:user, :activated, name: "other user same team", organisation:, team:) }
+  let!(:other_user_other_team) { create(:user, :activated, name: "other user same team", organisation:, team: other_team) }
   let!(:investigation) { create(:allegation, creator: user).decorate }
-  let!(:other_user_investigation) { create(:allegation, creator: other_user_same_team).decorate }
+  let!(:other_team_investigation) { create(:allegation, creator: other_user_other_team).decorate }
   let(:params) { { case_type: "all", sort_by: "recent", created_by: "all", case_status: "open", teams_with_access: "all" } }
   let(:case_export) { described_class.create!(user:, params:) }
 
@@ -33,51 +34,51 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 1)).to eq "ID"
       expect(sheet.cell(2, 1)).to eq investigation.pretty_id
-      expect(sheet.cell(3, 1)).to eq other_user_investigation.pretty_id
+      expect(sheet.cell(3, 1)).to eq other_team_investigation.pretty_id
 
       expect(sheet.cell(1, 2)).to eq "Status"
       expect(sheet.cell(2, 2)).to eq(investigation.is_closed? ? "Closed" : "Open")
-      expect(sheet.cell(3, 2)).to eq(other_user_investigation.is_closed? ? "Closed" : "Open")
+      expect(sheet.cell(3, 2)).to eq(other_team_investigation.is_closed? ? "Closed" : "Open")
 
       expect(sheet.cell(1, 3)).to eq "Title"
       expect(sheet.cell(2, 3)).to eq investigation.title
-      expect(sheet.cell(3, 3)).to eq other_user_investigation.title
+      expect(sheet.cell(3, 3)).to eq "Restricted"
 
       expect(sheet.cell(1, 4)).to eq "Type"
       expect(sheet.cell(2, 4)).to eq investigation.type
-      expect(sheet.cell(3, 4)).to eq other_user_investigation.type
+      expect(sheet.cell(3, 4)).to eq other_team_investigation.type
 
       expect(sheet.cell(1, 5)).to eq "Description"
       expect(sheet.cell(2, 5)).to eq investigation.object.description
-      expect(sheet.cell(3, 5)).to eq other_user_investigation.object.description
+      expect(sheet.cell(3, 5)).to eq other_team_investigation.object.description
 
       expect(sheet.cell(1, 6)).to eq "Product_Category"
       expect(sheet.cell(2, 6)).to eq investigation.categories.presence&.join(", ")
-      expect(sheet.cell(3, 6)).to eq other_user_investigation.categories.presence&.join(", ")
+      expect(sheet.cell(3, 6)).to eq other_team_investigation.categories.presence&.join(", ")
 
       expect(sheet.cell(1, 7)).to eq "Hazard_Type"
       expect(sheet.cell(2, 7)).to eq investigation.hazard_type
-      expect(sheet.cell(3, 7)).to eq other_user_investigation.hazard_type
+      expect(sheet.cell(3, 7)).to eq other_team_investigation.hazard_type
 
       expect(sheet.cell(1, 8)).to eq "Coronavirus_Related"
       expect(sheet.cell(2, 8)).to eq investigation.coronavirus_related?.to_s
-      expect(sheet.cell(3, 8)).to eq other_user_investigation.coronavirus_related?.to_s
+      expect(sheet.cell(3, 8)).to eq other_team_investigation.coronavirus_related?.to_s
 
       expect(sheet.cell(1, 9)).to eq "Risk_Level"
       expect(sheet.cell(2, 9)).to eq investigation.decorate.risk_level_description
-      expect(sheet.cell(3, 9)).to eq other_user_investigation.decorate.risk_level_description
+      expect(sheet.cell(3, 9)).to eq other_team_investigation.decorate.risk_level_description
 
       expect(sheet.cell(1, 10)).to eq "Case_Owner_Team"
       expect(sheet.cell(2, 10)).to eq investigation.owner_team&.name
-      expect(sheet.cell(3, 10)).to eq other_user_investigation.owner_team&.name
+      expect(sheet.cell(3, 10)).to eq other_team_investigation.owner_team&.name
 
       expect(sheet.cell(1, 11)).to eq "Case_Owner_User"
       expect(sheet.cell(2, 11)).to eq investigation.owner_user&.name
-      expect(sheet.cell(3, 11)).to eq other_user_investigation.owner_user&.name
+      expect(sheet.cell(3, 11)).to eq other_team_investigation.owner_user&.name
 
       expect(sheet.cell(1, 12)).to eq "Source_Type"
       expect(sheet.cell(2, 12)).to eq investigation.complainant&.complainant_type
-      expect(sheet.cell(3, 12)).to eq other_user_investigation.complainant&.complainant_type
+      expect(sheet.cell(3, 12)).to eq other_team_investigation.complainant&.complainant_type
 
       # TODO: This will be flaky if Faker generates two dupes
       expect(sheet.cell(1, 13)).to eq "Products"
@@ -110,23 +111,23 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 20)).to eq "Date_Created"
       expect(sheet.cell(2, 20)).to eq investigation.created_at&.to_s
-      expect(sheet.cell(3, 20)).to eq other_user_investigation.created_at&.to_s
+      expect(sheet.cell(3, 20)).to eq other_team_investigation.created_at&.to_s
 
       expect(sheet.cell(1, 21)).to eq "Last_Updated"
       expect(sheet.cell(2, 21)).to eq investigation.updated_at&.to_s
-      expect(sheet.cell(3, 21)).to eq other_user_investigation.updated_at&.to_s
+      expect(sheet.cell(3, 21)).to eq other_team_investigation.updated_at&.to_s
 
       expect(sheet.cell(1, 22)).to eq "Date_Closed"
       expect(sheet.cell(2, 22)).to eq investigation.date_closed&.to_s
-      expect(sheet.cell(3, 22)).to eq other_user_investigation.date_closed&.to_s
+      expect(sheet.cell(3, 22)).to eq other_team_investigation.date_closed&.to_s
 
       expect(sheet.cell(1, 23)).to eq "Date_Validated"
       expect(sheet.cell(2, 23)).to eq investigation.risk_validated_at&.to_s
-      expect(sheet.cell(3, 23)).to eq other_user_investigation.risk_validated_at&.to_s
+      expect(sheet.cell(3, 23)).to eq other_team_investigation.risk_validated_at&.to_s
 
       expect(sheet.cell(1, 24)).to eq "Case_Creator_Team"
       expect(sheet.cell(2, 24)).to eq investigation.creator_user&.team&.name
-      expect(sheet.cell(3, 24)).to eq other_user_investigation.creator_user&.team&.name
+      expect(sheet.cell(3, 24)).to eq other_team_investigation.creator_user&.team&.name
 
       expect(sheet.cell(1, 25)).to eq "Notifying_Country"
       expect(sheet.cell(2, 25)).to eq "England"
@@ -134,7 +135,7 @@ RSpec.describe CaseExport, :with_opensearch, :with_stubbed_notify, :with_stubbed
 
       expect(sheet.cell(1, 26)).to eq "Reported_as"
       expect(sheet.cell(2, 26)).to eq investigation.reported_reason
-      expect(sheet.cell(3, 26)).to eq other_user_investigation.reported_reason
+      expect(sheet.cell(3, 26)).to eq other_team_investigation.reported_reason
     end
     # rubocop:enable RSpec/MultipleExpectations
     # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
https://trello.com/c/JRrGkReH/1362-spike-investigate-how-to-implement-alldataexporter-role-restrictions-based-on-team

## Description
Redact information from the case export if the case is restricted and the current user is not on the team that owns the case.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
