### PR TITLE
Correct heading in the cases pages table footer

### DIFF
--- a/app/views/investigations/index.html.erb
+++ b/app/views/investigations/index.html.erb
@@ -55,7 +55,7 @@
                   <tr class="govuk-table__row">
                     <th class="govuk-visually-hidden">&nbsp;</th>
                     <th scope="col" class="govuk-table__header">Case number</th>
-                    <th scope="col" class="govuk-table__header">Case owner</th>
+                    <th scope="col" class="govuk-table__header">Case <%= ["team_cases", "your_cases"].include?(@page_name) ? "created" : "owner" %></th>
                     <% if query_params[:sort_by] == SortByHelper::SORT_BY_CREATED_AT && ["team_cases", "your_cases"].exclude?(@page_name) %>
                       <th scope="col" class="govuk-table__header">Created</th>
                     <% else %>


### PR DESCRIPTION
https://trello.com/c/W7tJiicf/1399-on-the-cases-pages-wrong-column-label-used-in-the-table-footer

## Description

Fixes a bug in the table footer for the Cases pages. On the Cases pages: 'Your cases' and 'Team cases' in the footer of the table, the second label currently reads "Case owner" when it should read "Case created".