### PR TITLE
Provide a standard format for dates on the Cases and Businesses lists

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,4 +51,8 @@ module ApplicationHelper
       ]
     )
   end
+
+  def date_or_recent_time_ago(datetime)
+    24.hours.ago < datetime ? "#{time_ago_in_words(datetime)} ago" : datetime.to_s(:govuk)
+  end
 end

--- a/app/views/businesses/_table_row.html.erb
+++ b/app/views/businesses/_table_row.html.erb
@@ -3,7 +3,7 @@
     <%= link_to business.trading_name, business, class: "govuk-link govuk-link--no-visited-state" %>
   </th>
   <td class="govuk-table__cell">
-    <%= business.created_at.to_s(:govuk) %>
+    <%= date_or_recent_time_ago business.created_at %>
   </td>
   <td class="govuk-table__cell">
     <%= business.company_number %>

--- a/app/views/investigations/_full_table_body.html.erb
+++ b/app/views/investigations/_full_table_body.html.erb
@@ -29,7 +29,7 @@
       </td>
     <% else %>
       <td headers="updated <%= dom_id investigation, :item %> <%= dom_id investigation, :meta %>" class="govuk-table__cell">
-        <%= "#{time_ago_in_words(investigation.updated_at)} ago" %>
+        <%= date_or_recent_time_ago investigation.updated_at %>
       </td>
     <% end %>
   </tr>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -74,4 +74,16 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#date_or_recent_time_ago" do
+    it "returns time ago in words within the last 24 hours" do
+      expect(helper.date_or_recent_time_ago(10.minutes.ago)).to eq("10 minutes ago")
+    end
+
+    it "returns the date in GovUK format outside of the last 24 hours" do
+      travel_to Time.zone.local(2000, 1, 1, 0, 0, 0) do
+        expect(helper.date_or_recent_time_ago(25.hours.ago)).to eq("30 December 1999")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/DRZxbvAt/1380-provide-standard-format-dates-on-cases-and-businesses-pages

## Description

Changes the dates on the cases and businesses lists from "About 1 month" terminology, to standard format dates e.g. "6 April 2022", except when the time frame is within the last 24hr.

 - Your cases - updated column
 - Team cases - updated column
 - All cases - updated column
 - All businesses - added column
 - Team businesses - added column
 - All businesses - added column