### PR TITLE
Allow redaction and exporting of custom tables

### DIFF
--- a/config/initializers/redacted_export.rb
+++ b/config/initializers/redacted_export.rb
@@ -8,21 +8,38 @@ end
 
 # NOTE: Application models can define fields which will form part of a 'redacted' export:
 #     redacted_export_with :id, :created_at, :updated_at
-# NOTE: Rails internal or gem model fields added to the registry below.
 
-ActiveSupport.on_load(:active_storage) do
-  RedactedExport.register_model_attributes(
-    ActiveStorage::Attachment,
-    :id, :blob_id, :created_at, :name, :record_id, :record_type
-  )
+# NOTE: Rails internal or gem model fields can be added to the registry like this:
+# ActiveSupport.on_load(:active_storage) do
+#   RedactedExport.register_model_attributes(
+#     ActiveStorage::Attachment,
+#     :id, :blob_id, :created_at, :name, :record_id, :record_type
+#   )
+# end
 
-  RedactedExport.register_model_attributes(
-    ActiveStorage::Blob,
-    :id, :byte_size, :checksum, :content_type, :created_at, :filename, :service_name
-  )
+# NOTE: Known or non-model tables can be redacted and exported like this:
 
-  RedactedExport.register_model_attributes(
-    ActiveStorage::VariantRecord,
-    :id, :blob_id
-  )
-end
+RedactedExport.register_table_attributes(
+  "active_storage_attachments",
+  :id, :blob_id, :created_at, :name, :record_id, :record_type
+)
+
+RedactedExport.register_table_attributes(
+  "active_storage_blobs",
+  :id, :byte_size, :checksum, :content_type, :created_at, :filename, :service_name
+)
+
+RedactedExport.register_table_attributes(
+  "active_storage_variant_records",
+  :id, :blob_id
+)
+
+RedactedExport.register_table_attributes(
+  "investigation_businesses",
+  :business_id, :created_at, :investigation_id, :relationship, :updated_at
+)
+
+RedactedExport.register_table_attributes(
+  "investigation_products",
+  :created_at, :investigation_id, :product_id, :updated_at
+)

--- a/lib/redacted_export.rb
+++ b/lib/redacted_export.rb
@@ -47,7 +47,7 @@ module RedactedExport
         DROP SCHEMA IF EXISTS redacted CASCADE; CREATE SCHEMA redacted;
 
       SQL_OUTPUT
-      self.sort.each do |table, attributes|
+      sort.each do |table, attributes|
         io.puts <<~SQL_OUTPUT
           CREATE TABLE redacted.#{table} AS (SELECT #{attributes.join ', '} FROM public.#{table});
 

--- a/lib/redacted_export.rb
+++ b/lib/redacted_export.rb
@@ -14,12 +14,51 @@ module RedactedExport
   end
 
   def self.registry
-    @registry ||= {}
+    @registry ||= Registry.new
   end
 
   def self.register_model_attributes(model, *attributes)
-    registry[model] ||= []
-    registry[model].concat attributes
-    registry[model].uniq!
+    registry.register_model_attributes(model, *attributes)
+  end
+
+  def self.register_table_attributes(table, *attributes)
+    registry.register_table_attributes(table, *attributes)
+  end
+
+  class Registry < Hash
+    def register_model_attributes(model, *attributes)
+      register_table_attributes(model.table_name, *attributes)
+    end
+
+    def register_table_attributes(table, *attributes)
+      self[table] ||= []
+      self[table].concat attributes
+      self[table].uniq!
+    end
+
+    def to_sql
+      io = StringIO.new
+      io.puts <<~SQL_OUTPUT
+        --
+        -- Redacted export generation SQL
+        -- #{Time.zone.now}
+        --
+
+        DROP SCHEMA IF EXISTS redacted CASCADE; CREATE SCHEMA redacted;
+
+      SQL_OUTPUT
+      self.sort.each do |table, attributes|
+        io.puts <<~SQL_OUTPUT
+          CREATE TABLE redacted.#{table} AS (SELECT #{attributes.join ', '} FROM public.#{table});
+
+        SQL_OUTPUT
+      end
+      io.puts <<~SQL_OUTPUT
+        --
+        -- Redacted export generation SQL complete
+        --
+      SQL_OUTPUT
+      io.string
+    end
   end
 end

--- a/lib/tasks/redacted_export.rake
+++ b/lib/tasks/redacted_export.rake
@@ -1,32 +1,8 @@
 namespace :redacted_export do
   desc "Emit SQL which will generate the redacted export tables"
   task generate_sql: %i[environment] do
-    puts <<~SQL_OUTPUT
-      --
-      -- Redacted export generation SQL
-      -- #{Time.zone.now}
-      --
-
-      DROP SCHEMA IF EXISTS redacted CASCADE; CREATE SCHEMA redacted;
-
-    SQL_OUTPUT
-
     Rails.application.eager_load!
-    RedactedExport.registry.each do |model, attributes|
-      puts <<~SQL_OUTPUT
-        --
-        -- #{model.name}
-        --
-        CREATE TABLE redacted.#{model.table_name} AS (SELECT #{attributes.join ', '} FROM public.#{model.table_name});
-
-      SQL_OUTPUT
-    end
-
-    puts <<~SQL_OUTPUT
-      --
-      -- Redacted export generation SQL complete
-      --
-    SQL_OUTPUT
+    puts RedactedExport.registry.to_sql
   end
 
   desc "Batch-copy appropriate S3 objects to the export bucket"

