### PR TITLE
Render correct hint text based on the parent of the potential attachment

### DIFF
--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -30,7 +30,11 @@
 
       <span class="govuk-caption-l"><%= @parent.pretty_description %></span>
       <h1 class="govuk-heading-l"><%= title %></h1>
-      <div class="govuk-hint govuk-!-margin-bottom-8">Image files will be saved to the case images page.</div>
+
+      <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
+        <% parent_name_for_hint_text = @parent.is_a?(Investigation) ? "case" : "product" %>
+        <div class="govuk-hint govuk-!-margin-bottom-8">Image files will be saved to the <%= parent_name_for_hint_text %> images page.</div>
+      <% end %>
 
       <%= render "upload_file_component", form: form, old_file: nil, field_name: :document, legend: "Upload a file", label: "Upload a file" %>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -32,7 +32,7 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
 
       <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
-        <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the case images page." : "Image files will be saved to the product images" %>
+        <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the case images page." : "Image files will be saved to the product images." %>
         <div class="govuk-hint govuk-!-margin-bottom-8"><%= hint_text %></div>
       <% end %>
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -32,8 +32,8 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
 
       <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
-        <% parent_name_for_hint_text = @parent.is_a?(Investigation) ? "case" : "product" %>
-        <div class="govuk-hint govuk-!-margin-bottom-8">Image files will be saved to the <%= parent_name_for_hint_text %> images page.</div>
+        <% hint_text = @parent.is_a?(Investigation) ? "Image files will be saved to the case images page." : "Image files will be saved to the product images" %>
+        <div class="govuk-hint govuk-!-margin-bottom-8"><%= hint_text %></div>
       <% end %>
 
       <%= render "upload_file_component", form: form, old_file: nil, field_name: :document, legend: "Upload a file", label: "Upload a file" %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -29,7 +29,7 @@
       <%= error_summary(@document_form.errors, %i[document title description])%>
 
       <span class="govuk-caption-l"><%= @parent.pretty_description %></span>
-      <h1 class="govuk-heading-l"><%= title %></h1>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-1"><%= title %></h1>
 
       <% if (@parent.is_a?(Investigation) || @parent.is_a?(Product)) %>
         <% parent_name_for_hint_text = @parent.is_a?(Investigation) ? "case" : "product" %>

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -447,7 +447,7 @@ module PageExpectations
   end
 
   def expect_to_be_on_add_attachment_to_a_product_page(product_id:)
-    expect(page).to have_content "Image files will be saved to the product images page."
+    expect(page).to have_content "Image files will be saved to the product images"
     expect(page).to have_current_path("/products/#{product_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")
@@ -553,7 +553,7 @@ module PageExpectations
 
   def expect_to_be_on_add_attachment_to_a_business_page(business_id:)
     expect(page).not_to have_content "Image files will be saved to the case images page."
-    expect(page).not_to have_content "Image files will be saved to the product page."
+    expect(page).not_to have_content "Image files will be saved to the product images"
     expect(page).to have_current_path("/businesses/#{business_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Businesses")

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -195,6 +195,7 @@ module PageExpectations
   end
 
   def expect_to_be_on_add_attachment_to_a_case_page
+    expect(page).to have_content "Image files will be saved to the case images page."
     expect(page).to have_current_path("/cases/#{investigation.pretty_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Cases")
@@ -423,6 +424,7 @@ module PageExpectations
   end
 
   def expect_to_be_on_product_image_page
+    expect(page).to have_content "Image files will be saved to the products page."
     expect(page).to have_current_path("/ts_investigation/product_images")
     expect(page).to have_selector("h1", text: "Upload a product image")
   end
@@ -550,6 +552,8 @@ module PageExpectations
   end
 
   def expect_to_be_on_add_attachment_to_a_business_page(business_id:)
+    expect(page).to_not have_content "Image files will be saved to the case images page."
+    expect(page).to_not have_content "Image files will be saved to the product page."
     expect(page).to have_current_path("/businesses/#{business_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Businesses")

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -552,8 +552,8 @@ module PageExpectations
   end
 
   def expect_to_be_on_add_attachment_to_a_business_page(business_id:)
-    expect(page).to_not have_content "Image files will be saved to the case images page."
-    expect(page).to_not have_content "Image files will be saved to the product page."
+    expect(page).not_to have_content "Image files will be saved to the case images page."
+    expect(page).not_to have_content "Image files will be saved to the product page."
     expect(page).to have_current_path("/businesses/#{business_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Businesses")

--- a/spec/support/features/page_expectations.rb
+++ b/spec/support/features/page_expectations.rb
@@ -424,7 +424,6 @@ module PageExpectations
   end
 
   def expect_to_be_on_product_image_page
-    expect(page).to have_content "Image files will be saved to the products page."
     expect(page).to have_current_path("/ts_investigation/product_images")
     expect(page).to have_selector("h1", text: "Upload a product image")
   end
@@ -448,6 +447,7 @@ module PageExpectations
   end
 
   def expect_to_be_on_add_attachment_to_a_product_page(product_id:)
+    expect(page).to have_content "Image files will be saved to the product images page."
     expect(page).to have_current_path("/products/#{product_id}/documents/new")
     expect(page).to have_h1("Add attachment")
     expect(page).to have_css(".psd-header__navigation-item--active", text: "Products")


### PR DESCRIPTION
https://trello.com/c/gKRLeYN4/1462-contextual-hint-text-required-on-a-form

## Description
This change fixes issues on the new attachments page. Prior to this change it always had the text relating to case images, this text now refers to product images if the parent is a product, case images if it is a case and nothing if it is neither

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
