### PR TITLE
Prevent double-click/back when removing a user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,8 +58,11 @@ class UsersController < ApplicationController
     return render(:remove) if @remove_user_form.invalid?
 
     if @remove_user_form.remove == "yes"
-      DeleteUser.call!(user: @user, deleted_by: current_user)
-      redirect_to team_path(team), flash: { success: "The team member was removed" }
+      if DeleteUser.call(user: @user, deleted_by: current_user).success?
+        redirect_to team_path(team), flash: { success: "The team member was removed" }
+      else
+        redirect_to team_path(team), flash: { alert: "The team member has already been removed" }
+      end
     else
       redirect_to team_path(team)
     end

--- a/app/views/users/remove.html.erb
+++ b/app/views/users/remove.html.erb
@@ -18,7 +18,7 @@
           <%= form.govuk_radios :remove, legend: "Do you want to remove #{name} from your team?", is_page_heading: true, hint: { text: "#{name.capitalize} will no longer be able to access the Product Safety Database. Any cases assigned to or owned by this member will be re-assigned to the team. This cannot be undone." }, classes: "govuk-radios govuk-!-padding-top-3", legend_classes: "govuk-fieldset__legend--l", items: [{ text: "Yes", value: "yes", id: "yes" }, { text: "No", value: "no", id: "no" }] %>
           <%= form.hidden_field :user_id, value: @user.id %>
 
-          <%= govukButton text: "Save and continue" %>
+          <%= govukButton text: "Save and continue", preventDoubleClick: true %>
     <% end %>
   </div>
 </div>

--- a/spec/features/remove_a_user_spec.rb
+++ b/spec/features/remove_a_user_spec.rb
@@ -45,6 +45,35 @@ RSpec.feature "Removing a user", :with_stubbed_mailer, :with_stubbed_opensearch,
           end
         end
 
+        context "when an admin removes a user then clicks back" do
+          scenario "user is deleted once" do
+            visit "/teams/#{team.id}"
+            click_link "Remove"
+
+            expect(page).to have_content "Do you want to remove #{other_user.name} from your team"
+
+            choose("Yes")
+
+            click_button("Save and continue")
+
+            expect(page).to have_current_path "/teams/#{team.id}", ignore_query: true
+            expect(page).to have_content "The team member was removed"
+            expect(page).not_to have_content other_user.name
+
+            visit remove_user_path(user_id: other_user.id)
+
+            expect(page).to have_content "Do you want to remove #{other_user.name} from your team"
+
+            choose("Yes")
+
+            click_button("Save and continue")
+
+            expect(page).to have_current_path "/teams/#{team.id}", ignore_query: true
+            expect(page).to have_content "The team member has already been removed"
+            expect(page).not_to have_content other_user.name
+          end
+        end
+
         context "when admin does not select an option" do
           scenario "shows error message" do
             visit "/teams/#{team.id}"


### PR DESCRIPTION
https://trello.com/c/x0BPJvqm/1240-prevent-double-click-on-remove-user-journey-and-backlink-to-return-back-to-the-team-page

## Description

When an admin removes a user from their team, if they clicked "save and continue" twice, or if they used the browser's back button after removing a user and tried to remove them a second time, a server error was produced. This PR prevents double-click on the button, and displayes an alert to the admin if they try to remove a user whom has already been removed.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
