### PR TITLE
Fix case search statement bug

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -125,6 +125,6 @@ private
       return false unless ["all", nil].include? param_value
     end
 
-    ["open", nil].include?(params["case_status"]) && params[:q].blank?
+    params["case_status"] == "all" && params[:q].blank?
   end
 end

--- a/spec/features/filter_investigations_spec.rb
+++ b/spec/features/filter_investigations_spec.rb
@@ -456,7 +456,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
         number_of_total_cases = Investigation.count
         expect(page).to have_content("#{number_of_total_cases} cases using the current filters, were found.")
 
-        expect(find("details#filter-details")["open"]).to eq("open")
+        expect(find("details#filter-details")["open"]).to eq(nil)
       end
 
       scenario "filtering only closed cases" do
@@ -470,7 +470,7 @@ RSpec.feature "Case filtering", :with_opensearch, :with_stubbed_mailer, type: :f
         expect(page).not_to have_listed_case(investigation.pretty_id)
         expect(page).to have_listed_case(closed_investigation.pretty_id)
 
-        expect(find("details#filter-details")["open"]).to eq("open")
+        expect(find("details#filter-details")["open"]).to eq(nil)
       end
     end
   end

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -255,6 +255,11 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
 
         it "shows total number of cases" do
           visit "/cases"
+          within_fieldset "Case status" do
+            choose "Closed"
+          end
+          click_button "Apply"
+          
           expect(page).to have_content "10001 cases using the current filters, were found."
         end
       end

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -256,7 +256,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
         it "shows total number of cases" do
           visit "/cases"
           within_fieldset "Case status" do
-            choose "Closed"
+            choose "All"
           end
           click_button "Apply"
 

--- a/spec/features/search_cases_spec.rb
+++ b/spec/features/search_cases_spec.rb
@@ -259,7 +259,7 @@ RSpec.feature "Searching cases", :with_opensearch, :with_stubbed_mailer, type: :
             choose "Closed"
           end
           click_button "Apply"
-          
+
           expect(page).to have_content "10001 cases using the current filters, were found."
         end
       end


### PR DESCRIPTION
https://trello.com/c/2ZCw3ARc/1386-regression-on-prod-total-cases-count-remains-the-same-for-open-and-all-cases

## Description
Prior to this change, when showing open cases on the first visit to all_cases page in the search summary text we quoted the number of all cases rather than just open cases, this PR fixes this issue

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
