### PR TITLE
Add extra debug info into the Sentry context for file proxy exceptions

### DIFF
--- a/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -12,6 +12,7 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetCurrent
   include HttpAuthConcern
   include SentryConfigurationConcern
+  include SetSentryBlobContext
   include Pundit
 
   self.etag_with_template_digest = false

--- a/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/app/controllers/active_storage/representations/proxy_controller.rb
@@ -10,6 +10,7 @@ class ActiveStorage::Representations::ProxyController < ActiveStorage::BaseContr
   include ActiveStorage::SetHeaders
   include HttpAuthConcern
   include SentryConfigurationConcern
+  include SetSentryBlobContext
 
   before_action :authorize_blob
 

--- a/app/controllers/concerns/set_sentry_blob_context.rb
+++ b/app/controllers/concerns/set_sentry_blob_context.rb
@@ -1,0 +1,27 @@
+module SetSentryBlobContext
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_sentry_blob_context
+  end
+
+private
+
+  def set_sentry_blob_context
+    return unless @blob
+
+    Sentry.configure_scope do |scope|
+      scope.set_context(
+        "blob",
+        @blob.serializable_hash(
+          only: %i[id byte_size key content_type filename],
+          include: {
+            attachments: {
+              only: %i[id record_type record_id name]
+            }
+          }
+        )
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/set_sentry_blob_context.rb
+++ b/app/controllers/concerns/set_sentry_blob_context.rb
@@ -14,7 +14,7 @@ private
       scope.set_context(
         "blob",
         @blob.serializable_hash(
-          only: %i[id byte_size key content_type filename],
+          only: %i[id byte_size key content_type],
           include: {
             attachments: {
               only: %i[id record_type record_id name]


### PR DESCRIPTION
https://trello.com/c/qfVpPoij/1367-capture-exceptions-on-image-thumbnail-generation

## Description

This PR adds some helpful information to the Sentry context which can be used to debug errors with user-uploaded files (for example, trying to thumbnail a zero-byte file or an unsupported image format).

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
