### PR TITLE
Move product images to the bottom of the page

### DIFF
--- a/app/views/application/_product_summary.html.erb
+++ b/app/views/application/_product_summary.html.erb
@@ -1,11 +1,13 @@
 <div class="product-summary govuk-!-margin-top-3 govuk-!-margin-bottom-6">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m"><%= product.name %></h2>
     </div>
   </div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-full">
+      <%= product.decorate.summary_list %>
+
       <% if product.images.any? %>
         <%= render "documents/document_preview",
                    document: product.images.first,
@@ -14,10 +16,7 @@
       <% else %>
         <p class="govuk-body">No images</p>
       <% end %>
-    </div>
 
-    <div class="govuk-grid-column-two-thirds">
-      <%= product.decorate.summary_list %>
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
https://trello.com/c/i6KVXQOY/1454-cases-page-products-page-design-tweak

## Description
This PR affects the Products tab on a Case page. It moves the images section to the bottom of the main content column - this will leave only one wide right hand column, which gives more space to the content.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
