### PR TITLE
Introduce an actions section on the case overview page

### DIFF
--- a/app/helpers/investigations/display_text_helper.rb
+++ b/app/helpers/investigations/display_text_helper.rb
@@ -28,7 +28,7 @@ module Investigations::DisplayTextHelper
       {
         href: investigation_images_path(investigation),
         text: "Images",
-        count: " (#{investigation.images.size + investigation.products.flat_map(&:images).count})",
+        count: " (#{investigation.number_of_related_images})",
         active: is_current_tab.images?
       },
       {

--- a/app/models/investigation.rb
+++ b/app/models/investigation.rb
@@ -127,6 +127,10 @@ class Investigation < ApplicationRecord
       .where.not(record: [corrective_actions, correspondences, tests])
   end
 
+  def number_of_related_images
+    images.size + products.flat_map(&:images).count
+  end
+
   def generic_supporting_information_attachments
     @generic_supporting_information_attachments ||= documents
       .includes(:blob)

--- a/app/views/investigations/_actions.html.erb
+++ b/app/views/investigations/_actions.html.erb
@@ -1,0 +1,72 @@
+<% if investigation.products.size.zero? %>
+  <div class="govuk-warning-text govuk-!-display-inline-block">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      A product has not been added to this case.
+    </strong>
+  </div>
+<% end %>
+
+<section class="govuk-grid-column-full govuk-!-padding-top-3 govuk-!-padding-bottom-1 opss-desktop-padding-top-3 opss-desktop-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3 opss-border-all opss-grey-bg opss-3-col-flow opss-responsive-margin-bottom-6">
+  <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0 opss-summary-list-mixed opss-summary-list-mixed--sm">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Product&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.products.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_product_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a product</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Business&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.businesses.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_business_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a business</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Image&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.number_of_related_images %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_document_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> an image</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Accident / Incident&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.unexpected_events.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_accident_or_incidents_type_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> an accident or incident</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Corrective action&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.corrective_actions.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_corrective_action_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a corrective action</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Risk assessment&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.risk_assessments.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_risk_assessment_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a risk assessment</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Correspondence&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.correspondences.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_correspondence_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a correspondence</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Test result&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.test_results.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_test_result_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a test result</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Other supporting <br class="opss-br-desktop">information&nbsp;<span class="govuk-!-font-weight-regular opss-no-wrap">(<%= @investigation.generic_supporting_information_attachments.size %><span class="govuk-visually-hidden"> added</span>)</span></dt>
+      <% if policy(@investigation).update? %>
+        <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_document_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a document or attachment</span></a></dd>
+      <% end %>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Comment</dt>
+      <dd class="govuk-summary-list__actions"><a href="<%= new_investigation_activity_comment_path(investigation) %>" class="govuk-link govuk-link--no-visited-state opss-no-wrap">Add<span class="govuk-visually-hidden"> a comment</span></a></dd>
+    </div>
+  </dl>
+</section>

--- a/app/views/investigations/_navigable_case_nav.html.erb
+++ b/app/views/investigations/_navigable_case_nav.html.erb
@@ -13,7 +13,7 @@
     <%= investigation_sub_nav(investigation, current_tab: current_tab) %>
   <% end %>
 
-  <div id="page-content" class="govuk-grid-column-three-quarters">
+  <section id="page-content" class="govuk-grid-column-three-quarters" role="region">
     <%= yield %>
-  </div>
+  </section>
 </div>

--- a/app/views/investigations/tabs/_overview.html.erb
+++ b/app/views/investigations/tabs/_overview.html.erb
@@ -1,5 +1,7 @@
 <%= page_title "Case - #{@investigation.pretty_id}" %>
-<% products_count = @investigation.products.count %>
+<% products_count = @investigation.products.size %>
+
+<%= render 'investigations/actions', investigation: @investigation %>
 
 <p class="govuk-body-l"><%= @investigation.title %></p>
 

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
-RSpec.feature "Case actions", :with_opensearch, :with_stubbed_mailer, type: :feature do
+RSpec.feature "Case actions", :with_stubbed_opensearch, :with_stubbed_antivirus, :with_stubbed_mailer, type: :feature do
   let(:user) { create :user, :activated, has_viewed_introduction: true }
   let(:investigation_1) { create :allegation, creator: user }
-  let(:washing_machine) { create :product_washing_machine, created_at: 1.day.ago }
-  let(:investigation_2) { create :allegation, products: [washing_machine], hazard_type: "Cuts", creator: user }
+  let(:washing_machine) { create :product_washing_machine }
+  let(:investigation_2) { create :allegation, products: [washing_machine], creator: user }
+  let(:investigation_3) { create :allegation, read_only_teams: [user.team] }
+  let(:investigation_4) { create :allegation, :with_business, :with_products, :with_document, creator: user }
 
   before do
     sign_in user
@@ -15,11 +17,82 @@ RSpec.feature "Case actions", :with_opensearch, :with_stubbed_mailer, type: :fea
     expect_to_be_on_case_page(case_id: investigation_1.pretty_id)
     expect(page).to have_css(".govuk-warning-text")
     expect(page).to have_text("A product has not been added to this case.")
+
+    within("#page-content section dl.govuk-summary-list") do
+      expect(page).to have_text("Product (0 added)")
+      expect(page).to have_text("Business (0 added)")
+      expect(page).to have_text("Image (0 added)")
+      expect(page).to have_text("Accident / Incident (0 added)")
+      expect(page).to have_text("Corrective action (0 added)")
+      expect(page).to have_text("Risk assessment (0 added)")
+      expect(page).to have_text("Correspondence (0 added)")
+      expect(page).to have_text("Test result (0 added)")
+      expect(page).to have_text("Other supporting information (0 added)")
+    end
   end
 
   scenario "with a product added to the case" do
     visit investigation_path(investigation_2)
     expect_to_be_on_case_page(case_id: investigation_2.pretty_id)
     expect(page).not_to have_css(".govuk-warning-text")
+
+    within("#page-content section dl.govuk-summary-list") do
+      expect(page).to have_text("Product (1 added)")
+      expect(page).to have_text("Business (0 added)")
+      expect(page).to have_text("Image (0 added)")
+      expect(page).to have_text("Accident / Incident (0 added)")
+      expect(page).to have_text("Corrective action (0 added)")
+      expect(page).to have_text("Risk assessment (0 added)")
+      expect(page).to have_text("Correspondence (0 added)")
+      expect(page).to have_text("Test result (0 added)")
+      expect(page).to have_text("Other supporting information (0 added)")
+    end
+  end
+
+  scenario "where the user can edit the case" do
+    visit investigation_path(investigation_1)
+    within("#page-content section dl.govuk-summary-list") do
+      expect(page).to have_link("Add a product", href: new_investigation_product_path(investigation_1))
+      expect(page).to have_link("Add a business", href: new_investigation_business_path(investigation_1))
+      expect(page).to have_link("Add an image", href: new_investigation_document_path(investigation_1))
+      expect(page).to have_link("Add an accident or incident", href: new_investigation_accident_or_incidents_type_path(investigation_1))
+      expect(page).to have_link("Add a corrective action", href: new_investigation_corrective_action_path(investigation_1))
+      expect(page).to have_link("Add a risk assessment", href: new_investigation_risk_assessment_path(investigation_1))
+      expect(page).to have_link("Add a correspondence", href: new_investigation_correspondence_path(investigation_1))
+      expect(page).to have_link("Add a test result", href: new_investigation_test_result_path(investigation_1))
+      expect(page).to have_link("Add a document or attachment", href: new_investigation_document_path(investigation_1))
+      expect(page).to have_link("Add a comment", href: new_investigation_activity_comment_path(investigation_1))
+    end
+  end
+
+  scenario "where the user can not edit the case" do
+    visit investigation_path(investigation_3)
+    within("#page-content section dl.govuk-summary-list") do
+      expect(page).not_to have_link("Add a product")
+      expect(page).not_to have_link("Add a business")
+      expect(page).not_to have_link("Add an image")
+      expect(page).not_to have_link("Add an accident or incident")
+      expect(page).not_to have_link("Add a corrective action")
+      expect(page).not_to have_link("Add a risk assessment")
+      expect(page).not_to have_link("Add a correspondence")
+      expect(page).not_to have_link("Add a test result")
+      expect(page).not_to have_link("Add a document or attachment")
+      expect(page).to have_link("Add a comment", href: new_investigation_activity_comment_path(investigation_3))
+    end
+  end
+
+  scenario "with some information added to the case" do
+    visit investigation_path(investigation_4)
+    within("#page-content section dl.govuk-summary-list") do
+      expect(page).to have_text("Product (1 added)")
+      expect(page).to have_text("Business (1 added)")
+      expect(page).to have_text("Image (0 added)")
+      expect(page).to have_text("Accident / Incident (0 added)")
+      expect(page).to have_text("Corrective action (0 added)")
+      expect(page).to have_text("Risk assessment (0 added)")
+      expect(page).to have_text("Correspondence (0 added)")
+      expect(page).to have_text("Test result (0 added)")
+      expect(page).to have_text("Other supporting information (1 added)")
+    end
   end
 end

--- a/spec/features/case_actions_spec.rb
+++ b/spec/features/case_actions_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Case actions", :with_opensearch, :with_stubbed_mailer, type: :feature do
+  let(:user) { create :user, :activated, has_viewed_introduction: true }
+  let(:investigation_1) { create :allegation, creator: user }
+  let(:washing_machine) { create :product_washing_machine, created_at: 1.day.ago }
+  let(:investigation_2) { create :allegation, products: [washing_machine], hazard_type: "Cuts", creator: user }
+
+  before do
+    sign_in user
+  end
+
+  scenario "without a product added to the case" do
+    visit investigation_path(investigation_1)
+    expect_to_be_on_case_page(case_id: investigation_1.pretty_id)
+    expect(page).to have_css(".govuk-warning-text")
+    expect(page).to have_text("A product has not been added to this case.")
+  end
+
+  scenario "with a product added to the case" do
+    visit investigation_path(investigation_2)
+    expect_to_be_on_case_page(case_id: investigation_2.pretty_id)
+    expect(page).not_to have_css(".govuk-warning-text")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/P2gn8vwe/1417-grey-action-bar-for-the-cases-landing-page

## Description

Part of a design update to cases, this PR adds an actions section to the top of the case overview page with counts of the various case information and quick navigation links to add more. It also introduces a visual warning which is shown when a case does not yet relate to a product.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
