### PR TITLE
Swap places of case owner and case status filters on the all cases page

### DIFF
--- a/app/helpers/search_params.rb
+++ b/app/helpers/search_params.rb
@@ -72,6 +72,6 @@ class SearchParams
 
   def uses_expanded_filter_options?
     teams_with_access != "all" || created_by != "all" ||
-      case_type != "all" || case_status != "open"
+      case_type != "all" || case_owner != "all"
   end
 end

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -11,15 +11,15 @@
 
     <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
 
-    <%= render "investigations/coronavirus_and_risk_level_radios", form: form %>
     <%= render "investigations/case_status_radios", form: form %>
+    <%= render "investigations/coronavirus_and_risk_level_radios", form: form %>
 
 
     <%= govukDetails(summaryText: "More options", classes: "opss-details--plain", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
+      <%= render "investigations/case_owner_radios", form: form %>
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>
       <%= render "investigations/case_type_radios", form: form %>
-      <%= render "investigations/case_owner_radios", form: form %>
     <% end %>
 
     <div class="govuk-button-group">

--- a/app/views/investigations/_filters.html.erb
+++ b/app/views/investigations/_filters.html.erb
@@ -12,14 +12,14 @@
     <%= govukSkipLink(text: "Skip to results", href: "#page-content") %>
 
     <%= render "investigations/coronavirus_and_risk_level_radios", form: form %>
-    <%= render "investigations/case_owner_radios", form: form %>
+    <%= render "investigations/case_status_radios", form: form %>
 
 
     <%= govukDetails(summaryText: "More options", classes: "opss-details--plain", id: "filter-details", open: search.uses_expanded_filter_options?) do %>
       <%= render "investigations/teams_with_access_radios", form: form %>
       <%= render "investigations/case_creator_radios", form: form %>
       <%= render "investigations/case_type_radios", form: form %>
-      <%= render "investigations/case_status_radios", form: form %>
+      <%= render "investigations/case_owner_radios", form: form %>
     <% end %>
 
     <div class="govuk-button-group">

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -229,8 +229,6 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
         expect(find("details#filter-details")["open"]).to eq("open")
 
-        # find("details#filter-details").click
-
         choose "Others", id: "case_owner_others"
         select other_user_same_team.name, from: "case_owner_is_someone_else_id"
         click_button "Apply"

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -136,68 +136,29 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
 
       expect(find("details#filter-details")["open"]).to eq(nil)
     end
-  end
 
-  describe "Case owner" do
-    scenario "filtering cases where the user is the owner" do
-      within_fieldset("Case owner") { choose "Me" }
-      click_button "Apply"
+    describe "Case status" do
+      scenario "filtering for both open and closed cases" do
+        within_fieldset("Case status") { choose "All" }
+        click_button "Apply"
 
-      expect(page).to have_listed_case(investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_user_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
+        expect(page).to have_listed_case(investigation.pretty_id)
+        expect(page).to have_listed_case(closed_investigation.pretty_id)
 
-      expect(find("details#filter-details")["open"]).to eq(nil)
-    end
-
-    scenario "filtering cases where the user’s team is the owner" do
-      within_fieldset("Case owner") { choose "Me and my team" }
-      click_button "Apply"
-
-      expect(page).to have_listed_case(investigation.pretty_id)
-      expect(page).to have_listed_case(other_user_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
-
-      expect(find("details#filter-details")["open"]).to eq(nil)
-    end
-
-    scenario "filtering cases where the owner is someone else" do
-      choose "Others", id: "case_owner_others"
-      click_button "Apply"
-      expect(page).not_to have_listed_case(investigation.pretty_id)
-      expect(page).to have_listed_case(other_user_investigation.pretty_id)
-      expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
-      expect(page).to have_listed_case(other_team_investigation.pretty_id)
-
-      expect(find("details#filter-details")["open"]).to eq(nil)
-    end
-
-    scenario "filtering cases where another person or team is the owner" do
-      within_fieldset("Case owner") do
-        choose "Others", id: "case_owner_others"
-        select other_team.name, from: "case_owner_is_someone_else_id"
+        expect(find("details#filter-details")["open"]).to eq(nil)
       end
-      click_button "Apply"
 
-      expect(page).not_to have_listed_case(investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_user_investigation.pretty_id)
-      expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
-      expect(page).to have_listed_case(other_team_investigation.pretty_id)
+      scenario "filtering only closed cases" do
+        within_fieldset "Case status" do
+          choose "Closed"
+        end
+        click_button "Apply"
 
-      expect(find("details#filter-details")["open"]).to eq(nil)
+        expect(page).not_to have_listed_case(investigation.pretty_id)
+        expect(page).to have_listed_case(closed_investigation.pretty_id)
 
-      choose "Others", id: "case_owner_others"
-      select other_user_same_team.name, from: "case_owner_is_someone_else_id"
-      click_button "Apply"
-
-      expect(page).not_to have_listed_case(investigation.pretty_id)
-      expect(page).to have_listed_case(other_user_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
-      expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
-
-      expect(find("details#filter-details")["open"]).to eq(nil)
+        expect(find("details#filter-details")["open"]).to eq(nil)
+      end
     end
   end
 
@@ -215,6 +176,71 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
       within_fieldset("Created by") do
         expect(page).to have_select("Person or team name", with_options: [team.name, other_team.name, another_active_user.name])
         expect(page).not_to have_select("Person or team name", with_options: [another_inactive_user.name, other_deleted_team.name])
+      end
+    end
+
+    describe "Case owner" do
+      scenario "filtering cases where the user is the owner" do
+        within_fieldset("Case owner") { choose "Me" }
+        click_button "Apply"
+
+        expect(page).to have_listed_case(investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_user_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
+
+        expect(find("details#filter-details")["open"]).to eq("open")
+      end
+
+      scenario "filtering cases where the user’s team is the owner" do
+        within_fieldset("Case owner") { choose "Me and my team" }
+        click_button "Apply"
+
+        expect(page).to have_listed_case(investigation.pretty_id)
+        expect(page).to have_listed_case(other_user_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
+
+        expect(find("details#filter-details")["open"]).to eq("open")
+      end
+
+      scenario "filtering cases where the owner is someone else" do
+        choose "Others", id: "case_owner_others"
+        click_button "Apply"
+        expect(page).not_to have_listed_case(investigation.pretty_id)
+        expect(page).to have_listed_case(other_user_investigation.pretty_id)
+        expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
+        expect(page).to have_listed_case(other_team_investigation.pretty_id)
+
+        expect(find("details#filter-details")["open"]).to eq("open")
+      end
+
+      scenario "filtering cases where another person or team is the owner" do
+        within_fieldset("Case owner") do
+          choose "Others", id: "case_owner_others"
+          select other_team.name, from: "case_owner_is_someone_else_id"
+        end
+        click_button "Apply"
+
+        expect(page).not_to have_listed_case(investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_user_investigation.pretty_id)
+        expect(page).to have_listed_case(other_user_other_team_investigation.pretty_id)
+        expect(page).to have_listed_case(other_team_investigation.pretty_id)
+
+        expect(find("details#filter-details")["open"]).to eq("open")
+
+        # find("details#filter-details").click
+
+        choose "Others", id: "case_owner_others"
+        select other_user_same_team.name, from: "case_owner_is_someone_else_id"
+        click_button "Apply"
+
+        expect(page).not_to have_listed_case(investigation.pretty_id)
+        expect(page).to have_listed_case(other_user_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_user_other_team_investigation.pretty_id)
+        expect(page).not_to have_listed_case(other_team_investigation.pretty_id)
+
+        expect(find("details#filter-details")["open"]).to eq("open")
       end
     end
 
@@ -273,7 +299,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
           expect(page).to have_listed_case(investigation.pretty_id)
           expect(page).to have_listed_case(other_user_investigation.pretty_id)
 
-          expect(find("details#filter-details")["open"]).to eq(nil)
+          expect(find("details#filter-details")["open"]).to eq("open")
         end
 
         scenario "with keywords entered" do
@@ -413,30 +439,6 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
         expect(page).to have_listed_case(investigation.pretty_id)
         expect(page).not_to have_listed_case(project.pretty_id)
         expect(page).not_to have_listed_case(enquiry.pretty_id)
-
-        expect(find("details#filter-details")["open"]).to eq("open")
-      end
-    end
-
-    describe "Case status" do
-      scenario "filtering for both open and closed cases" do
-        within_fieldset("Case status") { choose "All" }
-        click_button "Apply"
-
-        expect(page).to have_listed_case(investigation.pretty_id)
-        expect(page).to have_listed_case(closed_investigation.pretty_id)
-
-        expect(find("details#filter-details")["open"]).to eq("open")
-      end
-
-      scenario "filtering only closed cases" do
-        within_fieldset "Case status" do
-          choose "Closed"
-        end
-        click_button "Apply"
-
-        expect(page).not_to have_listed_case(investigation.pretty_id)
-        expect(page).to have_listed_case(closed_investigation.pretty_id)
 
         expect(find("details#filter-details")["open"]).to eq("open")
       end


### PR DESCRIPTION
https://trello.com/c/6wCLk0Kn/1366-change-to-case-status-filter-on-all-cases-search-page

## Description
Swap places of case owner and case status filters on the all cases page

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