--- a/spec/lib/redacted_export_spec.rb
+++ b/spec/lib/redacted_export_spec.rb
@@ -2,58 +2,105 @@ require "rails_helper"
 
 RSpec.describe RedactedExport do
   describe ".register_model_attributes" do
-    let(:model) { Class.new }
+    let(:table_name) { "test_models" }
+    let(:model) { OpenStruct.new(table_name:) }
     let(:attributes) { %i[id updated_at created_at] }
 
     after do
-      described_class.registry.delete model
+      described_class.registry.delete table_name
     end
 
     it "adds attributes into the registry" do
       described_class.register_model_attributes model, *attributes
-      expect(described_class.registry[model]).to eq(attributes)
+      expect(described_class.registry[table_name]).to eq(attributes)
     end
 
     it "merges attributes in multiple calls" do
       described_class.register_model_attributes model, *attributes
       described_class.register_model_attributes model, :name, :location
-      expect(described_class.registry[model]).to eq(attributes + %i[name location])
+      expect(described_class.registry[table_name]).to eq(attributes + %i[name location])
     end
 
     it "deduplicates attributes" do
       duplicate_attributes = attributes + attributes + [:id]
       described_class.register_model_attributes model, *duplicate_attributes
-      expect(described_class.registry[model]).to eq(attributes)
+      expect(described_class.registry[table_name]).to eq(attributes)
+    end
+  end
+
+  describe ".register_table_attributes" do
+    let(:table_name) { "test_models" }
+    let(:attributes) { %i[id updated_at created_at] }
+
+    after do
+      described_class.registry.delete table_name
+    end
+
+    it "adds attributes into the registry" do
+      described_class.register_table_attributes table_name, *attributes
+      expect(described_class.registry[table_name]).to eq(attributes)
+    end
+
+    it "merges attributes in multiple calls" do
+      described_class.register_table_attributes table_name, *attributes
+      described_class.register_table_attributes table_name, :name, :location
+      expect(described_class.registry[table_name]).to eq(attributes + %i[name location])
+    end
+
+    it "deduplicates attributes" do
+      duplicate_attributes = attributes + attributes + [:id]
+      described_class.register_table_attributes table_name, *duplicate_attributes
+      expect(described_class.registry[table_name]).to eq(attributes)
     end
   end
 
   describe ".registry" do
-    let(:model) { Class.new }
-
-    it "returns a Hash" do
-      expect(described_class.registry).to be_a(Hash)
-    end
+    let(:table_name) { "non_existent_table" }
 
     it "returns nil for an unknown model" do
-      expect(described_class.registry[model]).to eq(nil)
+      expect(described_class.registry[table_name]).to eq(nil)
+    end
+
+    describe ".to_sql" do
+      let(:model_table_name) { "test_models" }
+      let(:model) { OpenStruct.new(table_name: model_table_name) }
+      let(:model_attributes) { %i[id updated_at created_at] }
+      let(:custom_table_name) { "test_custom" }
+      let(:custom_attributes) { %i[name description] }
+
+      before do
+        described_class.register_model_attributes model, *model_attributes
+        described_class.register_table_attributes custom_table_name, *custom_attributes
+      end
+
+      it "returns the correct SQL for models" do
+        expect(described_class.registry.to_sql).to include("CREATE TABLE redacted.#{model_table_name} AS (SELECT #{model_attributes.join(', ')} FROM public.#{model_table_name});").once
+      end
+
+      it "returns the correct SQL for custom tables" do
+        expect(described_class.registry.to_sql).to include("CREATE TABLE redacted.#{custom_table_name} AS (SELECT #{custom_attributes.join(', ')} FROM public.#{custom_table_name});").once
+      end
     end
   end
 
   context "when included and used within a class" do
-    subject(:model) do
+    subject!(:model) do
       Class.new do
+        def self.table_name() = "things"
         include RedactedExport
         redacted_export_with :test_1, :test_2, :test_3
       end
     end
 
+    let(:table_name) { "things" }
+
     after do
-      described_class.registry.delete model
+      described_class.registry.delete table_name
     end
 
     describe ".redacted_export_with" do
       it "adds the attributes into the registry" do
-        expect(described_class.registry[model]).to eq(%i[test_1 test_2 test_3])
+        expect(described_class.registry[table_name]).to eq(%i[test_1 test_2 test_3])
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/hoUloDCd/1374-change-export-code-to-provide-additional-tables-in-the-cbas-export

## Description

This PR expands the redacted database export functionality to allow custom (non-model) tables to be exported. This is useful for many-to-many join tables.

```rb
# Inside of a model:
redacted_export_with :id, :created_at, :updated_at

# Outside of a model:
RedactedExport.register_model_attributes(
  ActiveStorage::Attachment,
  :id, :blob_id, :created_at, :name, :record_id, :record_type
)
RedactedExport.register_table_attributes(
  "investigation_businesses",
  :business_id, :created_at, :investigation_id, :relationship, :updated_at
)

# To create an export SQL script:
Rails.application.eager_load!
puts RedactedExport.registry.to_sql
```

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
