### PR TITLE
Do not create indexes concurrently

### DIFF
--- a/db/migrate/20220516133518_add_index_to_active_storage_blobs.rb
+++ b/db/migrate/20220516133518_add_index_to_active_storage_blobs.rb
@@ -1,7 +1,5 @@
 class AddIndexToActiveStorageBlobs < ActiveRecord::Migration[6.1]
-  disable_ddl_transaction!
-
   def change
-    add_index :active_storage_blobs, :metadata, algorithm: :concurrently
+    safety_assured { add_index :active_storage_blobs, :metadata }
   end
 end


### PR DESCRIPTION
## Description
A previous migration is not running, causing deploys to fail because (I think) creating an index concurrently on a large table is taking too long and timing out.

This change changes the migration so that it does not run concurrently, but will need to be run outside of business hours.

We will need to roll back the previous migration before deploying this change.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
