### PR TITLE
Change text/link from 'close case' to 're-open' case if the case is c…

### DIFF
--- a/app/views/investigations/show.html.erb
+++ b/app/views/investigations/show.html.erb
@@ -1,8 +1,11 @@
+<% href = @investigation.is_closed? ? reopen_investigation_status_path(@investigation) : close_investigation_status_path(@investigation) %>
+<% link_text = @investigation.is_closed? ? "Re-open case" : "Close case" %>
+
 <%= render "investigations/navigable_case_nav", investigation: @investigation,
                                                 current_tab: "overview",
                                                 case_page_heading: "Case",
                                                 secondary_text: "From here you can find all the information about this case. If you have editing rights for this case, you can add products, businesses and supporting information.",
-                                                href: close_investigation_status_path(@investigation),
-                                                link_text: "Close case" do %>
+                                                href: href,
+                                                link_text: link_text do %>
   <%= render "investigations/tabs/overview" %>
 <% end %>

--- a/spec/features/change_case_status_spec.rb
+++ b/spec/features/change_case_status_spec.rb
@@ -27,7 +27,14 @@ RSpec.feature "Changing the status of a case", :with_opensearch, :with_stubbed_m
 
     # Navigate via the case overview table
     visit "/cases/#{investigation.pretty_id}"
-    first(:link, "Close").click
+    # x = all("div.govuk-grid-row").first
+
+    within("div.opss-text-align-right") do
+      expect(page).to have_link "Close case"
+      expect(page).not_to have_link "Re-open case"
+      click_link "Close case"
+    end
+
     expect_to_be_on_close_case_page(case_id: investigation.pretty_id)
 
     fill_in "Why are you closing the case?", with: "Case has been resolved."
@@ -65,7 +72,13 @@ RSpec.feature "Changing the status of a case", :with_opensearch, :with_stubbed_m
 
     # Navigate via the case overview table
     visit "/cases/#{investigation.pretty_id}"
-    click_link "Re-open"
+
+    within("div.opss-text-align-right") do
+      expect(page).not_to have_link "Close case"
+      expect(page).to have_link "Re-open case"
+      click_link "Re-open case"
+    end
+
     expect_to_be_on_reopen_case_page(case_id: investigation.pretty_id)
 
     fill_in "Why are you re-opening the case?", with: "Case has not been resolved."

--- a/spec/features/change_case_status_spec.rb
+++ b/spec/features/change_case_status_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature "Changing the status of a case", :with_opensearch, :with_stubbed_m
 
     # Navigate via the case overview table
     visit "/cases/#{investigation.pretty_id}"
-    # x = all("div.govuk-grid-row").first
 
     within("div.opss-text-align-right") do
       expect(page).to have_link "Close case"


### PR DESCRIPTION
https://trello.com/c/Zpy8v3OO/1487-when-a-case-is-closed-header-link-should-change-to-re-open

## Description
This change fixes a bug which causes the link at the top of the case overview page to show "Close case" and take the user to the close case page, even when the case is already closed. The expected behaviour is that the link will take the user to the re-open case page in this case.

<!--- Put an `x` in all the boxes that apply. Delete items which are not relevant. -->
## Checklist:
- [ ] Have you documented your changes in the pull request description?
- [ ] Does the change present any security considerations?
- [ ] Is any gem functionality overloaded? Eg: Devise controller methods being overloaded.
- [ ] Has acceptance criteria been tested by a peer?
- [ ] Has the CHANGELOG been updated? (If change is worth telling users about.)

### General testing (author)
- [ ] Test without JavaScript
- [ ] Test on small screen

### Accessibility testing (author)
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable CSS - does content make sense and appear in a logical order?
