### PR TITLE
Change typo in help text link

### DIFF
--- a/app/views/products/heading/_all_products.html.erb
+++ b/app/views/products/heading/_all_products.html.erb
@@ -6,7 +6,7 @@
     <p class="govuk-body opss-secondary-text">
       Search all product records in the Product Safety Database (<abbr>PSD</abbr>).
     </p>
-    <%= govukDetails(summaryText: "Help with the Products search", classes: "opss-details--sm") do %>
+    <%= govukDetails(summaryText: "Help with the products search", classes: "opss-details--sm") do %>
       <p class="govuk-body-s">
         <span id="search-hint">You can search for one or more products by using the keywords that describe them or use a single <abbr>PSD</abbr> reference number to find a specific product record.</span> You can also sort the ordering of the search results.
       </p>


### PR DESCRIPTION
https://trello.com/c/X0X16yYV/1381-cases-and-products-page-snags

## Description
Before:
![Screenshot 2022-06-10 at 11 19 15](https://user-images.githubusercontent.com/13124899/173045301-0ca902bf-238d-4a96-822b-2ad595b48ef6.png)
After:
<img width="1208" alt="Screenshot 2022-06-10 at 12 14 53" src="https://user-images.githubusercontent.com/13124899/173053496-e88d632d-a046-4c5e-bb57-eb0ec0909b82.png">
 


<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
