### PR TITLE
Remove indirect associations from ERD

### DIFF
--- a/.erdconfig
+++ b/.erdconfig
@@ -4,4 +4,5 @@ attributes:
   - timestamps
   - inheritance
   - content
-indirect: true
+indirect: false
+cluster: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.7.0)
+    rails-erd (1.7.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       choice (~> 0.2.0)
@@ -620,7 +620,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
https://trello.com/c/Hii77EO4/1419-improvements-to-the-erd

In response to feedback from users of the Entity Relationship Diagram, this PR removes indirect (dotted line) associations. These were not strictly necessary and were cluttering the diagram making it harder to follow.