### PR TITLE
Deactivate unsafe files job until we can debug issue

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,24 +24,10 @@ def create_lock_inactive_users_job
   end
 end
 
-def create_delete_unsafe_files_job
-  delete_unsafe_files_job = Sidekiq::Cron::Job.new(
-    name: "#{ENV['SIDEKIQ_QUEUE'] || 'psd'}: delete unsafe files, every 15 minutes",
-    cron: "*/15 * * * *",
-    class: "DeleteUnsafeFilesJob",
-    queue: ENV["SIDEKIQ_QUEUE"] || "psd"
-  )
-  unless delete_unsafe_files_job.save
-    Rails.logger.error "***** WARNING - Delete unsafe files job not saved *****"
-    Rails.logger.error delete_unsafe_files_job.errors.join("; ")
-  end
-end
-
 Sidekiq.configure_server do |config|
   config.redis = Rails.application.config_for(:redis_store)
   create_log_db_metrics_job
   create_lock_inactive_users_job
-  create_delete_unsafe_files_job
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
## Description
The DeleteUnsafeFiles job is not working and causing a lot of unnecessary errors to be raised, this PR stops the job from running for now until we can debug and fix it.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
