### PR TITLE
Add additional legislation for corrective actions

### DIFF
--- a/config/constants/legislation_constants.yml
+++ b/config/constants/legislation_constants.yml
@@ -4,6 +4,7 @@ legislation:
   - Aerosol Dispensers Regulations 2009 (Consumer Protection Act 1987)
   - Cableway Installations Regulations 2018
   - Carriage of Dangerous Goods and Use of Transportable Pressure Equipment Regulations 2009
+  - Classification, Labelling and Packaging of Chemicals Regulations 2015
   - Construction Products Regulations 2013
   - Consumer Protection Act 1987
   - Consumer Protection Act 1987 / Motor Vehicle Tyres (Safety) Regulations 1994


### PR DESCRIPTION
https://trello.com/c/gTFsYkjt/1431-add-a-value-to-the-under-which-legislation-dropdown

This PR adds "Classification, Labelling and Packaging of Chemicals Regulations 2015" to the Corrective Action legislation options, allowing users to reference the [The Classification, Labelling and Packaging of Chemicals (Amendments to Secondary Legislation) Regulations 2015](https://www.legislation.gov.uk/uksi/2015/21/made).