### PR TITLE
Change migration time out

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,2 @@
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour


### PR DESCRIPTION
https://sentry.io/organizations/beis/issues/3277653425/?project=1329381&referrer=slack

## Description
A previous migration is not running, causing deploys to fail because (I think) creating an index concurrently on a large table is taking too long and timing out.

This change adds [the recommended time out settings for strong migrations](https://github.com/ankane/strong_migrations#migration-timeouts) so that we have a longer migration time out which may help us resolve the issue described above.

Note: Before deploying we may need to remove the index_active_storage_blobs_on_metadata index

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
